### PR TITLE
feat: message displayer actions fill available view, the remaining on…

### DIFF
--- a/src/hooks/use-message-actions.tsx
+++ b/src/hooks/use-message-actions.tsx
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { SnackbarManagerContext, useModal } from '@zextras/carbonio-design-system';
+import {
+	FOLDERS,
+	useAppContext,
+	useIntegratedComponent,
+	useReplaceHistoryCallback,
+	useUserSettings
+} from '@zextras/carbonio-shell-ui';
+import { includes } from 'lodash';
+import { useContext, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { useSelection } from './useSelection';
+import { MailMessage } from '../types/mail-message';
+import {
+	deleteMsg,
+	editAsNewMsg,
+	editDraft,
+	forwardMsg,
+	moveMsgToTrash,
+	redirectMsg,
+	replyAllMsg,
+	replyMsg,
+	sendDraft,
+	setMsgFlag,
+	setMsgAsSpam,
+	printMsg,
+	showOriginalMsg,
+	setMsgRead,
+	moveMessageToFolder,
+	deleteMessagePermanently
+} from '../ui-actions/message-actions';
+
+export const useMessageActions = (message: MailMessage): Array<any> => {
+	const [t] = useTranslation();
+	const { folderId }: { folderId: string } = useParams();
+	const replaceHistory = useReplaceHistoryCallback();
+	const createSnackbar = useContext(SnackbarManagerContext);
+	const dispatch = useDispatch();
+	const createModal = useModal();
+	const ContactInput = useIntegratedComponent('contact-input');
+	const { setCount } = useAppContext();
+	const { deselectAll } = useSelection(folderId, setCount);
+	const settings = useUserSettings();
+	const timezone = useMemo(
+		() => settings?.prefs.zimbraPrefTimeZoneId,
+		[settings?.prefs.zimbraPrefTimeZoneId]
+	);
+
+	const systemFolders = useMemo(
+		() => [FOLDERS.INBOX, FOLDERS.SENT, FOLDERS.DRAFTS, FOLDERS.TRASH, FOLDERS.SPAM],
+		[]
+	);
+
+	const arr = [];
+
+	if (message.parent === FOLDERS.DRAFTS) {
+		arr.push(sendDraft(message.id, message, t, dispatch));
+		arr.push(editDraft(message.id, folderId, t, replaceHistory));
+		arr.push(
+			moveMsgToTrash(
+				[message.id],
+				t,
+				dispatch,
+				createSnackbar,
+				deselectAll,
+				folderId,
+				replaceHistory,
+				message.conversation
+			)
+		);
+		arr.push(setMsgFlag([message.id], message.flagged, t, dispatch));
+	}
+	if (
+		message.parent === FOLDERS.INBOX ||
+		message.parent === FOLDERS.SENT ||
+		!includes(systemFolders, message.parent)
+	) {
+		// INBOX, SENT OR CREATED_FOLDER
+		arr.push(replyMsg(message.id, folderId, t, replaceHistory));
+		arr.push(replyAllMsg(message.id, folderId, t, replaceHistory));
+		arr.push(forwardMsg(message.id, folderId, t, replaceHistory));
+		arr.push(
+			moveMsgToTrash(
+				[message.id],
+				t,
+				dispatch,
+				createSnackbar,
+				deselectAll,
+				folderId,
+				replaceHistory,
+				message.conversation
+			)
+		);
+		arr.push(
+			setMsgRead([message.id], message.read, t, dispatch, folderId, replaceHistory, deselectAll)
+		);
+		arr.push(moveMessageToFolder([message.id], t, dispatch, false, createModal, deselectAll));
+		arr.push(printMsg(message.id, t, timezone));
+		arr.push(setMsgFlag([message.id], message.flagged, t, dispatch));
+		arr.push(redirectMsg(message.id, t, dispatch, createSnackbar, createModal, ContactInput));
+		arr.push(editAsNewMsg(message.id, folderId, t, replaceHistory));
+		arr.push(setMsgAsSpam([message.id], false, t, dispatch, replaceHistory));
+		arr.push(showOriginalMsg(message.id, t));
+	}
+
+	if (message.parent === FOLDERS.TRASH) {
+		arr.push(moveMessageToFolder([message.id], t, dispatch, true, createModal, deselectAll));
+		arr.push(deleteMessagePermanently([message.id], t, dispatch, createModal, deselectAll));
+	}
+	if (message.parent === FOLDERS.SPAM) {
+		arr.push(deleteMsg([message.id], t, dispatch, createSnackbar, createModal));
+		arr.push(setMsgAsSpam([message.id], true, t, dispatch, replaceHistory));
+		arr.push(printMsg(message.id, t, timezone));
+		arr.push(showOriginalMsg(message.id, t));
+	}
+	return arr;
+};

--- a/src/hooks/use-visible-actions-count.tsx
+++ b/src/hooks/use-visible-actions-count.tsx
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+// This is a temporary solution to avoid errors from theme import
+import { ThemeContext } from '@zextras/carbonio-design-system';
+import { min } from 'lodash';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+
+type ThemeContextProps = {
+	sizes: {
+		icon: {
+			large: string;
+		};
+	};
+};
+
+type ArgsProps = {
+	iconWidth?: number;
+	numberLimit?: number;
+};
+
+export const useVisibleActionsCount = (
+	containerRef: React.RefObject<HTMLInputElement>,
+	args: ArgsProps
+): [number, () => void] => {
+	const [visibleActionsCount, setVisibleActionsCount] = useState<number>(0);
+	const { iconWidth, numberLimit } = args;
+	const theme = useContext<ThemeContextProps>(ThemeContext);
+	const iconSize = iconWidth ?? parseInt(theme.sizes.icon.large, 10);
+
+	const calculateVisibleActionsCount = useCallback(() => {
+		if (containerRef && containerRef.current && containerRef?.current?.clientWidth > 0) {
+			const evaluation = Math.floor(containerRef.current.clientWidth / iconSize);
+			const valueToSet = numberLimit ? (min([evaluation, numberLimit]) as number) : evaluation;
+			setVisibleActionsCount(valueToSet);
+		}
+	}, [containerRef, iconSize, numberLimit]);
+
+	useEffect(() => {
+		window.addEventListener('resize', calculateVisibleActionsCount);
+		return (): void => window.removeEventListener('resize', calculateVisibleActionsCount);
+	}, [calculateVisibleActionsCount]);
+
+	useEffect(() => {
+		window.addEventListener('transitionend', calculateVisibleActionsCount);
+		return (): void => window.removeEventListener('transitionend', calculateVisibleActionsCount);
+	}, [calculateVisibleActionsCount]);
+
+	return [visibleActionsCount, calculateVisibleActionsCount];
+};

--- a/src/ui-actions/mail-message-preview-actions.tsx
+++ b/src/ui-actions/mail-message-preview-actions.tsx
@@ -22,6 +22,7 @@ type MailMsgPreviewActionsType = {
 	maxActions?: number;
 	maxWidth?: string;
 	mainAlignment?: string;
+	minWidth?: string;
 };
 
 type ThemeContextProps = {
@@ -36,6 +37,7 @@ const MailMsgPreviewActions: FC<MailMsgPreviewActionsType> = ({
 	actions,
 	maxActions,
 	maxWidth = '120px',
+	minWidth,
 	mainAlignment = 'flex-end'
 }): ReactElement => {
 	const actionContainerRef = useRef<HTMLInputElement>(null);
@@ -70,6 +72,11 @@ const MailMsgPreviewActions: FC<MailMsgPreviewActionsType> = ({
 		[iconSize, maxActions, maxWidth]
 	);
 
+	const _minWidth = useMemo(
+		() => minWidth ?? theme?.sizes?.icon?.large,
+		[minWidth, theme?.sizes?.icon?.large]
+	);
+
 	useLayoutEffect(() => {
 		calculateVisibleActionsCount();
 	}, [calculateVisibleActionsCount]);
@@ -79,7 +86,7 @@ const MailMsgPreviewActions: FC<MailMsgPreviewActionsType> = ({
 			ref={actionContainerRef}
 			mainAlignment={mainAlignment}
 			maxWidth={_maxWidth}
-			style={{ minWidth: '24px' }}
+			style={{ minWidth: _minWidth }}
 			wrap="nowrap"
 			takeAvailableSpace
 		>

--- a/src/views/app/detail-panel/preview/mail-preview.jsx
+++ b/src/views/app/detail-panel/preview/mail-preview.jsx
@@ -134,13 +134,13 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 	const [_minWidth, _setMinWidth] = useState();
 
 	useLayoutEffect(() => {
-		let width = iconSize;
+		let width = actions.length > 2 ? iconSize : 2 * iconSize;
 		if (message.attachment && attachments.length > 0) width += iconSize;
 		if (message.flagged) width += iconSize;
 		if (textRef?.current?.clientWidth) width += textRef.current.clientWidth;
 		_setMinWidth(`${width}px`);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
+		actions.length,
 		attachments.length,
 		iconSize,
 		message.attachment,
@@ -309,12 +309,12 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 									<Icon color="error" icon="Flag" data-testid="FlagIcon" />
 								</Padding>
 							)}
-							<Row ref={textRef} minWidth="fit" padding={{ left: 'small' }}>
+							<Row ref={textRef} minWidth="fit" padding={{ right: 'small' }}>
 								<Text color="gray1" data-testid="DateLabel" size="extrasmall">
 									{getTimeLabel(message.date)}
 								</Text>
 							</Row>
-							{!isMessageView && open && <MailMsgPreviewActions actions={actions} maxActions={6} />}
+							{!isMessageView && open && <MailMsgPreviewActions actions={actions} />}
 						</Row>
 					</Container>
 					{!open && (

--- a/src/views/app/detail-panel/preview/mail-preview.jsx
+++ b/src/views/app/detail-panel/preview/mail-preview.jsx
@@ -198,18 +198,13 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 					crossAlignment="flex-start"
 					height="fit"
 					width="calc(100% - 48px)"
-					padding={{ all: 'small', bottom: 'medium' }}
+					padding={{ all: 'small' }}
 					takeAvailableSpace
 				>
 					<Container orientation="horizontal" mainAlignment="space-between" width="fill">
-						<Container
-							orientation="horizontal"
-							width="fit"
-							height="24px"
-							mainAlignment="flex-start"
-						>
+						<Row takeAvailableSpace width="fit" mainAlignment="flex-start" wrap="nowrap">
 							{isEmpty(senderContact) ? (
-								<>
+								<Row takeAvailableSpace width="fit" mainAlignment="flex-start" wrap="nowrap">
 									<Text
 										data-testid="SenderText"
 										size={message.read ? 'small' : 'medium'}
@@ -218,14 +213,13 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 									>
 										{participantToString(mainContact, t, accounts)}
 									</Text>
-									<Padding left="small">
-										<Text color="gray1" size={message.read ? 'small' : 'medium'}>
-											{mainContact.address && mainContact.address}
-										</Text>
-									</Padding>
-								</>
+									<Padding left="small" />
+									<Text color="gray1" size={message.read ? 'small' : 'medium'}>
+										{mainContact.address && mainContact.address}
+									</Text>
+								</Row>
 							) : (
-								<>
+								<Text overflow="break-word">
 									<Text
 										data-testid="SenderText"
 										size={message.read ? 'small' : 'medium'}
@@ -254,10 +248,10 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 											{mainContact.address && `<${mainContact.address}>`}
 										</Text>
 									</Padding>
-								</>
+								</Text>
 							)}
-						</Container>
-						<Container orientation="horizontal" width="fit" height="24px">
+						</Row>
+						<Row takeAvailableSpace width="fill" wrap="nowrap" mainAlignment="flex-end">
 							{message.attachment && attachments.length > 0 && (
 								<Padding left="small">
 									<Icon icon="AttachOutline" />
@@ -273,19 +267,16 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 									{getTimeLabel(message.date)}
 								</Text>
 							</Padding>
-
-							{isMessageView ? null : (
-								<>
-									{open && (
-										<MailMsgPreviewActions
-											message={message}
-											folderId={folderId}
-											timezone={timezone}
-										/>
-									)}
-								</>
+							{!isMessageView && open && (
+								<Row takeAvailableSpace maxWidth="35%">
+									<MailMsgPreviewActions
+										message={message}
+										folderId={folderId}
+										timezone={timezone}
+									/>
+								</Row>
 							)}
-						</Container>
+						</Row>
 					</Container>
 					{!open && (
 						<Container
@@ -301,8 +292,8 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 						orientation="horizontal"
 						mainAlignment="space-between"
 						crossAlignment="flex-end"
-						height="20px"
 						padding={{ top: open ? 'small' : '0' }}
+						height="24px"
 					>
 						<Container
 							orientation="horizontal"
@@ -465,10 +456,13 @@ export default function MailPreview({ message, expanded, isAlone, isMessageView,
 			isAttendee
 		]
 	);
+	const onClick = () => {
+		setOpen((o) => !o);
+	};
 	return (
 		<Container ref={mailContainerRef} height="fit" data-testid={`MailPreview-${message.id}`}>
 			<MailPreviewBlock
-				onClick={() => setOpen((o) => !o)}
+				onClick={onClick}
 				message={aggregatedMessage}
 				timezone={timezone}
 				// open={isAlone ? true : open}

--- a/src/views/app/detail-panel/preview/mail-preview.jsx
+++ b/src/views/app/detail-panel/preview/mail-preview.jsx
@@ -39,6 +39,7 @@ import { selectMessages, selectMessagesStatus } from '../../../../store/messages
 import { getMsg, msgAction } from '../../../../store/actions';
 import { retrieveAttachmentsType } from '../../../../store/editor-slice-utils';
 import SharedInviteReply from '../../../../integrations/shared-invite-reply';
+import { useMessageActions } from '../../../../hooks/use-message-actions';
 
 const ContactsContainer = styled.div`
 	display: grid;
@@ -100,11 +101,6 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 	const replaceHistory = useReplaceHistoryCallback();
 	const { folderId } = useParams();
 	const accounts = useUserAccounts();
-	const settings = useUserSettings();
-	const timezone = useMemo(
-		() => settings?.prefs.zimbraPrefTimeZoneId,
-		[settings?.prefs.zimbraPrefTimeZoneId]
-	);
 	const dispatch = useDispatch();
 	const { isMessageView } = useAppContext();
 	const { folderId: currentFolderId } = useParams();
@@ -121,6 +117,8 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 			? { color: 'text', weight: 'regular', badge: 'read', size: 'small' }
 			: { color: 'primary', weight: 'bold', badge: 'unread', size: 'medium' };
 	}, [message.read]);
+	const actions = useMessageActions(message);
+
 	return (
 		<>
 			{folderId === '4' && (
@@ -202,7 +200,17 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 					takeAvailableSpace
 				>
 					<Container orientation="horizontal" mainAlignment="space-between" width="fill">
-						<Row takeAvailableSpace width="fit" mainAlignment="flex-start" wrap="nowrap">
+						<Row
+							// this style replace takeAvailableSpace prop, it calculates growth depending from content (all 4 props are needed)
+							style={{
+								flexGrow: 1,
+								flexBasis: 'content',
+								overflow: 'hidden',
+								whiteSpace: 'nowrap'
+							}}
+							mainAlignment="flex-start"
+							wrap="nowrap"
+						>
 							{isEmpty(senderContact) ? (
 								<Row takeAvailableSpace width="fit" mainAlignment="flex-start" wrap="nowrap">
 									<Text
@@ -251,7 +259,17 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 								</Text>
 							)}
 						</Row>
-						<Row takeAvailableSpace width="fill" wrap="nowrap" mainAlignment="flex-end">
+						<Row
+							wrap="nowrap"
+							mainAlignment="flex-end"
+							// this style replace takeAvailableSpace prop, it calculates growth depending from content (all 4 props are needed)
+							style={{
+								flexGrow: 1,
+								flexBasis: 'content',
+								overflow: 'hidden',
+								whiteSpace: 'nowrap'
+							}}
+						>
 							{message.attachment && attachments.length > 0 && (
 								<Padding left="small">
 									<Icon icon="AttachOutline" />
@@ -267,15 +285,7 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 									{getTimeLabel(message.date)}
 								</Text>
 							</Padding>
-							{!isMessageView && open && (
-								<Row takeAvailableSpace maxWidth="35%">
-									<MailMsgPreviewActions
-										message={message}
-										folderId={folderId}
-										timezone={timezone}
-									/>
-								</Row>
-							)}
+							{!isMessageView && open && <MailMsgPreviewActions actions={actions} maxActions={6} />}
 						</Row>
 					</Container>
 					{!open && (

--- a/src/views/app/detail-panel/preview/mail-preview.jsx
+++ b/src/views/app/detail-panel/preview/mail-preview.jsx
@@ -13,7 +13,8 @@ import {
 	useReplaceHistoryCallback,
 	useAppContext,
 	useIntegratedComponent,
-	useUserSettings
+	useUserSettings,
+	FOLDERS
 } from '@zextras/carbonio-shell-ui';
 import { useParams } from 'react-router-dom';
 import {
@@ -121,7 +122,7 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 
 	return (
 		<>
-			{folderId === '4' && (
+			{folderId === FOLDERS.DRAFTS && (
 				<Container
 					mainAlignment="flex-start"
 					crossAlignment="flex-start"
@@ -266,7 +267,6 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 							style={{
 								flexGrow: 1,
 								flexBasis: 'content',
-								overflow: 'hidden',
 								whiteSpace: 'nowrap'
 							}}
 						>
@@ -343,7 +343,7 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 	);
 };
 
-export default function MailPreview({ message, expanded, isAlone, isMessageView, conversation }) {
+export default function MailPreview({ message, expanded, isAlone, isMessageView }) {
 	const dispatch = useDispatch();
 	const mailContainerRef = useRef(undefined);
 	const accounts = useUserAccounts();

--- a/src/views/app/detail-panel/preview/mail-preview.jsx
+++ b/src/views/app/detail-panel/preview/mail-preview.jsx
@@ -279,7 +279,6 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 									>
 										{mainContact.fullName && `"${mainContact.fullName}"`}
 									</Text>
-
 									<Padding left="small">
 										<Text color="gray1" size={message.read ? 'small' : 'medium'}>
 											{mainContact.address && `<${mainContact.address}>`}
@@ -310,7 +309,7 @@ const MailPreviewBlock = ({ message, open, onClick }) => {
 									<Icon color="error" icon="Flag" data-testid="FlagIcon" />
 								</Padding>
 							)}
-							<Row ref={textRef} minWidth="fit">
+							<Row ref={textRef} minWidth="fit" padding={{ left: 'small' }}>
 								<Text color="gray1" data-testid="DateLabel" size="extrasmall">
 									{getTimeLabel(message.date)}
 								</Text>


### PR DESCRIPTION
This PR contain the feature needed to create a component which given few parameters,  will render a X number of visible actions and wrap all the remainings inside the dropdown of the 3dot action


I added also @beawar so she can have a look and understand if this solution is feasible for the DS. 