### PR TITLE
fix: default unsend time

### DIFF
--- a/src/views/app/detail-panel/edit/parts/edit-view-header.tsx
+++ b/src/views/app/detail-panel/edit/parts/edit-view-header.tsx
@@ -180,7 +180,7 @@ const EditViewHeader: FC<PropType> = ({
 			}, 10);
 
 			let countdownSeconds: number =
-				(find(props, ['name', 'mails_snackbar_delay'])?._content as unknown as number) ?? 30;
+				(find(props, ['name', 'mails_snackbar_delay'])?._content as unknown as number) ?? 3;
 
 			const countdown = setInterval(() => {
 				countdownSeconds -= 1;

--- a/src/views/settings/components/utils.js
+++ b/src/views/settings/components/utils.js
@@ -353,11 +353,7 @@ export const findLabel = (list, value) => filter(list, (item) => item.value === 
 
 export const UnsendTimeOptions = () => [
 	{
-		label: t('settings.mail_unsend_time.second', {
-			count: 0,
-			defaultValue: '{{count}} second',
-			defaultValue_plural: '{{count}} seconds'
-		}),
+		label: t('settings.mail_unsend_time.no_delay', 'No delay'),
 		value: '0'
 	},
 	{

--- a/translations/en.json
+++ b/translations/en.json
@@ -659,6 +659,7 @@
         "linkedin_msg": "LinkedIn messages and connections",
         "localpart": "localpart",
         "mail_unsend_time": {
+            "no_delay": "No delay",
             "second": "{{count}} second",
             "second_plural": "{{count}} seconds"
         },


### PR DESCRIPTION
Default unsend time set to 3 seconds, changed '0 seconds' option label to be 'No delay'