### PR TITLE
fix: fixed the edit props modal of shared folders

### DIFF
--- a/src/views/sidebar/parts/edit/share-folder-properties.jsx
+++ b/src/views/sidebar/parts/edit/share-folder-properties.jsx
@@ -173,7 +173,7 @@ export const ShareFolderProperties = ({
 	setActiveModal
 }) => {
 	const [t] = useTranslation();
-	const grant = folder?.acl?.grant;
+	const grant = folder?.folder?.acl?.grant;
 	const shareCalendarRoleOptions = useMemo(
 		() => ShareCalendarRoleOptions(t, grant.perm?.includes('p')),
 		[t, grant?.perm]


### PR DESCRIPTION
Editing settings on a shared folder from you was crashing the app, giving a blank page; fixed the level of nesting from which the prop for ShareCalendarRoleOptions was taken