### PR TITLE
[HOTFIX] reply from message list

### DIFF
--- a/src/store/zustand/editor/editor-generators.ts
+++ b/src/store/zustand/editor/editor-generators.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { Account, AccountSettings, t } from '@zextras/carbonio-shell-ui';
+import { getUserAccount, t } from '@zextras/carbonio-shell-ui';
 import { v4 as uuid } from 'uuid';
 
 import { buildSavedAttachments, replaceCidUrlWithServiceUrl } from './editor-transformations';
@@ -149,11 +149,10 @@ export const generateIntegratedNewEditor = (
  */
 export const generateReplyAndReplyAllMsgEditor = (
 	messagesStoreDispatch: AppDispatch,
-	account: Account,
-	settings: AccountSettings,
 	originalMessage: MailMessage,
 	action: EditViewActionsType
 ): MailsEditorV2 => {
+	const account = getUserAccount();
 	const editorId = uuid();
 	const savedInlineAttachments = filterSavedInlineAttachment(
 		buildSavedAttachments(originalMessage)
@@ -214,8 +213,6 @@ export const generateReplyAndReplyAllMsgEditor = (
  */
 export const generateForwardMsgEditor = (
 	messagesStoreDispatch: AppDispatch,
-	account: Account,
-	settings: AccountSettings,
 	originalMessage: MailMessage
 ): MailsEditorV2 => {
 	const editorId = uuid();
@@ -266,8 +263,6 @@ export const generateForwardMsgEditor = (
 
 export const generateEditAsDraftEditor = (
 	messagesStoreDispatch: AppDispatch,
-	account: Account,
-	settings: AccountSettings,
 	originalMessage: MailMessage
 ): MailsEditorV2 => {
 	const editorId = uuid();
@@ -307,8 +302,6 @@ export const generateEditAsDraftEditor = (
 
 export const generateEditAsNewEditor = (
 	messagesStoreDispatch: AppDispatch,
-	account: Account,
-	settings: AccountSettings,
 	originalMessage: MailMessage
 ): MailsEditorV2 => {
 	const editorId = uuid();
@@ -360,9 +353,7 @@ export type GenerateEditorParams = {
 	action: EditViewActionsType;
 	id?: string;
 	messagesStoreDispatch: AppDispatch;
-	account: Account;
-	settings: AccountSettings;
-	message?: MailMessage | undefined;
+	message?: MailMessage | null;
 	compositionData?: EditorPrefillData;
 };
 
@@ -371,16 +362,12 @@ export type GenerateEditorParams = {
  * @param action
  * @param id
  * @param messagesStoreDispatch
- * @param account
- * @param settings
- * @param messages
+ * @param message
  */
 export const generateEditor = ({
 	action,
 	id,
 	messagesStoreDispatch,
-	account,
-	settings,
 	message,
 	compositionData
 }: GenerateEditorParams): MailsEditorV2 | null => {
@@ -398,13 +385,7 @@ export const generateEditor = ({
 				throw new Error('Cannot generate a reply editor without a message id');
 			}
 			if (message) {
-				return generateReplyAndReplyAllMsgEditor(
-					messagesStoreDispatch,
-					account,
-					settings,
-					message,
-					action
-				);
+				return generateReplyAndReplyAllMsgEditor(messagesStoreDispatch, message, action);
 			}
 			break;
 		case EditViewActions.REPLY_ALL:
@@ -413,13 +394,7 @@ export const generateEditor = ({
 				throw new Error('Cannot generate a reply all editor without a message id');
 			}
 			if (message) {
-				return generateReplyAndReplyAllMsgEditor(
-					messagesStoreDispatch,
-					account,
-					settings,
-					message,
-					action
-				);
+				return generateReplyAndReplyAllMsgEditor(messagesStoreDispatch, message, action);
 			}
 			break;
 		case EditViewActions.FORWARD:
@@ -428,7 +403,7 @@ export const generateEditor = ({
 				throw new Error('Cannot generate a forward editor without a message id');
 			}
 			if (message) {
-				return generateForwardMsgEditor(messagesStoreDispatch, account, settings, message);
+				return generateForwardMsgEditor(messagesStoreDispatch, message);
 			}
 			break;
 		case EditViewActions.EDIT_AS_DRAFT:
@@ -437,7 +412,7 @@ export const generateEditor = ({
 				throw new Error('Cannot generate a draft editor without a message id');
 			}
 			if (message) {
-				return generateEditAsDraftEditor(messagesStoreDispatch, account, settings, message);
+				return generateEditAsDraftEditor(messagesStoreDispatch, message);
 			}
 			break;
 		case EditViewActions.EDIT_AS_NEW:
@@ -446,7 +421,7 @@ export const generateEditor = ({
 				throw new Error('Cannot generate an edit as new editor without a message id');
 			}
 			if (message) {
-				return generateEditAsNewEditor(messagesStoreDispatch, account, settings, message);
+				return generateEditAsNewEditor(messagesStoreDispatch, message);
 			}
 			break;
 		case EditViewActions.MAIL_TO:
@@ -460,3 +435,13 @@ export const generateEditor = ({
 
 	return null;
 };
+//
+// export const useGenerateEditor = ({
+// 	action,
+// 	id,
+// 	compositionData
+// }: Omit<GenerateEditorParams, 'message' | 'messagesStoreDispatch'>): MailsEditorV2 | null => {
+// 	const messagesStoreDispatch = useAppDispatch();
+// 	const message = use;
+// 	return generateEditor({ action, id, messagesStoreDispatch, message });
+// };

--- a/src/store/zustand/editor/hooks.ts
+++ b/src/store/zustand/editor/hooks.ts
@@ -288,6 +288,7 @@ const saveDraftFromEditor = (editorId: MailsEditorV2['id'], options?: SaveDraftO
 	// FIXME use a subscription to the store update
 	computeAndUpdateEditorStatus(editorId);
 };
+
 const delay = getDraftSaveDelay();
 const debouncedSaveDraftFromEditor = debounce(saveDraftFromEditor, delay);
 

--- a/src/views/app/detail-panel/edit/edit-view-controller.tsx
+++ b/src/views/app/detail-panel/edit/edit-view-controller.tsx
@@ -195,7 +195,7 @@ const EditViewController: FC = () => {
 		if (isMessageLoadingRequired && !!id) {
 			messagesStoreDispatch(getMsg({ msgId: id }));
 		}
-	});
+	}, [id, isMessageLoadingRequired, messagesStoreDispatch]);
 
 	return isMessageLoadingRequired ? (
 		<Button loading disabled label="" type="ghost" onClick={noop} />

--- a/src/views/app/detail-panel/edit/edit-view-controller.tsx
+++ b/src/views/app/detail-panel/edit/edit-view-controller.tsx
@@ -5,7 +5,7 @@
  */
 import React, { FC, memo, useCallback, useEffect, useMemo } from 'react';
 
-import { Button } from '@zextras/carbonio-design-system';
+import { Button, Container } from '@zextras/carbonio-design-system';
 import {
 	updateBoardContext,
 	closeBoard,
@@ -171,6 +171,10 @@ const EditViewControllerCore: FC<EditViewControllerCoreProps> = ({ action, entit
 
 const MemoizedEditViewControllerCore = memo(EditViewControllerCore);
 
+/**
+ * Get and parse the parameters. Get the original message if it is needed
+ * @constructor
+ */
 const EditViewController: FC = () => {
 	const messagesStoreDispatch = useAppDispatch();
 
@@ -191,6 +195,10 @@ const EditViewController: FC = () => {
 		[isMessageRequired, message?.isComplete]
 	);
 
+	/**
+	 * Load the original message if it's required and is not
+	 * in the store or is not complete
+	 */
 	useEffect(() => {
 		if (isMessageLoadingRequired && !!id) {
 			messagesStoreDispatch(getMsg({ msgId: id }));
@@ -198,7 +206,9 @@ const EditViewController: FC = () => {
 	}, [id, isMessageLoadingRequired, messagesStoreDispatch]);
 
 	return isMessageLoadingRequired ? (
-		<Button loading disabled label="" type="ghost" onClick={noop} />
+		<Container>
+			<Button loading disabled label="" type="ghost" onClick={noop} />
+		</Container>
 	) : (
 		<MemoizedEditViewControllerCore entityId={id} action={action} message={message} />
 	);

--- a/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
@@ -56,8 +56,8 @@ export const TextEditorContainer: FC<TextEditorContainerProps> = ({
 	const urlConverter = useEditorInlineUrlConverter(editorId);
 
 	const composerCustomOptions = {
-		toolbar_sticky: false,
-		convert_url: true
+		toolbar_sticky: false
+		// newline_behavior: 'default'
 		// urlconverter_callback: (url: string): string => urlConverter(url)
 	};
 

--- a/src/views/app/folder-panel/messages/message-list-item.tsx
+++ b/src/views/app/folder-panel/messages/message-list-item.tsx
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import React, { FC, memo, useCallback, useMemo } from 'react';
+
 import {
 	Badge,
 	Container,
@@ -24,12 +26,12 @@ import {
 } from '@zextras/carbonio-shell-ui';
 import { find, includes, isEmpty, noop, reduce } from 'lodash';
 import moment from 'moment';
-import React, { FC, memo, useCallback, useMemo } from 'react';
+
 import { useFolder } from '../../../../carbonio-ui-commons/store/zustand/folder/hooks';
 import { getTimeLabel, participantToString } from '../../../../commons/utils';
 import { EditViewActions, MAILS_ROUTE } from '../../../../constants';
 import { useAppDispatch } from '../../../../hooks/redux';
-import type { MessageListItemProps, TextReadValuesType } from '../../../../types';
+import type { BoardContext, MessageListItemProps, TextReadValuesType } from '../../../../types';
 import { setMsgRead } from '../../../../ui-actions/message-actions';
 import { useTagExist } from '../../../../ui-actions/tag-actions';
 import { getFolderTranslatedName } from '../../../sidebar/utils';
@@ -69,15 +71,14 @@ export const MessageListItem: FC<MessageListItemProps> = memo(function MessageLi
 			if (!e.isDefaultPrevented()) {
 				const { id, isDraft } = item;
 				if (isDraft) {
-					addBoard({
-						url: `${MAILS_ROUTE}/edit/${id}?action=${EditViewActions.EDIT_AS_DRAFT}`,
-						context: { mailId: id, folderId: firstChildFolderId },
+					addBoard<BoardContext>({
+						url: `${MAILS_ROUTE}/edit?action=${EditViewActions.EDIT_AS_DRAFT}&id=${id}`,
 						title: ''
 					});
 				}
 			}
 		},
-		[firstChildFolderId, item]
+		[item]
 	);
 
 	const accounts = useUserAccounts();


### PR DESCRIPTION
Fix an error that appears on the editor (blank editor and red 'No editor provided' message). This error occurs when the original message for the reply/forward/edit is still not completely read and need to be full fetched from the BE

refs: IRIS-4667, IRIS-4671