### PR TITLE
fix: message slice sorting feature is broken

### DIFF
--- a/src/store/messages-slice.ts
+++ b/src/store/messages-slice.ts
@@ -63,7 +63,7 @@ function fetchMessagesFulfilled(
 	if (payload?.messages && payload?.types === 'message') {
 		state.searchRequestStatus = meta.requestStatus;
 		const newMessagesState =
-			payload.offset !== undefined && payload.offset >= 0
+			payload.offset !== undefined && payload.offset > 0
 				? { ...state.messages, ...payload.messages }
 				: { ...payload.messages };
 		state.messages = newMessagesState;


### PR DESCRIPTION
Last 24.7 release broke sorting feature in message view ( works only with conversation view )