### PR TITLE
HOTFIX inline images without content disposition

### DIFF
--- a/src/commons/mail-message-renderer.tsx
+++ b/src/commons/mail-message-renderer.tsx
@@ -31,7 +31,7 @@ import styled from 'styled-components';
 import { getOriginalContent, getQuotedTextOnly } from './get-quoted-text-util';
 import { isAvailableInTrusteeList } from './utils';
 import { ParticipantRole } from '../carbonio-ui-commons/constants/participants';
-import { findAttachments } from '../helpers/attachments';
+import { getAttachmentParts } from '../helpers/attachments';
 import type { MailMessage, MailMessagePart, Participant } from '../types';
 
 export const _CI_REGEX = /^<(.*)>$/;
@@ -446,7 +446,7 @@ const MailMessageRenderer: FC<{ mailMsg: MailMessage; onLoadChange: () => void }
 	mailMsg,
 	onLoadChange
 }) => {
-	const parts = findAttachments(mailMsg.parts ?? [], []);
+	const parts = getAttachmentParts(mailMsg);
 
 	useEffect(() => {
 		if (!mailMsg.read) {

--- a/src/helpers/attachments.ts
+++ b/src/helpers/attachments.ts
@@ -167,10 +167,10 @@ export function filterAttachmentsParts(
 			if (
 				part.disposition === 'attachment' ||
 				(part.disposition === 'inline' && part.filename) ||
-				isReferredByCid
+				(part.disposition === undefined && isReferredByCid)
 			) {
 				// Force the inline disposition if the part is referred by something else in the body
-				if (isReferredByCid) {
+				if (part.disposition === undefined && isReferredByCid) {
 					filtered.push({
 						...part,
 						disposition: 'inline'

--- a/src/helpers/tests/attachments.test.ts
+++ b/src/helpers/tests/attachments.test.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { getMsgCall } from '../../store/actions';
+import { getAttachmentParts } from '../attachments';
+
+describe('getAttachmentParts', () => {
+	test('Inline attachment without content disposition are recognized anyway', async () => {
+		const msg = await getMsgCall({ msgId: '13' });
+		const attachmentParts = getAttachmentParts(msg);
+		expect(attachmentParts).toHaveLength(1);
+		expect(attachmentParts[0].name).toBe('2');
+		expect(attachmentParts[0].disposition).toBe('inline');
+		expect(attachmentParts[0].filename).toBe('image001.jpg');
+		expect(attachmentParts[0].ci).toBe('<image001.jpg@01D9CB62.1AADEDA0>');
+	});
+});

--- a/src/store/actions/get-msg.ts
+++ b/src/store/actions/get-msg.ts
@@ -5,22 +5,24 @@
  */
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { soapFetch } from '@zextras/carbonio-shell-ui';
+
 import { normalizeMailMessageFromSoap } from '../../normalizations/normalize-message';
 import type { GetMsgParameters, MailMessage, GetMsgRequest, GetMsgResponse } from '../../types';
 
+export const getMsgCall = async ({ msgId }: GetMsgParameters): Promise<MailMessage> => {
+	const result = (await soapFetch<GetMsgRequest, GetMsgResponse>('GetMsg', {
+		_jsns: 'urn:zimbraMail',
+		m: {
+			html: 1,
+			id: msgId,
+			needExp: 1
+		}
+	})) as GetMsgResponse;
+	const msg = result?.m[0];
+	return normalizeMailMessageFromSoap(msg, true) as MailMessage;
+};
+
 export const getMsg = createAsyncThunk<MailMessage, GetMsgParameters>(
 	'messages/getMsg',
-	async ({ msgId }) => {
-		const result = (await soapFetch<GetMsgRequest, GetMsgResponse>('GetMsg', {
-			_jsns: 'urn:zimbraMail',
-			m: {
-				html: 1,
-				id: msgId,
-				needExp: 1
-			}
-		})) as GetMsgResponse;
-		const msg = result?.m[0];
-		const normalizedMsg = normalizeMailMessageFromSoap(msg, true) as MailMessage;
-		return normalizedMsg;
-	}
+	getMsgCall
 );

--- a/src/store/zustand/editor/editor-transformations.ts
+++ b/src/store/zustand/editor/editor-transformations.ts
@@ -14,10 +14,10 @@ import {
 } from './editor-utils';
 import { ParticipantRole } from '../../../carbonio-ui-commons/constants/participants';
 import {
-	CIDURL_REGEX,
 	composeAttachmentDownloadUrl,
 	extractContentIdInnerPart,
 	getAttachmentParts,
+	getCidFromCidUrl,
 	isCidUrl,
 	isContentIdEqual,
 	isDownloadServicedUrl
@@ -48,11 +48,10 @@ export const convertCidUrlToServiceUrl = (
 	cidUrl: string,
 	savedInlineAttachments: Array<SavedAttachment>
 ): string => {
-	const cidUrlTokens = new RegExp(CIDURL_REGEX, 'gi').exec(cidUrl);
-	if (!cidUrlTokens) {
+	const cid = getCidFromCidUrl(cidUrl);
+	if (!cid) {
 		return cidUrl;
 	}
-	const cid = cidUrlTokens[1];
 	const referredAttachment = reduce<SavedAttachment, SavedAttachment | null>(
 		savedInlineAttachments,
 		(result, attachment) =>

--- a/src/tests/mocks/network/msw/cases/getMsg/getMsg-13.ts
+++ b/src/tests/mocks/network/msw/cases/getMsg/getMsg-13.ts
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { createFakeIdentity } from '../../../../../../carbonio-ui-commons/test/mocks/accounts/fakeAccounts';
+
+/**
+ * Email with an inline attachment without content disposition
+ */
+const identity1 = createFakeIdentity();
+const identity2 = createFakeIdentity();
+
+export const getMsgResult = {
+	Header: {
+		context: {
+			session: {
+				id: '154557',
+				_content: '154557'
+			},
+			change: {
+				token: 48598
+			},
+			_jsns: 'urn:zimbra'
+		}
+	},
+	Body: {
+		GetMsgResponse: {
+			m: [
+				{
+					s: 40567,
+					d: 1692794194000,
+					l: '2',
+					cid: '24112',
+					f: 'aw',
+					rev: 45411,
+					id: '23449',
+					e: [
+						{
+							a: identity1.email,
+							d: identity1.firstName,
+							p: identity1.fullName,
+							t: 'f'
+						},
+						{
+							a: identity2.email,
+							d: identity2.firstName,
+							p: identity2.fullName,
+							t: 't'
+						}
+					],
+					su: 'Test 2 - inline image sent via Outlook as ActiveSync client',
+					mid: '<1752150646.6396125.1691648702500.JavaMail.zextras@df3>',
+					sd: 1691648702000,
+					rd: 1692794194000,
+					mp: [
+						{
+							part: 'TEXT',
+							ct: 'multipart/related',
+							mp: [
+								{
+									part: '1',
+									ct: 'multipart/alternative',
+									mp: [
+										{
+											part: '1.1',
+											ct: 'text/plain',
+											s: 4
+										},
+										{
+											part: '1.2',
+											ct: 'text/html',
+											s: 2024,
+											body: true,
+											content:
+												'<html xmlns="http://www.w3.org/TR/REC-html40"><head><style>/*<![CDATA[*/p.MsoNormal, li.MsoNormal, div.MsoNormal {\n\tmargin: 0.0in;\n\tfont-size: 11.0pt;\n\tfont-family: Calibri , sans-serif;\n}\nspan.StileMessaggioDiPostaElettronica18 {\n\tfont-family: Calibri , sans-serif;\n\tcolor: windowtext;\n}\n*.MsoChpDefault {\n\tfont-size: 10.0pt;\n}\ndiv.WordSection1 {\n\tpage: WordSection1;\n}\n/*]]>*/</style></head><body lang="EN-US" style="word-wrap:break-word"><div class="WordSection1"><p class="MsoNormal"><img width="474" height="474" style="width:4.9375in;height:4.9375in" id="Immagine_x0020_1" src="cid:image001.jpg&#64;01D9CB62.1AADEDA0" alt="Immagine che contiene clipart, cartone animato\n\nDescrizione generata automaticamente" /></p></div></body></html>'
+										}
+									]
+								},
+								{
+									part: '2',
+									ct: 'image/jpeg',
+									s: 22848,
+									filename: 'image001.jpg',
+									ci: '<image001.jpg@01D9CB62.1AADEDA0>'
+								}
+							]
+						}
+					]
+				}
+			],
+			_jsns: 'urn:zimbraMail'
+		}
+	}
+};


### PR DESCRIPTION
In some case a message can contain an inline image without any content disposition. In this case the algorithm fails to recognise it as an attachment.
The logic is then changed as the following:
1. create a list of CIDs referred in the html body of the message
2. parse all the attachments and, for the ones without content disposition and that are listed in the step 1, the _inline_ disposition is forced

For step 2 we took the chance to replace the recursive function that collect the attachments with the new one created for the new editor. This way we reduced the code duplication.

A test is added to check that the algorithm works with a real case email that was provided to our team

refs: IRIS-4621