### PR TITLE
hotfix: Advanced search for Mails in Search Tab does not work

### DIFF
--- a/src/views/search/search-view.tsx
+++ b/src/views/search/search-view.tsx
@@ -5,6 +5,7 @@
  */
 import React, { FC, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { isRejected } from '@reduxjs/toolkit';
 import { Container, Spinner } from '@zextras/carbonio-design-system';
 import {
 	SEARCH_APP_ID,
@@ -117,17 +118,14 @@ const SearchView: FC<SearchViewProps> = ({ useDisableSearch, useQuery, ResultsHe
 					locale: prefLocale
 				})
 			);
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			if (searchByQuery.rejected.match(resultAction)) {
-				if (
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore
-					resultAction?.payload?.Detail?.Error?.Code === 'mail.QUERY_PARSE_ERROR'
-				) {
-					setIsInvalidQuery(true);
-					setSearchDisabled(true, invalidQueryTooltip);
-				}
+			if (
+				isRejected(resultAction) &&
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				resultAction?.payload?.Detail?.Error?.Code === 'mail.QUERY_PARSE_ERROR'
+			) {
+				setIsInvalidQuery(true);
+				setSearchDisabled(true, invalidQueryTooltip);
 			}
 		},
 		[
@@ -201,6 +199,7 @@ const SearchView: FC<SearchViewProps> = ({ useDisableSearch, useQuery, ResultsHe
 	useEffect(() => {
 		if (query?.length > 0 && !isInvalidQuery) {
 			setFilterCount(query.length);
+			searchQuery(queryToString, true);
 		}
 		if (query?.length === 0) {
 			setFilterCount(0);
@@ -211,11 +210,7 @@ const SearchView: FC<SearchViewProps> = ({ useDisableSearch, useQuery, ResultsHe
 				route: SEARCH_APP_ID
 			});
 		}
-	}, [dispatch, isInvalidQuery, query.length]);
-
-	useEffect(() => {
-		searchQuery(queryToString, true);
-	}, [queryToString, searchQuery]);
+	}, [dispatch, isInvalidQuery, query.length, queryToString, searchQuery]);
 
 	const { path } = useRouteMatch();
 	const resultLabelType = isInvalidQuery ? 'warning' : undefined;

--- a/src/views/search/test/search-view.test.tsx
+++ b/src/views/search/test/search-view.test.tsx
@@ -6,11 +6,12 @@
 import React, { ReactElement } from 'react';
 
 import { screen } from '@testing-library/react';
-import { QueryChip, SearchViewProps } from '@zextras/carbonio-shell-ui';
+import { ErrorSoapBodyResponse, QueryChip, SearchViewProps } from '@zextras/carbonio-shell-ui';
 import { noop } from 'lodash';
 
 import { createSoapAPIInterceptor } from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
+import * as searchByQuery from '../../../store/actions/searchByQuery';
 import { generateStore } from '../../../tests/generators/store';
 import { SearchRequest, SearchResponse } from '../../../types';
 import SearchView from '../search-view';
@@ -89,5 +90,52 @@ describe('SearchView', () => {
 		});
 		expect(advancedFiltersButton).toBeVisible();
 		expect(advancedFiltersButton).toBeDisabled();
+	});
+
+	it('should not call search API if query empty', async () => {
+		const store = generateStore();
+		const spySearchByQuery = jest.spyOn(searchByQuery, 'searchByQuery');
+		const resultsHeader = (props: { label: string }): ReactElement => <>{props.label}</>;
+		const searchViewProps: SearchViewProps = {
+			useQuery: () => [[], noop],
+			useDisableSearch: () => [false, noop],
+			ResultsHeader: resultsHeader
+		};
+
+		setupTest(<SearchView {...searchViewProps} />, {
+			store
+		});
+
+		const advancedFiltersButton = screen.getByRole('button', {
+			name: /label\.single_advanced_filter/i
+		});
+		expect(advancedFiltersButton).toBeVisible();
+		expect(advancedFiltersButton).toBeEnabled();
+		expect(spySearchByQuery).not.toBeCalled();
+	});
+
+	it('should call setSearchDisabled button if Search API fails with mail.QUERY_PARSE_ERROR', async () => {
+		const store = generateStore();
+		const interceptor = createSoapAPIInterceptor<SearchRequest, ErrorSoapBodyResponse>('Search', {
+			Fault: {
+				Reason: { Text: 'Failed to execute search' },
+				Detail: {
+					Error: { Code: 'mail.QUERY_PARSE_ERROR', Detail: 'Failed' }
+				}
+			}
+		});
+		const resultsHeader = (props: { label: string }): ReactElement => <>{props.label}</>;
+		const setSearchDisabled = jest.fn();
+		const searchViewProps: SearchViewProps = {
+			useQuery: () => [[], noop],
+			useDisableSearch: () => [false, setSearchDisabled],
+			ResultsHeader: resultsHeader
+		};
+
+		setupTest(<SearchView {...searchViewProps} />, {
+			store
+		});
+		await interceptor;
+		expect(setSearchDisabled).toBeCalled();
 	});
 });

--- a/src/views/search/test/search-view.test.tsx
+++ b/src/views/search/test/search-view.test.tsx
@@ -53,4 +53,41 @@ describe('SearchView', () => {
 
 		expect(await screen.findByText('label.results_for')).toBeInTheDocument();
 	});
+
+	it('should display a disabled Advanced Filters button when SearchDisabled is true', async () => {
+		const store = generateStore();
+		createSoapAPIInterceptor<SearchRequest, SearchResponse>('Search', {
+			c: [
+				{
+					id: '123',
+					n: 1,
+					u: 1,
+					f: 'flag',
+					tn: 'tag names',
+					d: 123,
+					m: [],
+					e: [],
+					su: 'Subject',
+					fr: 'fragment'
+				}
+			],
+			more: false
+		});
+		const resultsHeader = (props: { label: string }): ReactElement => <>{props.label}</>;
+		const searchViewProps: SearchViewProps = {
+			useQuery: () => [[], noop],
+			useDisableSearch: () => [true, noop],
+			ResultsHeader: resultsHeader
+		};
+
+		setupTest(<SearchView {...searchViewProps} />, {
+			store
+		});
+
+		const advancedFiltersButton = screen.getByRole('button', {
+			name: /label\.single_advanced_filter/i
+		});
+		expect(advancedFiltersButton).toBeVisible();
+		expect(advancedFiltersButton).toBeDisabled();
+	});
 });

--- a/src/views/search/test/search-view.test.tsx
+++ b/src/views/search/test/search-view.test.tsx
@@ -69,7 +69,6 @@ describe('SearchView', () => {
 		setupTest(<SearchView {...searchViewProps} />, {
 			store
 		});
-		screen.logTestingPlaygroundURL();
 		const advancedFiltersButton = screen.getByRole('button', {
 			name: /label\.single_advanced_filter/i
 		});


### PR DESCRIPTION
- Avoid making a Search request if query invalid

Ref: CO-1257