### PR TITLE
Iris 3656 identity selection

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -147,6 +147,7 @@ const App = () => {
 						addBoard({
 							url: `${MAILS_ROUTE}/new?action=new`,
 							title: t('label.new_email', 'New E-mail')
+							// TODO provide the context filled with the current folder id
 						});
 					},
 					disabled: false,

--- a/src/store/editor-slice.ts
+++ b/src/store/editor-slice.ts
@@ -41,6 +41,7 @@ type CreateEditorPayload = {
 	original: MailMessage;
 	id?: string;
 	action: string | undefined;
+	change?: string;
 	accounts: Array<Account>;
 	settings: AccountSettings;
 	boardContext: Partial<{ compositionData: MailsEditor; contacts: Array<Participant> }>;

--- a/src/types/editor/index.d.ts
+++ b/src/types/editor/index.d.ts
@@ -67,6 +67,7 @@ type FindDefaultIdentityType = {
 	list: Array<IdentityType>;
 	allAccounts: Record<string, Folder & { owner: string }>;
 	folderId: string;
+	currentMessage?: MailMessage;
 	originalMessage?: MailMessage;
 	account: Account;
 	settings: AccountSettings;

--- a/src/views/app/detail-panel/edit/edit-view.tsx
+++ b/src/views/app/detail-panel/edit/edit-view.tsx
@@ -26,6 +26,7 @@ import React, {
 import { useForm } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
+import { v4 as uuid } from 'uuid';
 import { ActionsType } from '../../../../commons/utils';
 import { useQueryParam } from '../../../../hooks/useQueryParam';
 import { getMsg } from '../../../../store/actions';
@@ -120,7 +121,19 @@ const EditView: FC<EditViewPropType> = ({ setHeader }) => {
 		[editId, board?.context?.mailId]
 	);
 
-	const editorId = useMemo(() => activeMailId ?? generateId(), [activeMailId]);
+	/*
+	 * If the mail id is not set in the context, it means that the user is creating a
+	 * new mail, so an id with prefix 'new-' is created.
+	 *
+	 * Otherwise an uuid is generated in order to keep apart different replies to the same mail.
+	 */
+	const editorId = useMemo(() => {
+		if (!board?.context?.mailId) {
+			return generateId();
+		}
+
+		return uuid();
+	}, [board?.context?.mailId]);
 
 	const [editor, setEditor] = useState<MailsEditor>(editors[editorId]);
 	const draftId = useSelector((s: StateType) => selectDraftId(s, editor?.editorId));
@@ -254,8 +267,6 @@ const EditView: FC<EditViewPropType> = ({ setHeader }) => {
 						original: messages?.[activeMailId ?? editorId],
 						boardContext: board?.context,
 						action,
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore
 						change,
 						accounts,
 						labels: {
@@ -280,6 +291,7 @@ const EditView: FC<EditViewPropType> = ({ setHeader }) => {
 		isSameAction,
 		activeMailId,
 		board?.context,
+		board?.context?.mailId,
 		change,
 		dispatch,
 		editor,

--- a/src/views/app/detail-panel/edit/parts/edit-view-header.tsx
+++ b/src/views/app/detail-panel/edit/parts/edit-view-header.tsx
@@ -118,7 +118,13 @@ const EditViewHeader: FC<PropType> = ({
 		updateEditorCb,
 		setOpen,
 		editorId: editor?.editorId,
-		originalMessage: editor?.original,
+		currentMessage: editor?.original,
+		originalMessage:
+			action === ActionsType.REPLY_ALL ||
+			action === ActionsType.REPLY ||
+			action === ActionsType.FORWARD
+				? editor?.original
+				: undefined,
 		folderId: boardContext?.folderId ?? FOLDERS.INBOX
 	});
 

--- a/src/views/app/folder-panel/lists-item/message-list-item.tsx
+++ b/src/views/app/folder-panel/lists-item/message-list-item.tsx
@@ -14,6 +14,7 @@ import {
 	Tooltip
 } from '@zextras/carbonio-design-system';
 import {
+	addBoard,
 	FOLDERS,
 	replaceHistory,
 	t,
@@ -30,7 +31,8 @@ import moment from 'moment';
 import React, { FC, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { getTimeLabel, participantToString } from '../../../../commons/utils';
+import { ActionsType, getTimeLabel, participantToString } from '../../../../commons/utils';
+import { MAILS_ROUTE } from '../../../../constants';
 
 import { AppContext, MsgListDraggableItemType, TextReadValuesType } from '../../../../types';
 import { setMsgRead } from '../../../../ui-actions/message-actions';
@@ -180,7 +182,13 @@ export const MessageListItem: FC<any> = ({
 		(e) => {
 			if (!e.isDefaultPrevented()) {
 				const { id, isDraft } = item;
-				if (isDraft) replaceHistory(`/folder/${folderId}/edit/${id}?action=editAsDraft`);
+				if (isDraft) {
+					addBoard({
+						url: `${MAILS_ROUTE}/edit/${id}?action=${ActionsType.EDIT_AS_DRAFT}`,
+						context: { mailId: id, folderId },
+						title: ''
+					});
+				}
 			}
 		},
 		[folderId, item]


### PR DESCRIPTION
- feat: Automatic identity selection based on the mail's folder
- fix: force draft opening in board
- fix: keep sender set on draft
- fix: open new replies on different (redux) editor