### PR TITLE
fix: block download for untrusted images

### DIFF
--- a/src/commons/mail-message-renderer.tsx
+++ b/src/commons/mail-message-renderer.tsx
@@ -318,9 +318,8 @@ const _HtmlMessageRenderer: FC<_HtmlMessageRendererType> = ({
 			iframeRef.current.contentDocument.body.getElementsByTagName('img');
 		if (images)
 			forEach(images, (p: HTMLImageElement) => {
-				if (p.hasAttribute('dfsrc')) {
+				if (p.hasAttribute('dfsrc') && showImage) {
 					p.setAttribute('src', p.getAttribute('dfsrc') ?? '');
-					p.setAttribute('style', showImage ? 'display: block' : 'display: none');
 				}
 				if (!_CI_SRC_REGEX.test(p.src)) return;
 				const ci = _CI_SRC_REGEX.exec(p.getAttribute('src') ?? '')?.[1] ?? '';


### PR DESCRIPTION
- fix: block download for untrusted images (IRIS-3611)
- fix: change the CSS layout of the img tags inside a mail (IRIS-3610)