### PR TITLE
fix: block ascending/descending for options not supported by the be

### DIFF
--- a/src/store/actions/search.ts
+++ b/src/store/actions/search.ts
@@ -42,8 +42,42 @@ export const search = createAsyncThunk<
 		{ rejectWithValue }
 	) => {
 		const queryPart = [`inId:"${folderId}"`];
+		let finalsortBy = sortBy;
 		if (before) queryPart.push(`before:${before.getTime()}`);
-		if (sortBy === 'readAsc') queryPart.push('is:unread');
+		// if (sortBy === 'readAsc') queryPart.push('is:unread');
+		switch (sortBy) {
+			case 'readAsc':
+				queryPart.push('is:unread');
+				finalsortBy = 'dateAsc';
+				break;
+			case 'readDesc':
+				queryPart.push('is:unread');
+				finalsortBy = 'dateDesc';
+				break;
+			case 'priorityAsc':
+			case 'priorityDesc':
+				queryPart.push('priority:high');
+				break;
+			case 'flagAsc':
+			case 'flagDesc':
+				queryPart.push('is:flagged');
+				break;
+			case 'attachAsc':
+			case 'attachDesc':
+				queryPart.push('has:attachment');
+				break;
+			default:
+				break;
+		}
+
+		let finalQuery = '';
+
+		if (folderId) {
+			finalQuery = queryPart.join(' ');
+		}
+		if (!folderId && query) {
+			finalQuery = query;
+		}
 
 		try {
 			const result = await soapFetch<SearchRequest, SearchResponse | ErrorSoapBodyResponse>(
@@ -55,8 +89,8 @@ export const search = createAsyncThunk<
 					recip,
 					fullConversation: 1,
 					wantContent,
-					sortBy,
-					query: query || queryPart.join(' '),
+					sortBy: finalsortBy,
+					query: finalQuery,
 					offset,
 					types,
 					...(locale

--- a/src/store/actions/search.ts
+++ b/src/store/actions/search.ts
@@ -44,7 +44,6 @@ export const search = createAsyncThunk<
 		const queryPart = [`inId:"${folderId}"`];
 		let finalsortBy = sortBy;
 		if (before) queryPart.push(`before:${before.getTime()}`);
-		// if (sortBy === 'readAsc') queryPart.push('is:unread');
 		switch (sortBy) {
 			case 'readAsc':
 				queryPart.push('is:unread');

--- a/src/ui-actions/modals/tests/select-folder-modal.test.tsx
+++ b/src/ui-actions/modals/tests/select-folder-modal.test.tsx
@@ -16,7 +16,7 @@ import { Folder, RootFolder } from '../../../carbonio-ui-commons/types/folder';
 import { FOLDER_ACTIONS } from '../../../commons/utilities';
 import { folderAction } from '../../../store/actions/folder-action';
 import { generateStore } from '../../../tests/generators/store';
-import { FolderAction, FolderActionResponse } from '../../../types';
+import { FolderActionResponse, SoapFolderAction } from '../../../types';
 import { SelectFolderModal } from '../select-folder-modal';
 
 const folderToMove: Folder = {
@@ -192,7 +192,7 @@ test('API is called with the proper parameters to move the selected folder into 
 		name: /label\.move/i
 	});
 
-	const folderActionInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+	const folderActionInterceptor = createAPIInterceptor<SoapFolderAction>('FolderAction', 'action');
 	await user.click(actionButton);
 	const action = await folderActionInterceptor;
 	expect(action.id).toBe(folderToMove.id);

--- a/src/views/sidebar/tests/delete-modal.test.tsx
+++ b/src/views/sidebar/tests/delete-modal.test.tsx
@@ -17,7 +17,7 @@ import { Folder, FolderView } from '../../../carbonio-ui-commons/types/folder';
 import { FOLDER_ACTIONS } from '../../../commons/utilities';
 import { getFolders } from '../../../hooks/use-folders';
 import { generateStore } from '../../../tests/generators/store';
-import { FolderAction } from '../../../types';
+import { SoapFolderAction } from '../../../types';
 import { DeleteModal } from '../delete-modal';
 
 describe('delete-modal', () => {
@@ -133,7 +133,7 @@ describe('delete-modal', () => {
 			name: /action\.ok/i
 		});
 		expect(okButton).toBeEnabled();
-		const wipeInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+		const wipeInterceptor = createAPIInterceptor<SoapFolderAction>('FolderAction', 'action');
 
 		await user.click(okButton);
 		const action = await wipeInterceptor;
@@ -158,7 +158,7 @@ describe('delete-modal', () => {
 			name: /action\.ok/i
 		});
 		expect(okButton).toBeEnabled();
-		const wipeInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+		const wipeInterceptor = createAPIInterceptor<SoapFolderAction>('FolderAction', 'action');
 
 		await user.click(okButton);
 		const action = await wipeInterceptor;
@@ -188,7 +188,7 @@ describe('delete-modal', () => {
 			name: /action\.ok/i
 		});
 		expect(okButton).toBeEnabled();
-		const wipeInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+		const wipeInterceptor = createAPIInterceptor<SoapFolderAction>('FolderAction', 'action');
 
 		await user.click(okButton);
 		const action = await wipeInterceptor;

--- a/src/views/sidebar/tests/edit-modal.test.tsx
+++ b/src/views/sidebar/tests/edit-modal.test.tsx
@@ -15,7 +15,7 @@ import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/st
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
 import { Folder, FolderView } from '../../../carbonio-ui-commons/types/folder';
 import { generateStore } from '../../../tests/generators/store';
-import { FolderAction } from '../../../types';
+import { SoapFolderAction } from '../../../types';
 import { EditModal } from '../edit-modal';
 
 describe('edit-modal', () => {
@@ -234,7 +234,7 @@ describe('edit-modal', () => {
 		const editButton = screen.getByRole('button', {
 			name: /label\.edit/i
 		});
-		const wipeInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+		const wipeInterceptor = createAPIInterceptor<SoapFolderAction>('FolderAction', 'action');
 
 		await user.click(editButton);
 		const action = await wipeInterceptor;
@@ -291,7 +291,7 @@ describe('edit-modal', () => {
 		const folderName = faker.lorem.word();
 		// update the existing folder name into the text input
 		await user.type(folderInputElement, folderName);
-		const wipeInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+		const wipeInterceptor = createAPIInterceptor<SoapFolderAction>('FolderAction', 'action');
 
 		await user.click(editButton);
 		const action = await wipeInterceptor;

--- a/src/views/sidebar/tests/empty-modal.test.tsx
+++ b/src/views/sidebar/tests/empty-modal.test.tsx
@@ -15,7 +15,7 @@ import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/st
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
 import { Folder } from '../../../carbonio-ui-commons/types/folder';
 import { generateStore } from '../../../tests/generators/store';
-import { FolderAction } from '../../../types';
+import { SoapFolderAction } from '../../../types';
 import { EmptyModal } from '../empty-modal';
 
 describe('empty-modal', () => {
@@ -121,7 +121,7 @@ describe('empty-modal', () => {
 		const wipeButton = screen.getByRole('button', {
 			name: /label\.empty/i
 		});
-		const wipeInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+		const wipeInterceptor = createAPIInterceptor<SoapFolderAction>('FolderAction', 'action');
 
 		await user.click(wipeButton);
 

--- a/src/views/sidebar/tests/mark-read.test.tsx
+++ b/src/views/sidebar/tests/mark-read.test.tsx
@@ -16,7 +16,7 @@ import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/st
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
 import { MAIL_APP_ID, MAILS_ROUTE } from '../../../constants';
 import { generateStore } from '../../../tests/generators/store';
-import { FolderAction } from '../../../types';
+import { SoapFolderAction } from '../../../types';
 import Sidebar from '../sidebar';
 
 describe('Mark all as read', () => {
@@ -45,7 +45,10 @@ describe('Mark all as read', () => {
 		const actionMenuItem = await screen.findByTestId(
 			`folder-action-${FolderActionsType.MARK_ALL_READ}`
 		);
-		const folderActionInterceptor = createAPIInterceptor<FolderAction>('FolderAction', 'action');
+		const folderActionInterceptor = createAPIInterceptor<SoapFolderAction>(
+			'FolderAction',
+			'action'
+		);
 
 		await user.click(actionMenuItem);
 


### PR DESCRIPTION
block ascending/descending for options not supported by the back-end