### PR TITLE
HOTFIX - IRIS-3757 - let user to visualize emails and conversation in a larger way

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -259,10 +259,18 @@ export const MessageActionsDescriptors = {
 	DELETE_PERMANENTLY: {
 		id: 'message-delete-permanently',
 		desc: 'Delete Permanently'
+	},
+	PREVIEW_ON_SEPARATED_WINDOW: {
+		id: 'preview-on-separated-window',
+		desc: 'Preview the message on a separated window'
 	}
 } as const;
 
 export const ConversationActionsDescriptors = {
+	PREVIEW_ON_SEPARATED_WINDOW: {
+		id: 'preview-on-separated-window',
+		desc: 'Preview the conversation on a separated window'
+	},
 	FLAG: {
 		id: 'flag-conversation',
 		desc: 'Add flag'

--- a/src/hooks/use-message-actions.tsx
+++ b/src/hooks/use-message-actions.tsx
@@ -5,13 +5,13 @@
  */
 import { useMemo } from 'react';
 
-import { FOLDERS, useAppContext, useTags, useUserAccount } from '@zextras/carbonio-shell-ui';
+import { FOLDERS, useAppContext, useTags } from '@zextras/carbonio-shell-ui';
 import { includes } from 'lodash';
 import { useParams } from 'react-router-dom';
 
 import { useAppDispatch } from './redux';
 import { useSelection } from './use-selection';
-import type { AppContext, MailMessage } from '../types';
+import type { AppContext, MailMessage, MessageAction } from '../types';
 import {
 	deleteMessagePermanently,
 	deleteMsg,
@@ -20,6 +20,7 @@ import {
 	forwardMsg,
 	moveMessageToFolder,
 	moveMsgToTrash,
+	previewMessageOnSeparatedWindow,
 	printMsg,
 	redirectMsg,
 	replyAllMsg,
@@ -31,58 +32,77 @@ import {
 	showOriginalMsg
 } from '../ui-actions/message-actions';
 import { applyTag } from '../ui-actions/tag-actions';
+import { useExtraWindowsManager } from '../views/app/extra-windows/extra-window-manager';
+import { useExtraWindow } from '../views/app/extra-windows/use-extra-window';
 
-export const useMessageActions = (message: MailMessage, isAlone = false): Array<any> => {
+/*
+ * FIXME this hook is used only by the displayer. It should be aligned/merged with
+ * 	the others functions that are providing primary and secondary actions for a message
+ *
+ * FIXME the folder id comparisons are weak: they're not working for shared folders nor for subfolders.
+ *  Consider using/creating common utility functions
+ */
+export const useMessageActions = (
+	message: MailMessage | undefined,
+	isAlone = false
+): Array<MessageAction> => {
 	const { folderId }: { folderId: string } = useParams();
 	const dispatch = useAppDispatch();
 	const { setCount } = useAppContext<AppContext>();
 	const { deselectAll } = useSelection({ currentFolderId: folderId, setCount, count: 0 });
-
-	const account = useUserAccount();
+	const { isInsideExtraWindow } = useExtraWindow();
+	const { createWindow } = useExtraWindowsManager();
 
 	const systemFolders = useMemo(
 		() => [FOLDERS.INBOX, FOLDERS.SENT, FOLDERS.DRAFTS, FOLDERS.TRASH, FOLDERS.SPAM],
 		[]
 	);
 	const tags = useTags();
-	const arr = [];
+	const actions = [];
+
+	if (!message) {
+		return [];
+	}
 
 	if (message.parent === FOLDERS.DRAFTS) {
-		arr.push(sendDraft({ message, dispatch }));
-		arr.push(editDraft({ id: message.id, folderId, message }));
-		arr.push(
-			moveMsgToTrash({
-				ids: [message.id],
-				dispatch,
-				deselectAll,
-				folderId,
-				conversationId: message?.conversation,
-				closeEditor: isAlone
-			})
-		);
-		arr.push(setMsgFlag({ ids: [message.id], value: message.flagged, dispatch }));
-		arr.push(applyTag({ tags, conversation: message, isMessage: true }));
+		!isInsideExtraWindow && actions.push(sendDraft({ message, dispatch }));
+		!isInsideExtraWindow && actions.push(editDraft({ id: message.id, folderId, message }));
+		!isInsideExtraWindow &&
+			actions.push(
+				moveMsgToTrash({
+					ids: [message.id],
+					dispatch,
+					deselectAll,
+					folderId,
+					conversationId: message?.conversation,
+					closeEditor: isAlone
+				})
+			);
+		actions.push(setMsgFlag({ ids: [message.id], value: message.flagged, dispatch }));
+		actions.push(applyTag({ tags, conversation: message, isMessage: true }));
 	}
+
 	if (
 		message.parent === FOLDERS.INBOX ||
 		message.parent === FOLDERS.SENT ||
 		!includes(systemFolders, message.parent)
 	) {
 		// INBOX, SENT OR CREATED_FOLDER
-		arr.push(replyMsg({ id: message.id, folderId }));
-		arr.push(replyAllMsg({ id: message.id, folderId }));
-		arr.push(forwardMsg({ id: message.id, folderId }));
-		arr.push(
-			moveMsgToTrash({
-				ids: [message.id],
-				dispatch,
-				deselectAll,
-				folderId,
-				conversationId: message?.conversation,
-				closeEditor: isAlone
-			})
-		);
-		arr.push(
+		!isInsideExtraWindow && actions.push(replyMsg({ id: message.id, folderId }));
+		!isInsideExtraWindow && actions.push(replyAllMsg({ id: message.id, folderId }));
+		!isInsideExtraWindow && actions.push(forwardMsg({ id: message.id, folderId }));
+		!isInsideExtraWindow &&
+			actions.push(
+				moveMsgToTrash({
+					ids: [message.id],
+					dispatch,
+					deselectAll,
+					folderId,
+					conversationId: message?.conversation,
+					closeEditor: isAlone
+				})
+			);
+		actions.push(
 			setMsgRead({
 				ids: [message.id],
 				value: message.read,
@@ -92,49 +112,62 @@ export const useMessageActions = (message: MailMessage, isAlone = false): Array<
 				deselectAll
 			})
 		);
-		arr.push(
-			moveMessageToFolder({
-				id: [message.id],
-				folderId,
-				dispatch,
-				isRestore: false,
-				deselectAll
-			})
-		);
+		!isInsideExtraWindow &&
+			actions.push(
+				moveMessageToFolder({
+					id: [message.id],
+					folderId,
+					dispatch,
+					isRestore: false,
+					deselectAll
+				})
+			);
 
-		arr.push(applyTag({ tags, conversation: message, isMessage: true }));
-		arr.push(printMsg({ message }));
-		arr.push(setMsgFlag({ ids: [message.id], value: message.flagged, dispatch }));
-		arr.push(redirectMsg({ id: message.id }));
-		arr.push(editAsNewMsg({ id: message.id, folderId }));
-		arr.push(setMsgAsSpam({ ids: [message.id], value: false, dispatch, folderId }));
-		arr.push(showOriginalMsg({ id: message.id }));
+		actions.push(applyTag({ tags, conversation: message, isMessage: true }));
+		actions.push(printMsg({ message }));
+		actions.push(setMsgFlag({ ids: [message.id], value: message.flagged, dispatch }));
+		!isInsideExtraWindow && actions.push(redirectMsg({ id: message.id }));
+		!isInsideExtraWindow && actions.push(editAsNewMsg({ id: message.id, folderId }));
+		!isInsideExtraWindow &&
+			actions.push(setMsgAsSpam({ ids: [message.id], value: false, dispatch, folderId }));
+		actions.push(showOriginalMsg({ id: message.id }));
 	}
 
 	if (message.parent === FOLDERS.TRASH) {
-		arr.push(
-			moveMessageToFolder({
-				id: [message.id],
-				folderId,
-				dispatch,
-				isRestore: true,
-				deselectAll
-			})
-		);
-		arr.push(deleteMessagePermanently({ ids: [message.id], dispatch, deselectAll }));
-		arr.push(applyTag({ tags, conversation: message, isMessage: true }));
+		!isInsideExtraWindow &&
+			actions.push(
+				moveMessageToFolder({
+					id: [message.id],
+					folderId,
+					dispatch,
+					isRestore: true,
+					deselectAll
+				})
+			);
+		!isInsideExtraWindow &&
+			actions.push(deleteMessagePermanently({ ids: [message.id], dispatch, deselectAll }));
+		actions.push(applyTag({ tags, conversation: message, isMessage: true }));
 	}
+
 	if (message.parent === FOLDERS.SPAM) {
-		arr.push(
-			deleteMsg({
-				ids: [message.id],
-				dispatch
-			})
-		);
-		arr.push(setMsgAsSpam({ ids: [message.id], value: true, dispatch, folderId }));
-		arr.push(printMsg({ message }));
-		arr.push(showOriginalMsg({ id: message.id }));
-		arr.push(applyTag({ tags, conversation: message, isMessage: true }));
+		!isInsideExtraWindow &&
+			actions.push(
+				deleteMsg({
+					ids: [message.id],
+					dispatch
+				})
+			);
+		!isInsideExtraWindow &&
+			actions.push(setMsgAsSpam({ ids: [message.id], value: true, dispatch, folderId }));
+		actions.push(printMsg({ message }));
+		actions.push(showOriginalMsg({ id: message.id }));
+		actions.push(applyTag({ tags, conversation: message, isMessage: true }));
 	}
-	return arr;
+
+	!isInsideExtraWindow &&
+		actions.push(
+			previewMessageOnSeparatedWindow(message.id, folderId, message.subject, createWindow, actions)
+		);
+
+	return actions;
 };

--- a/src/types/actions/index.d.ts
+++ b/src/types/actions/index.d.ts
@@ -39,3 +39,9 @@ export type ActionReturnType =
 	| MessageActionReturnType
 	| ConvActionReturnType
 	| TagActionItemType;
+
+/*
+ * The "any" is inherited from the return type of the useMessageActions hook.
+ * We define an alias, and then we will refactor the MessageAction type
+ */
+export type MessageAction = any;

--- a/src/ui-actions/conversation-actions.tsx
+++ b/src/ui-actions/conversation-actions.tsx
@@ -15,7 +15,9 @@ import { getContentForPrint } from '../commons/print-conversation/print-conversa
 import { ConversationActionsDescriptors } from '../constants';
 import { convAction, getMsgsForPrint } from '../store/actions';
 import { AppDispatch, StoreProvider } from '../store/redux';
+import { ExtraWindowCreationParams, ExtraWindowsContextType } from '../types';
 import type { ConvActionReturnType, Conversation, MailMessage } from '../types';
+import { ConversationPreviewPanel } from '../views/app/detail-panel/conversation-preview-panel';
 
 type ConvActionIdsType = Array<string>;
 type ConvActionValueType = string | boolean;
@@ -58,6 +60,43 @@ export function setConversationsFlag({
 		}
 	};
 }
+
+export const previewConversationOnSeparatedWindow = (
+	conversationId: string,
+	folderId: string,
+	subject: string,
+	createWindow: ExtraWindowsContextType['createWindow']
+): void => {
+	if (!createWindow) {
+		return;
+	}
+
+	const createWindowParams: ExtraWindowCreationParams = {
+		name: `conversation-${conversationId}`,
+		returnComponent: false,
+		children: <ConversationPreviewPanel conversationId={conversationId} folderId={folderId} />,
+		title: subject,
+		closeOnUnmount: false
+	};
+	createWindow(createWindowParams);
+};
+
+export const previewConversationOnSeparatedWindowAction = (
+	conversationId: string,
+	folderId: string,
+	subject: string,
+	createWindow: ExtraWindowsContextType['createWindow']
+): ConvActionReturnType => {
+	const actDescriptor = ConversationActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW;
+	return {
+		id: actDescriptor.id,
+		icon: 'BrowserOutline',
+		label: t('action.preview_on_separated_window', 'Open on a new window'),
+		onClick: (): void => {
+			previewConversationOnSeparatedWindow(conversationId, folderId, subject, createWindow);
+		}
+	};
+};
 
 export function setMultipleConversationsFlag({
 	ids,

--- a/src/ui-actions/get-msg-conv-actions-functions.ts
+++ b/src/ui-actions/get-msg-conv-actions-functions.ts
@@ -10,6 +10,7 @@ import {
 	deleteConversationPermanently,
 	moveConversationToFolder,
 	moveConversationToTrash,
+	previewConversationOnSeparatedWindowAction,
 	printConversation,
 	setConversationsFlag,
 	setConversationsRead,
@@ -22,6 +23,7 @@ import {
 	forwardMsg,
 	moveMessageToFolder,
 	moveMsgToTrash,
+	previewMessageOnSeparatedWindow,
 	printMsg,
 	redirectMsg,
 	replyAllMsg,
@@ -35,7 +37,13 @@ import {
 import { applyTag } from './tag-actions';
 import { getFolderIdParts } from '../helpers/folders';
 import { AppDispatch } from '../store/redux';
-import type { ActionReturnType, Conversation, MailMessage } from '../types';
+import type {
+	ActionReturnType,
+	Conversation,
+	ExtraWindowsContextType,
+	MailMessage,
+	MessageAction
+} from '../types';
 
 /**
  * get the action to be executed when the user clicks on the "Mark as read/unread" button
@@ -238,6 +246,26 @@ export function getMarkRemoveSpam({
 				folderId
 		  });
 	return !foldersExcludedMarkUnmarkSpam.includes(getFolderIdParts(folderId).id ?? '0') && action;
+}
+
+export function getPreviewOnSeparatedWindowAction({
+	isConversation,
+	id,
+	folderId,
+	subject,
+	createWindow,
+	messageActions
+}: {
+	isConversation: boolean;
+	id: string;
+	folderId: string;
+	subject: string;
+	createWindow: ExtraWindowsContextType['createWindow'];
+	messageActions: Array<MessageAction>;
+}): ActionReturnType {
+	return isConversation
+		? previewConversationOnSeparatedWindowAction(id, folderId, subject, createWindow)
+		: previewMessageOnSeparatedWindow(id, folderId, subject, createWindow, messageActions);
 }
 
 export function getApplyTagAction({

--- a/src/ui-actions/get-msg-conv-actions.ts
+++ b/src/ui-actions/get-msg-conv-actions.ts
@@ -17,6 +17,7 @@ import {
 	getMarkRemoveSpam,
 	getMoveToFolderAction,
 	getMoveToTrashAction,
+	getPreviewOnSeparatedWindowAction,
 	getPrintAction,
 	getReadUnreadAction,
 	getRedirectAction,
@@ -28,13 +29,21 @@ import {
 import { getFolderIdParts, getParentFolderId } from '../helpers/folders';
 import { isConversation, isSingleMessageConversation } from '../helpers/messages';
 import { AppDispatch } from '../store/redux';
-import type { ActionReturnType, Conversation, MailMessage } from '../types';
+import type {
+	ActionReturnType,
+	Conversation,
+	ExtraWindowsContextType,
+	MailMessage,
+	MessageAction
+} from '../types';
 
 type GetMessageActionsProps = {
 	item: MailMessage | Conversation;
 	dispatch: AppDispatch;
 	deselectAll: () => void;
 	tags: Tags;
+	createWindow: ExtraWindowsContextType['createWindow'];
+	messageActions: Array<MessageAction>;
 };
 
 export type MsgConvActionsReturnType = [
@@ -46,7 +55,9 @@ export function getMsgConvActions({
 	item,
 	dispatch,
 	deselectAll,
-	tags
+	tags,
+	createWindow,
+	messageActions
 }: GetMessageActionsProps): MsgConvActionsReturnType {
 	const isConv = isConversation(item);
 	const folderId = getParentFolderId(item);
@@ -211,6 +222,15 @@ export function getMsgConvActions({
 		folderId
 	});
 
+	const previewOnSeparatedWindow = getPreviewOnSeparatedWindowAction({
+		isConversation: isConv,
+		id,
+		folderId,
+		subject: item.subject,
+		createWindow,
+		messageActions
+	});
+
 	/**
 	 * Primary actions are the ones that are shown when the user hovers over a message
 	 * @returns an array of arrays of actions
@@ -247,6 +267,7 @@ export function getMsgConvActions({
 		applyTagAction,
 		moveToFolderAction,
 		printAction,
+		previewOnSeparatedWindow,
 		redirectAction,
 		editDraftAction,
 		editAsNewAction,

--- a/src/ui-actions/message-actions.tsx
+++ b/src/ui-actions/message-actions.tsx
@@ -28,10 +28,13 @@ import { AppDispatch, StoreProvider } from '../store/redux';
 import type {
 	BoardContext,
 	MailMessage,
+	MessageAction,
 	MessageActionReturnType,
 	MsgActionParameters,
 	MsgActionResult
 } from '../types';
+import { ConvActionReturnType, ExtraWindowCreationParams, ExtraWindowsContextType } from '../types';
+import { MessagePreviewPanel } from '../views/app/detail-panel/message-preview-panel';
 
 type MessageActionIdsType = Array<string>;
 type MessageActionValueType = string | boolean;
@@ -192,6 +195,51 @@ export function setMsgAsSpam({
 				/** If the user has not clicked on the undo button, we can proceed with the action */
 				setAsSpam({ notCanceled, value, dispatch, ids, shouldReplaceHistory, folderId });
 			}, TIMEOUTS.SET_AS_SPAM);
+		}
+	};
+}
+
+export const previewOnSeparatedWindow = (
+	messageId: string,
+	folderId: string,
+	subject: string,
+	createWindow: ExtraWindowsContextType['createWindow'],
+	messageActions: Array<MessageAction>
+): void => {
+	if (!createWindow) {
+		return;
+	}
+
+	const createWindowParams: ExtraWindowCreationParams = {
+		name: `message-${messageId}`,
+		returnComponent: false,
+		children: (
+			<MessagePreviewPanel
+				messageId={messageId}
+				folderId={folderId}
+				messageActions={messageActions}
+			/>
+		),
+		title: subject,
+		closeOnUnmount: false
+	};
+	createWindow(createWindowParams);
+};
+
+export function previewMessageOnSeparatedWindow(
+	messageId: string,
+	folderId: string,
+	subject: string,
+	createWindow: ExtraWindowsContextType['createWindow'],
+	messageActions: Array<MessageAction>
+): ConvActionReturnType {
+	const actDescriptor = MessageActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW;
+	return {
+		id: actDescriptor.id,
+		icon: 'BrowserOutline',
+		label: t('action.preview_on_separated_window', 'Open on a new window'),
+		onClick: (): void => {
+			previewOnSeparatedWindow(messageId, folderId, subject, createWindow, messageActions);
 		}
 	};
 }

--- a/src/ui-actions/tests/conversation-actions.test.tsx
+++ b/src/ui-actions/tests/conversation-actions.test.tsx
@@ -32,6 +32,7 @@ import DeleteConvConfirm from '../delete-conv-modal';
 import MoveConvMessage from '../move-conv-msg';
 import { TagsDropdownItem } from '../tag-actions';
 
+// TODO move into an utility module
 function createAPIInterceptor<T>(apiAction: string): Promise<T> {
 	return new Promise<T>((resolve, reject) => {
 		// Register a handler for the REST call

--- a/src/ui-actions/tests/conversation-primary-action.test.tsx
+++ b/src/ui-actions/tests/conversation-primary-action.test.tsx
@@ -30,6 +30,7 @@ describe('Actions visibility', () => {
 		`(
 			`(case #$case) primary actions for a conversation in $folder.desc folder $assertion.desc the $action.desc action`,
 			async ({ folder, assertion, action }) => {
+				const createWindow = jest.fn();
 				const conv = generateConversation({
 					isSingleMessageConversation: false,
 					folderId: folder.id
@@ -42,7 +43,9 @@ describe('Actions visibility', () => {
 					item: conv,
 					dispatch,
 					deselectAll,
-					tags: {}
+					tags: {},
+					createWindow,
+					messageActions: []
 				});
 				expect(existsActionById({ id: action.id, actions })).toBe(assertion.value);
 			}
@@ -81,6 +84,7 @@ describe('Actions visibility', () => {
 		`(
 			`(case #$case) primary actions for a $read.desc conversation in $folder.desc folder $assertion.desc the $action.desc action`,
 			async ({ folder, read, assertion, action }) => {
+				const createWindow = jest.fn();
 				const conv = generateConversation({
 					isSingleMessageConversation: false,
 					folderId: folder.id,
@@ -93,7 +97,9 @@ describe('Actions visibility', () => {
 					item: conv,
 					dispatch,
 					deselectAll,
-					tags: {}
+					tags: {},
+					createWindow,
+					messageActions: []
 				});
 				expect(existsActionById({ id: action.id, actions })).toBe(assertion.value);
 			}
@@ -132,6 +138,7 @@ describe('Actions visibility', () => {
 		`(
 			`(case #$case) primary actions for a $flagged.desc conversation in $folder.desc folder $assertion.desc the $action.desc action`,
 			async ({ folder, flagged, assertion, action }) => {
+				const createWindow = jest.fn();
 				const conv = generateConversation({
 					isSingleMessageConversation: false,
 					folderId: folder.id,
@@ -144,7 +151,9 @@ describe('Actions visibility', () => {
 					item: conv,
 					dispatch,
 					deselectAll,
-					tags: {}
+					tags: {},
+					createWindow,
+					messageActions: []
 				});
 				expect(existsActionById({ id: action.id, actions })).toBe(assertion.value);
 			}

--- a/src/ui-actions/tests/conversation-secondary-action.test.tsx
+++ b/src/ui-actions/tests/conversation-secondary-action.test.tsx
@@ -29,13 +29,19 @@ describe('Actions visibility', () => {
 			${4} | ${FOLDERIDS.DRAFTS}       | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.MOVE_TO_TRASH}
 			${4} | ${FOLDERIDS.SPAM}         | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.MOVE_TO_TRASH}
 			${4} | ${FOLDERIDS.USER_DEFINED} | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.MOVE_TO_TRASH}
-			${4} | ${FOLDERIDS.INBOX}        | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
-			${4} | ${FOLDERIDS.SENT}         | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
-			${4} | ${FOLDERIDS.SPAM}         | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
-			${4} | ${FOLDERIDS.USER_DEFINED} | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
+			${5} | ${FOLDERIDS.INBOX}        | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
+			${5} | ${FOLDERIDS.SENT}         | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
+			${5} | ${FOLDERIDS.SPAM}         | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
+			${5} | ${FOLDERIDS.USER_DEFINED} | ${ASSERTION.CONTAIN} | ${MessageActionsDescriptors.SHOW_SOURCE}
+			${6} | ${FOLDERIDS.INBOX}        | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+			${6} | ${FOLDERIDS.SENT}         | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+			${6} | ${FOLDERIDS.DRAFTS}       | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+			${6} | ${FOLDERIDS.SPAM}         | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+			${6} | ${FOLDERIDS.USER_DEFINED} | ${ASSERTION.CONTAIN} | ${ConversationActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
 		`(
 			`(case #$case) secondary actions for a conversation in $folder.desc folder $assertion.desc the $action.desc action`,
 			async ({ folder, assertion, action }) => {
+				const createWindow = jest.fn();
 				const conv = generateConversation({
 					isSingleMessageConversation: false,
 					folderId: folder.id
@@ -47,7 +53,9 @@ describe('Actions visibility', () => {
 					item: conv,
 					dispatch,
 					deselectAll,
-					tags: {}
+					tags: {},
+					createWindow,
+					messageActions: []
 				});
 				expect(existsActionById({ id: action.id, actions, type: 'secondary' })).toBe(
 					assertion.value
@@ -69,6 +77,7 @@ describe('Actions visibility', () => {
 		`(
 			`(case #$case) secondary actions for a conversation in $folder.desc folder $assertion.desc the $action.desc action`,
 			async ({ folder, assertion, action }) => {
+				const createWindow = jest.fn();
 				const conv = generateMessage({
 					folderId: folder.id
 				});
@@ -79,7 +88,9 @@ describe('Actions visibility', () => {
 					item: conv,
 					dispatch,
 					deselectAll,
-					tags: {}
+					tags: {},
+					createWindow,
+					messageActions: []
 				});
 				expect(existsActionById({ id: action.id, actions, type: 'secondary' })).toBe(
 					assertion.value
@@ -120,6 +131,7 @@ describe('Actions visibility', () => {
 		`(
 			`(case #$case) secondary actions for a $read.desc conversation in $folder.desc folder $assertion.desc the $action.desc action`,
 			async ({ folder, read, assertion, action }) => {
+				const createWindow = jest.fn();
 				const conv = generateConversation({
 					isSingleMessageConversation: false,
 					folderId: folder.id,
@@ -132,7 +144,9 @@ describe('Actions visibility', () => {
 					item: conv,
 					dispatch,
 					deselectAll,
-					tags: {}
+					tags: {},
+					createWindow,
+					messageActions: []
 				});
 				expect(existsActionById({ id: action.id, actions, type: 'secondary' })).toBe(
 					assertion.value
@@ -173,6 +187,7 @@ describe('Actions visibility', () => {
 		`(
 			`(case #$case) secondary actions for a $flagged.desc conversation in $folder.desc folder $assertion.desc the $action.desc action`,
 			async ({ folder, flagged, assertion, action }) => {
+				const createWindow = jest.fn();
 				const conv = generateConversation({
 					isSingleMessageConversation: false,
 					folderId: folder.id,
@@ -185,7 +200,9 @@ describe('Actions visibility', () => {
 					item: conv,
 					dispatch,
 					deselectAll,
-					tags: {}
+					tags: {},
+					createWindow,
+					messageActions: []
 				});
 				expect(existsActionById({ id: action.id, actions, type: 'secondary' })).toBe(
 					assertion.value

--- a/src/ui-actions/tests/message-primary-action.test.tsx
+++ b/src/ui-actions/tests/message-primary-action.test.tsx
@@ -88,6 +88,7 @@ describe('Primary actions visibility', () => {
 	`(
 		`(case #$case) primary actions for a message in $folder.desc folder $assertion.desc the $action.desc action`,
 		async ({ folder, assertion, action }) => {
+			const createWindow = jest.fn();
 			const msg = generateMessage({ folderId: folder.id });
 			const dispatch = jest.fn();
 			const deselectAll = jest.fn();
@@ -96,7 +97,9 @@ describe('Primary actions visibility', () => {
 				item: msg,
 				dispatch,
 				deselectAll,
-				tags: {}
+				tags: {},
+				createWindow,
+				messageActions: []
 			});
 			expect(existsActionById({ id: action.id, actions: primaryActions })).toBe(assertion.value);
 		}
@@ -133,6 +136,7 @@ describe('Primary actions visibility', () => {
 	`(
 		`(case #$case) primary actions for a $read.desc message in $folder.desc folder $assertion.desc the $action.desc action`,
 		async ({ folder, read, assertion, action }) => {
+			const createWindow = jest.fn();
 			const msg = generateMessage({ folderId: folder.id, isRead: read.value });
 			const dispatch = jest.fn();
 			const deselectAll = jest.fn();
@@ -141,7 +145,9 @@ describe('Primary actions visibility', () => {
 				item: msg,
 				dispatch,
 				deselectAll,
-				tags: {}
+				tags: {},
+				createWindow,
+				messageActions: []
 			});
 			expect(existsActionById({ id: action.id, actions: primaryActions })).toBe(assertion.value);
 		}
@@ -180,6 +186,7 @@ describe('Primary actions visibility', () => {
 	`(
 		`(case #$case) primary actions for a $flagged.desc message in $folder.desc folder $assertion.desc the $action.desc action`,
 		async ({ folder, flagged, assertion, action }) => {
+			const createWindow = jest.fn();
 			const msg = generateMessage({ folderId: folder.id, isFlagged: flagged.value });
 			const dispatch = jest.fn();
 			const deselectAll = jest.fn();
@@ -188,7 +195,9 @@ describe('Primary actions visibility', () => {
 				item: msg,
 				dispatch,
 				deselectAll,
-				tags: {}
+				tags: {},
+				createWindow,
+				messageActions: []
 			});
 			expect(existsActionById({ id: action.id, actions: primaryActions })).toBe(assertion.value);
 		}

--- a/src/ui-actions/tests/message-secondary-action.test.tsx
+++ b/src/ui-actions/tests/message-secondary-action.test.tsx
@@ -134,9 +134,16 @@ describe('Secondary actions visibility', () => {
 		${20} | ${FOLDERS.TRASH}        | ${ASSERTION.NOT_CONTAIN} | ${MessageActionsDescriptors.MOVE}
 		${20} | ${FOLDERS.SPAM}         | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.MOVE}
 		${20} | ${FOLDERS.USER_DEFINED} | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.MOVE}
+		${21} | ${FOLDERS.INBOX}        | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+		${21} | ${FOLDERS.SENT}         | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+		${21} | ${FOLDERS.DRAFTS}       | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+		${21} | ${FOLDERS.TRASH}        | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+		${21} | ${FOLDERS.SPAM}         | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
+		${21} | ${FOLDERS.USER_DEFINED} | ${ASSERTION.CONTAIN}     | ${MessageActionsDescriptors.PREVIEW_ON_SEPARATED_WINDOW}
 	`(
 		`(case #$case) secondary actions for a message in $folder.desc folder $assertion.desc the $action.desc action`,
 		async ({ folder, assertion, action }) => {
+			const createWindow = jest.fn();
 			const msg = generateMessage({ folderId: folder.id });
 			const dispatch = jest.fn();
 			const deselectAll = jest.fn();
@@ -145,7 +152,9 @@ describe('Secondary actions visibility', () => {
 				item: msg,
 				dispatch,
 				deselectAll,
-				tags
+				tags,
+				createWindow,
+				messageActions: []
 			});
 			expect(
 				existsActionById({ id: action.id, actions: secondaryActions, type: 'secondary' })
@@ -186,6 +195,7 @@ describe('Secondary actions visibility', () => {
 	`(
 		`(case #$case) secondary actions for a $read.desc message in $folder.desc folder $assertion.desc the $action.desc action`,
 		async ({ folder, read, assertion, action }) => {
+			const createWindow = jest.fn();
 			const msg = generateMessage({ folderId: folder.id, isRead: read.value });
 			const dispatch = jest.fn();
 			const deselectAll = jest.fn();
@@ -194,7 +204,9 @@ describe('Secondary actions visibility', () => {
 				item: msg,
 				dispatch,
 				deselectAll,
-				tags: {}
+				tags: {},
+				createWindow,
+				messageActions: []
 			});
 			expect(
 				existsActionById({ id: action.id, actions: secondaryActions, type: 'secondary' })
@@ -235,6 +247,7 @@ describe('Secondary actions visibility', () => {
 	`(
 		`(case #$case) secondary actions for a $flagged.desc message in $folder.desc folder $assertion.desc the $action.desc action`,
 		async ({ folder, flagged, assertion, action }) => {
+			const createWindow = jest.fn();
 			const msg = generateMessage({ folderId: folder.id, isFlagged: flagged.value });
 			const dispatch = jest.fn();
 			const deselectAll = jest.fn();
@@ -243,7 +256,9 @@ describe('Secondary actions visibility', () => {
 				item: msg,
 				dispatch,
 				deselectAll,
-				tags: {}
+				tags: {},
+				createWindow,
+				messageActions: []
 			});
 			expect(
 				existsActionById({ id: action.id, actions: secondaryActions, type: 'secondary' })
@@ -265,6 +280,7 @@ describe('Secondary actions visibility', () => {
 	`(
 		`(case #$case) secondary actions for a message in $folder.desc folder $assertion.desc the $action.desc action`,
 		async ({ folder, assertion, action }) => {
+			const createWindow = jest.fn();
 			const msg = generateMessage({ folderId: folder.id });
 			const dispatch = jest.fn();
 			const deselectAll = jest.fn();
@@ -273,7 +289,9 @@ describe('Secondary actions visibility', () => {
 				item: msg,
 				dispatch,
 				deselectAll,
-				tags
+				tags,
+				createWindow,
+				messageActions: []
 			});
 			expect(existsActionById({ id: action, actions: secondaryActions, type: 'secondary' })).toBe(
 				assertion.value

--- a/src/ui-actions/tests/utils.test.ts
+++ b/src/ui-actions/tests/utils.test.ts
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { MessageAction } from '../../types';
+import { findMessageActionById } from '../utils';
+
+describe('findMessageActionById', () => {
+	test('returns undefined if an empty actions array is passed', () => {
+		expect(findMessageActionById([], '42')).toBeUndefined();
+	});
+
+	test('returns undefined if no action has the given name', () => {
+		const actions: Array<MessageAction> = [
+			{
+				id: 'dummy-action-1',
+				icon: 'gear',
+				label: 'dummy action 1',
+				onClick: jest.fn()
+			},
+			{
+				id: 'dummy-action-2',
+				icon: 'gear',
+				label: 'dummy action 2',
+				onClick: jest.fn()
+			}
+		];
+		expect(findMessageActionById(actions, '42')).toBeUndefined();
+	});
+
+	test('returns the action that has the given name', () => {
+		const action1 = {
+			id: 'dummy-action-1',
+			icon: 'gear',
+			label: 'dummy action 1',
+			onClick: jest.fn()
+		};
+
+		const action2 = {
+			id: 'dummy-action-2',
+			icon: 'gear',
+			label: 'dummy action 2',
+			onClick: jest.fn()
+		};
+
+		const action3 = {
+			id: 'dummy-action-3',
+			icon: 'gear',
+			label: 'dummy action 3',
+			onClick: jest.fn()
+		};
+
+		const actions: Array<MessageAction> = [action1, action2, action3];
+		expect(findMessageActionById(actions, 'dummy-action-2')).toBe(action2);
+	});
+
+	test('returns the first action if multiple actions have the same given name', () => {
+		const action1 = {
+			id: 'dummy-action-1',
+			icon: 'gear',
+			label: 'dummy action 1',
+			onClick: jest.fn()
+		};
+
+		const action2 = {
+			id: 'dummy-action-2',
+			icon: 'gear',
+			label: 'dummy action 2',
+			onClick: jest.fn()
+		};
+
+		const action3 = {
+			id: 'dummy-action-3',
+			icon: 'gear',
+			label: 'dummy action 3',
+			onClick: jest.fn()
+		};
+
+		const action4 = {
+			id: 'dummy-action-2',
+			icon: 'gear',
+			label: 'dummy action 2',
+			onClick: jest.fn()
+		};
+
+		const action5 = {
+			id: 'dummy-action-4',
+			icon: 'gear',
+			label: 'dummy action 4',
+			onClick: jest.fn()
+		};
+
+		const actions: Array<MessageAction> = [action1, action2, action3, action4, action5];
+		expect(findMessageActionById(actions, 'dummy-action-2')).toBe(action2);
+		expect(findMessageActionById(actions, 'dummy-action-4')).not.toBe(action2);
+	});
+});

--- a/src/views/app/detail-panel.tsx
+++ b/src/views/app/detail-panel.tsx
@@ -10,7 +10,7 @@ import { useAppContext } from '@zextras/carbonio-shell-ui';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
 
 import { ConversationPreviewPanel } from './detail-panel/conversation-preview-panel';
-import { MessagePreviewPanel } from './detail-panel/message-preview-panel';
+import { MessagePreviewPanelContainer } from './detail-panel/message-preview-panel-container';
 import { SelectionInteractive } from './detail-panel/selection-interactive';
 import type { AppContext } from '../../types';
 
@@ -27,7 +27,7 @@ const DetailPanel: FC = () => {
 					<ConversationPreviewPanel />
 				</Route>
 				<Route exact path={`${path}/folder/:folderId/message/:messageId`}>
-					<MessagePreviewPanel />
+					<MessagePreviewPanelContainer />
 				</Route>
 			</Switch>
 		</Container>

--- a/src/views/app/detail-panel/conversation-message-preview.tsx
+++ b/src/views/app/detail-panel/conversation-message-preview.tsx
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { FC } from 'react';
+
+import { Padding } from '@zextras/carbonio-design-system';
+
+import MailPreview from './preview/mail-preview';
+import { useMessageActions } from '../../../hooks/use-message-actions';
+import { MailMessage } from '../../../types';
+import { useExtraWindow } from '../extra-windows/use-extra-window';
+
+export type ConversationMessagePreviewProps = {
+	message: MailMessage;
+	idPrefix: string;
+	isExpanded: boolean;
+	isAlone: boolean;
+};
+
+export const ConversationMessagePreview: FC<ConversationMessagePreviewProps> = ({
+	idPrefix,
+	message,
+	isExpanded,
+	isAlone
+}) => {
+	const { isInsideExtraWindow } = useExtraWindow();
+	const messageActions = useMessageActions(message, isAlone);
+	return (
+		<Padding key={`${idPrefix}-${message.id}`} bottom="medium" width="100%">
+			<MailPreview
+				message={message}
+				expanded={isExpanded}
+				isAlone={isAlone}
+				messageActions={messageActions}
+				isMessageView={false}
+				isInsideExtraWindow={isInsideExtraWindow}
+			/>
+		</Padding>
+	);
+};

--- a/src/views/app/detail-panel/message-preview-panel-container.tsx
+++ b/src/views/app/detail-panel/message-preview-panel-container.tsx
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { FC } from 'react';
+
+import { useParams } from 'react-router-dom';
+
+import { MessagePreviewPanel } from './message-preview-panel';
+import { useAppSelector } from '../../../hooks/redux';
+import { useMessageActions } from '../../../hooks/use-message-actions';
+import { selectMessage } from '../../../store/messages-slice';
+import { MailsStateType } from '../../../types';
+
+export const MessagePreviewPanelContainer: FC = () => {
+	const { folderId, messageId } = useParams<{ folderId: string; messageId: string }>();
+	const message = useAppSelector((state: MailsStateType) => selectMessage(state, messageId));
+	const messageActions = useMessageActions(message, true);
+	return (
+		<MessagePreviewPanel
+			folderId={folderId}
+			messageId={messageId}
+			messageActions={messageActions}
+		/>
+	);
+};

--- a/src/views/app/detail-panel/message-preview-panel.tsx
+++ b/src/views/app/detail-panel/message-preview-panel.tsx
@@ -6,17 +6,27 @@
 import React, { FC, useEffect } from 'react';
 
 import { Container, Padding } from '@zextras/carbonio-design-system';
-import { useParams } from 'react-router-dom';
 
 import MailPreview from './preview/mail-preview';
 import PreviewPanelHeader from './preview/preview-panel-header';
 import { useAppDispatch, useAppSelector } from '../../../hooks/redux';
 import { getMsg } from '../../../store/actions';
 import { selectMessage } from '../../../store/messages-slice';
-import type { MailsStateType } from '../../../types';
+import type { MailsStateType, MessageAction } from '../../../types';
+import { useExtraWindow } from '../extra-windows/use-extra-window';
 
-export const MessagePreviewPanel: FC = () => {
-	const { folderId, messageId } = useParams<{ folderId: string; messageId: string }>();
+export type MessagePreviewPanelProps = {
+	folderId: string;
+	messageId: string;
+	messageActions: Array<MessageAction>;
+};
+
+export const MessagePreviewPanel: FC<MessagePreviewPanelProps> = ({
+	folderId,
+	messageId,
+	messageActions
+}) => {
+	const { isInsideExtraWindow } = useExtraWindow();
 	const dispatch = useAppDispatch();
 
 	const message = useAppSelector((state: MailsStateType) => selectMessage(state, messageId));
@@ -31,9 +41,7 @@ export const MessagePreviewPanel: FC = () => {
 		<Container orientation="vertical" mainAlignment="flex-start" crossAlignment="flex-start">
 			{message && (
 				<>
-					<PreviewPanelHeader item={message} folderId={folderId} />
-					{/* commented to hide the panel actions */}
-					{/* <PreviewPanelActions item={message} folderId={folderId} isMessageView /> */}
+					{!isInsideExtraWindow && <PreviewPanelHeader item={message} folderId={folderId} />}
 					<Container
 						style={{ overflowY: 'auto' }}
 						height="fill"
@@ -43,9 +51,15 @@ export const MessagePreviewPanel: FC = () => {
 					>
 						<Container height="fit" mainAlignment="flex-start" background="gray5">
 							<Padding bottom="medium" width="100%">
-								{/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-								{/* @ts-ignore */}
-								<MailPreview message={message} expanded isAlone isMessageView />
+								eslint-disable-next-line @typescript-eslint/ban-ts-comment @ts-ignore
+								<MailPreview
+									message={message}
+									expanded
+									isAlone
+									messageActions={messageActions}
+									isMessageView
+									isInsideExtraWindow={isInsideExtraWindow}
+								/>
 							</Padding>
 						</Container>
 					</Container>

--- a/src/views/app/detail-panel/preview/parts/preview-header.tsx
+++ b/src/views/app/detail-panel/preview/parts/preview-header.tsx
@@ -59,9 +59,8 @@ import OnBehalfOfDisplayer from './on-behalf-of-displayer';
 import { ParticipantRole } from '../../../../../carbonio-ui-commons/constants/participants';
 import { getTimeLabel, participantToString } from '../../../../../commons/utils';
 import { getNoIdentityPlaceholder } from '../../../../../helpers/identities';
-import { useMessageActions } from '../../../../../hooks/use-message-actions';
 import { retrieveAttachmentsType } from '../../../../../store/editor-slice-utils';
-import type { MailMessage } from '../../../../../types';
+import type { MailMessage, MessageAction } from '../../../../../types';
 import MailMsgPreviewActions from '../../../../../ui-actions/mail-message-preview-actions';
 import { useTagExist } from '../../../../../ui-actions/tag-actions';
 
@@ -85,9 +84,10 @@ type PreviewHeaderProps = {
 		message: MailMessage;
 		onClick: (e: SyntheticEvent) => void;
 		open: boolean;
-		isAlone: boolean;
 		isExternalMessage?: boolean;
+		isInsideExtraWindow?: boolean;
 	};
+	actions: MessageAction[];
 };
 
 const fallbackContact = {
@@ -97,15 +97,14 @@ const fallbackContact = {
 	fullName: ''
 };
 
-const PreviewHeader: FC<PreviewHeaderProps> = ({ compProps }): ReactElement => {
-	const { message, onClick, open, isAlone, isExternalMessage } = compProps;
+const PreviewHeader: FC<PreviewHeaderProps> = ({ compProps }, actions): ReactElement => {
+	const { message, onClick, open, isExternalMessage } = compProps;
 
 	const textRef = useRef<HTMLInputElement>(null);
 	const accounts = useUserAccounts();
 
 	const [_minWidth, _setMinWidth] = useState('');
 	const [isContactListExpand, setIsContactListExpand] = useState(false);
-	const actions = useMessageActions(message, isAlone);
 	const mainContact = find(message.participants, ['type', 'f']) || fallbackContact;
 	const _onClick = useCallback((e) => !e.isDefaultPrevented() && onClick(e), [onClick]);
 	const attachments = retrieveAttachmentsType(message, 'attachment');

--- a/src/views/app/detail-panel/preview/tests/mail-preview.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/mail-preview.test.tsx
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { screen } from '@testing-library/react';
 import React from 'react';
+
+import { screen } from '@testing-library/react';
+
 import { setupTest } from '../../../../../carbonio-ui-commons/test/test-setup';
 import { getMsg } from '../../../../../store/actions';
 import { selectMessage } from '../../../../../store/messages-slice';
 import { generateStore } from '../../../../../tests/generators/store';
-import MailPreview from '../mail-preview';
+import MailPreview, { MailPreviewProps } from '../mail-preview';
 
 /**
  * Test the Mail Preview component in different scenarios
@@ -29,11 +31,12 @@ describe('Mail preview', () => {
 		await store.dispatch<any>(getMsg({ msgId }));
 		const state = store.getState();
 		const message = selectMessage(state, msgId);
-		const props = {
+		const props: MailPreviewProps = {
 			message,
 			expanded: true,
 			isAlone: true,
-			isMessageView: true
+			isMessageView: true,
+			messageActions: []
 		};
 
 		// Render the component

--- a/src/views/app/folder-panel/conversations/conversation-list-item.tsx
+++ b/src/views/app/folder-panel/conversations/conversation-list-item.tsx
@@ -119,10 +119,6 @@ export const ConversationListItem: FC<ConversationListItemProps> = memo(
 			[item.tags, tagsFromStore]
 		);
 
-		const showTrashedMessagesInSearch =
-			useUserSettings()?.prefs?.zimbraPrefIncludeTrashInSearch === 'TRUE';
-		const showSpamMessagesInSearch =
-			useUserSettings()?.prefs?.zimbraPrefIncludeSpamInSearch === 'TRUE';
 		const sortBy = useUserSettings()?.prefs?.zimbraPrefConversationOrder || 'dateDesc';
 		const zimbraPrefMarkMsgRead = useUserSettings()?.prefs?.zimbraPrefMarkMsgRead !== '-1';
 		const participantsString = useMemo(
@@ -134,26 +130,6 @@ export const ConversationListItem: FC<ConversationListItemProps> = memo(
 				),
 			[item.participants, accounts]
 		);
-
-		// const openDisplayerOnSeparatedWindow = useCallback(
-		// 	(conversationId: string, folderId: string, subject?: string): void => {
-		// 		if (!createWindow) {
-		// 			return;
-		// 		}
-		//
-		// 		const createWindowParams: ExtraWindowCreationParams = {
-		// 			name: `conversation-${conversationId}`,
-		// 			returnComponent: false,
-		// 			children: (
-		// 				<ConversationPreviewPanel conversationId={conversationId} folderId={folderId} />
-		// 			),
-		// 			title: subject,
-		// 			closeOnUnmount: false
-		// 		};
-		// 		createWindow(createWindowParams);
-		// 	},
-		// 	[createWindow]
-		// );
 
 		const toggleOpen = useCallback(
 			(e) => {

--- a/src/views/app/folder-panel/messages/message-list-item.tsx
+++ b/src/views/app/folder-panel/messages/message-list-item.tsx
@@ -31,10 +31,15 @@ import { useFolder } from '../../../../carbonio-ui-commons/store/zustand/folder/
 import { getTimeLabel, participantToString } from '../../../../commons/utils';
 import { EditViewActions, MAILS_ROUTE } from '../../../../constants';
 import { useAppDispatch } from '../../../../hooks/redux';
+import { useMessageActions } from '../../../../hooks/use-message-actions';
 import type { BoardContext, MessageListItemProps, TextReadValuesType } from '../../../../types';
-import { setMsgRead } from '../../../../ui-actions/message-actions';
+import {
+	previewMessageOnSeparatedWindow,
+	setMsgRead
+} from '../../../../ui-actions/message-actions';
 import { useTagExist } from '../../../../ui-actions/tag-actions';
 import { getFolderTranslatedName } from '../../../sidebar/utils';
+import { useExtraWindowsManager } from '../../extra-windows/extra-window-manager';
 import { ItemAvatar } from '../parts/item-avatar';
 import { ListItemActionWrapper } from '../parts/list-item-actions-wrapper';
 import { SenderName } from '../parts/sender-name';
@@ -54,6 +59,8 @@ export const MessageListItem: FC<MessageListItemProps> = memo(function MessageLi
 
 	const dispatch = useAppDispatch();
 	const zimbraPrefMarkMsgRead = useUserSettings()?.prefs?.zimbraPrefMarkMsgRead !== '-1';
+	const { createWindow } = useExtraWindowsManager();
+	const messageActions = useMessageActions(item, true);
 
 	const onClick = useCallback(
 		(e) => {
@@ -75,10 +82,18 @@ export const MessageListItem: FC<MessageListItemProps> = memo(function MessageLi
 						url: `${MAILS_ROUTE}/edit?action=${EditViewActions.EDIT_AS_DRAFT}&id=${id}`,
 						title: ''
 					});
+				} else {
+					previewMessageOnSeparatedWindow(
+						id,
+						firstChildFolderId,
+						item.subject,
+						createWindow,
+						messageActions
+					).onClick({});
 				}
 			}
 		},
-		[item]
+		[createWindow, firstChildFolderId, item, messageActions]
 	);
 
 	const accounts = useUserAccounts();

--- a/src/views/app/folder-panel/parts/list-item-actions-wrapper.tsx
+++ b/src/views/app/folder-panel/parts/list-item-actions-wrapper.tsx
@@ -9,7 +9,9 @@ import { Container, Dropdown, IconButton, Tooltip } from '@zextras/carbonio-desi
 import { useTags } from '@zextras/carbonio-shell-ui';
 import styled, { DefaultTheme } from 'styled-components';
 
+import { isConversation } from '../../../../helpers/messages';
 import { useAppDispatch } from '../../../../hooks/redux';
+import { useMessageActions } from '../../../../hooks/use-message-actions';
 import type {
 	ConvActionReturnType,
 	Conversation,
@@ -19,6 +21,7 @@ import type {
 	TagActionItemType
 } from '../../../../types';
 import { getMsgConvActions } from '../../../../ui-actions/get-msg-conv-actions';
+import { useExtraWindowsManager } from '../../extra-windows/extra-window-manager';
 
 const HoverBarContainer = styled(Container)<{ background: keyof DefaultTheme['palette'] }>`
 	top: 0;
@@ -89,12 +92,16 @@ export const ListItemActionWrapper: FC<ListItemActionWrapperProps> = ({
 }) => {
 	const dispatch = useAppDispatch();
 	const tags = useTags();
+	const { createWindow } = useExtraWindowsManager();
+	const messageActions = useMessageActions(isConversation(item) ? undefined : item, true);
 
 	const [hoverActions, dropdownActions] = getMsgConvActions({
 		item,
 		dispatch,
 		deselectAll,
-		tags
+		tags,
+		createWindow,
+		messageActions
 	});
 
 	const dropdownActionsItems = dropdownActions.map((action) => ({

--- a/src/views/search/search-panel.tsx
+++ b/src/views/search/search-panel.tsx
@@ -12,7 +12,7 @@ import { useRouteMatch, Switch, Route } from 'react-router-dom';
 import { EmptyFieldMessages, EmptyListMessages } from './utils';
 import type { SearchPanelProps } from '../../types';
 import { ConversationPreviewPanel } from '../app/detail-panel/conversation-preview-panel';
-import { MessagePreviewPanel } from '../app/detail-panel/message-preview-panel';
+import { MessagePreviewPanelContainer } from '../app/detail-panel/message-preview-panel-container';
 
 const generateRandomNumber = (): number => Math.floor(Math.random() * 3);
 
@@ -43,7 +43,7 @@ const SearchPanel: FC<SearchPanelProps> = ({ searchResults, query }) => {
 				<ConversationPreviewPanel />
 			</Route>
 			<Route path={`${path}/folder/:folderId/message/:messageId`}>
-				<MessagePreviewPanel />
+				<MessagePreviewPanelContainer />
 			</Route>
 			<Route
 				path={path}

--- a/translations/en.json
+++ b/translations/en.json
@@ -18,6 +18,7 @@
         "ok": "Ok",
         "preview": "Preview",
         "preview_new_tab": "Click to preview in another tab",
+        "preview_on_separated_window": "Open on a new window",
         "print": "Print",
         "redirect": "Redirect",
         "reply": "Reply",


### PR DESCRIPTION
The main goal of this PR is the feature that makes possible to open a message or a conversation in a new browser tab.
This implementation involves primarily the message/conversation actions, the message/conversation list item, the displayer and related tests.
Beside that many files were modified in order to resolve a dependency cycle between the actions and the displayer, involving a bunch of components between them.

The feature is released as an hotfix because the RC are already released: the dependency cycle resolution caused a delay

refs: IRIS-3757