### PR TITLE
fix: sharing folder set 'send notification about this shared' is checked by default

### DIFF
--- a/src/views/sidebar/edit-permissions-modal.tsx
+++ b/src/views/sidebar/edit-permissions-modal.tsx
@@ -47,7 +47,7 @@ const EditPermissionsModal: FC<EditPermissionsModalProps> = ({
 	const [ContactInput, integrationAvailable] = useIntegratedComponent('contact-input');
 	const shareCalendarWithOptions = useMemo(() => ShareCalendarWithOptions(t), []);
 	const shareCalendarRoleOptions = useMemo(() => ShareCalendarRoleOptions(t), []);
-	const [sendNotification, setSendNotification] = useState(false);
+	const [sendNotification, setSendNotification] = useState(true);
 	const [standardMessage, setStandardMessage] = useState('');
 	const [contacts, setContacts] = useState<any>([]);
 	const [shareWithUserType, setshareWithUserType] = useState('usr');

--- a/src/views/sidebar/tests/edit-permissions-modal.test.tsx
+++ b/src/views/sidebar/tests/edit-permissions-modal.test.tsx
@@ -288,22 +288,22 @@ describe('edit-permissions-modal', () => {
 
 		const sendNotificationUnCheckbox = within(
 			screen.getByTestId('sendNotificationCheckboxContainer')
-		).getByTestId('icon: Square');
+		).getByTestId('icon: CheckmarkSquare');
 
 		expect(sendNotificationUnCheckbox).toBeInTheDocument();
 
 		const standardMessage = screen.getByRole('textbox', {
 			name: /share\.standard_message/i
 		});
-		expect(standardMessage).toBeDisabled();
+		expect(standardMessage).toBeEnabled();
 
 		await user.click(sendNotificationUnCheckbox);
 		const sendNotificationCheckbox = within(
 			screen.getByTestId('sendNotificationCheckboxContainer')
-		).getByTestId('icon: CheckmarkSquare');
+		).getByTestId('icon: Square');
 		expect(sendNotificationCheckbox).toBeInTheDocument();
 
-		expect(standardMessage).toBeEnabled();
+		expect(standardMessage).toBeDisabled();
 		expect(standardMessage).toHaveValue('');
 	});
 	test.todo('when chips inside chipInput have errors, the confirm button is disabled');


### PR DESCRIPTION
fix: sharing folder set 'send notification about this shared' is checked by default