### PR TITLE
fix: print email headers

### DIFF
--- a/src/commons/print-conversation/get-header.ts
+++ b/src/commons/print-conversation/get-header.ts
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { type MailMessage } from '../../types';
 import { getParticipantHeader } from './get-participant-header';
 import { getAttachments } from './get-attachments';
+import { getSubject } from './get-subject';
 
 export function getHeader(msg: MailMessage, content: string): string {
 	const { participants, subject } = msg;
@@ -29,10 +30,7 @@ export function getHeader(msg: MailMessage, content: string): string {
                         <td align="left">
                             <table width="100%" align="left" cellpadding="2" cellspacing="0" border="0">
                                 ${getParticipantHeader(from, 'From')}
-                                <tr>
-                                    <td class='MsgHdrName'> Subject: </td>
-                                    <td  class='MsgHdrValue'>${subject}</td>
-                                </tr>
+                                ${getSubject(subject, 'Subject')}
                                 ${getParticipantHeader(to, 'To')} 
                                 ${getParticipantHeader(cc, 'Cc')}
                                 ${getParticipantHeader(bcc, 'Bcc')}

--- a/src/commons/print-conversation/get-participant-header.ts
+++ b/src/commons/print-conversation/get-participant-header.ts
@@ -21,8 +21,7 @@ export const getParticipantHeader = (participants: Participant[], type: string):
       vertical-align: top;
       text-align: left;
       font-weight: bold;
-      white-space: nowrap;
-      ">${type}: <span style="padding: 0.1875rem 0.1875rem 0.1875rem 0.1875rem; vertical-align: top; overflow: hidden; color: #828282;font-family: Roboto, sans-serif;
+      ">${type}: <span style="padding: 0.1875rem 0.1875rem 0.1875rem 0.1875rem; vertical-align: top; overflow: hidden;font-family: Roboto, sans-serif;
       font-style: normal;
       font-weight: 400;
       font-size: 0.875rem;

--- a/src/commons/print-conversation/get-subject.ts
+++ b/src/commons/print-conversation/get-subject.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export const getSubject = (content: string, subject: string): string => `<tr>
+    <td style="
+       width: auto;
+       padding: 0.1875rem 0 0.1875rem 0;
+       vertical-align: top;
+       text-align: left;
+       font-weight: bold;
+       ">${subject}: <span style="padding: 0.1875rem 0.1875rem 0.1875rem 0.1875rem; vertical-align: top; overflow: hidden;font-family: Roboto, sans-serif;
+       font-style: normal;
+       font-weight: 400;
+       font-size: 0.875rem;
+       line-height: 1.3125rem;">${content}</span></td>
+    </tr>`;


### PR DESCRIPTION
rifs: IRIS-4598
- print Subject is expanded in vertical
- removed double td + removed whitespace:nowrap
- removed grey scale color over header content