### PR TITLE
fix: delete parent folders

### DIFF
--- a/src/store/folders-slice.ts
+++ b/src/store/folders-slice.ts
@@ -101,19 +101,6 @@ function folderActionPending(state: FoldersStateType, { meta }: any): void {
 
 	switch (op) {
 		case 'move':
-			state.folders = reduce(
-				state.folders,
-				(r, v, k) => {
-					if (v.id === newFolder.id) {
-						return r;
-					}
-					return { ...r, [k]: v };
-				},
-				{}
-			);
-			state.folders[newFolder.id] = newFolder;
-			updateFolderInStore(state, [newFolder]);
-			state.status = 'updating';
 			break;
 
 		case '!grant': {

--- a/src/views/sidebar/delete-modal.tsx
+++ b/src/views/sidebar/delete-modal.tsx
@@ -57,7 +57,6 @@ export const DeleteModal: FC<ModalProps> = ({ folder, onClose }) => {
 		dispatch(
 			folderAction({
 				folder: folder.folder,
-				recursive: true,
 				l: FOLDERS.TRASH,
 				op: inTrash ? FOLDER_ACTIONS.DELETE : FOLDER_ACTIONS.MOVE
 			})

--- a/src/views/sidebar/delete-modal.tsx
+++ b/src/views/sidebar/delete-modal.tsx
@@ -57,6 +57,7 @@ export const DeleteModal: FC<ModalProps> = ({ folder, onClose }) => {
 		dispatch(
 			folderAction({
 				folder: folder.folder,
+				recursive: true,
 				l: FOLDERS.TRASH,
 				op: inTrash ? FOLDER_ACTIONS.DELETE : FOLDER_ACTIONS.MOVE
 			})


### PR DESCRIPTION
The deletion of a parent folder raises an error caused by a loop in a redux callback used to update the optimistic UI. Since the optimistic UI is no longer applied in this context and the folders management should be delegated to Shell, we simply remove the problematic code