### PR TITLE
fix: [CO-1315] avoid API call loop in case folder request fails

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -12,12 +12,11 @@ import App from './app';
 import * as addComponentsToShell from './app-utils/add-shell-components';
 import * as registerShellActions from './app-utils/register-shell-actions';
 import * as registerShellIntegrations from './app-utils/register-shell-integrations';
-import * as toggleBackupSearch from './app-utils/toggle-backup-search-component';
-import * as useFoldersController from './carbonio-ui-commons/hooks/use-folders-controller';
+import * as useInitializeFolders from './carbonio-ui-commons/hooks/use-initialize-folders';
 import { setupTest } from './carbonio-ui-commons/test/test-setup';
+import { BACKUP_SEARCH_ROUTE } from './constants';
 import { useBackupSearchStore } from './store/zustand/backup-search/store';
 import { DeletedMessageFromAPI } from './types';
-import { BACKUP_SEARCH_ROUTE } from './constants';
 
 function aDeletedMessage(): DeletedMessageFromAPI {
 	return {
@@ -48,7 +47,7 @@ describe('App', () => {
 	});
 
 	it('should register a "mails" route accessible from the primary bar with specific position, name and icon', () => {
-		const useFoldersControllerSpy = jest.spyOn(useFoldersController, 'useFoldersController');
+		const useInitializeFoldersSpy = jest.spyOn(useInitializeFolders, 'useInitializeFolders');
 		const addComponentsToShellSpy = jest.spyOn(addComponentsToShell, 'addComponentsToShell');
 		const registerShellActionSpy = jest.spyOn(registerShellActions, 'registerShellActions');
 		const registerShellIntegrationsSpy = jest.spyOn(
@@ -59,7 +58,7 @@ describe('App', () => {
 		expect(addComponentsToShellSpy).toHaveBeenCalled();
 		expect(registerShellActionSpy).toHaveBeenCalled();
 		expect(registerShellIntegrationsSpy).toHaveBeenCalled();
-		expect(useFoldersControllerSpy).toHaveBeenCalledWith('message');
+		expect(useInitializeFoldersSpy).toHaveBeenCalledWith('message');
 	});
 
 	it('should add the backup search route when the backup search messages are present', () => {

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -12,7 +12,6 @@ import App from './app';
 import * as addComponentsToShell from './app-utils/add-shell-components';
 import * as registerShellActions from './app-utils/register-shell-actions';
 import * as registerShellIntegrations from './app-utils/register-shell-integrations';
-import * as useInitializeFolders from './carbonio-ui-commons/hooks/use-initialize-folders';
 import { setupTest } from './carbonio-ui-commons/test/test-setup';
 import { BACKUP_SEARCH_ROUTE } from './constants';
 import { useBackupSearchStore } from './store/zustand/backup-search/store';
@@ -47,7 +46,6 @@ describe('App', () => {
 	});
 
 	it('should register a "mails" route accessible from the primary bar with specific position, name and icon', () => {
-		const useInitializeFoldersSpy = jest.spyOn(useInitializeFolders, 'useInitializeFolders');
 		const addComponentsToShellSpy = jest.spyOn(addComponentsToShell, 'addComponentsToShell');
 		const registerShellActionSpy = jest.spyOn(registerShellActions, 'registerShellActions');
 		const registerShellIntegrationsSpy = jest.spyOn(
@@ -58,7 +56,6 @@ describe('App', () => {
 		expect(addComponentsToShellSpy).toHaveBeenCalled();
 		expect(registerShellActionSpy).toHaveBeenCalled();
 		expect(registerShellIntegrationsSpy).toHaveBeenCalled();
-		expect(useInitializeFoldersSpy).toHaveBeenCalledWith('message');
 	});
 
 	it('should add the backup search route when the backup search messages are present', () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,8 +12,6 @@ import { addComponentsToShell } from './app-utils/add-shell-components';
 import { registerShellActions } from './app-utils/register-shell-actions';
 import { registerShellIntegrations } from './app-utils/register-shell-integrations';
 import { toggleBackupSearchComponent } from './app-utils/toggle-backup-search-component';
-import { FOLDER_VIEW } from './carbonio-ui-commons/constants';
-import { useInitializeFolders } from './carbonio-ui-commons/hooks/use-initialize-folders';
 import { StoreProvider } from './store/redux';
 import { useBackupSearchStore } from './store/zustand/backup-search/store';
 import { GlobalExtraWindowManager } from './views/app/extra-windows/global-extra-window-manager';
@@ -32,8 +30,6 @@ const App = (): React.JSX.Element => {
 	useEffect(() => {
 		toggleBackupSearchComponent(hasBackupSearchMessages);
 	}, [hasBackupSearchMessages]);
-
-	useInitializeFolders(FOLDER_VIEW.message);
 
 	return (
 		<StoreProvider>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,7 +13,7 @@ import { registerShellActions } from './app-utils/register-shell-actions';
 import { registerShellIntegrations } from './app-utils/register-shell-integrations';
 import { toggleBackupSearchComponent } from './app-utils/toggle-backup-search-component';
 import { FOLDER_VIEW } from './carbonio-ui-commons/constants';
-import { useFoldersController } from './carbonio-ui-commons/hooks/use-folders-controller';
+import { useInitializeFolders } from './carbonio-ui-commons/hooks/use-initialize-folders';
 import { StoreProvider } from './store/redux';
 import { useBackupSearchStore } from './store/zustand/backup-search/store';
 import { GlobalExtraWindowManager } from './views/app/extra-windows/global-extra-window-manager';
@@ -33,7 +33,7 @@ const App = (): React.JSX.Element => {
 		toggleBackupSearchComponent(hasBackupSearchMessages);
 	}, [hasBackupSearchMessages]);
 
-	useFoldersController(FOLDER_VIEW.message);
+	useInitializeFolders(FOLDER_VIEW.message);
 
 	return (
 		<StoreProvider>

--- a/src/views/sidebar/commons/sync-data-handler-hooks.ts
+++ b/src/views/sidebar/commons/sync-data-handler-hooks.ts
@@ -5,8 +5,9 @@
  */
 import { useEffect, useState } from 'react';
 
-import { getTags, useNotify, useRefresh } from '@zextras/carbonio-shell-ui';
+import { getTags, SoapNotify, useNotify, useRefresh } from '@zextras/carbonio-shell-ui';
 import { filter, find, forEach, isEmpty, keyBy, map, reduce, sortBy } from 'lodash';
+import { StoreApi, UseBoundStore } from 'zustand';
 
 import { useFolderStore } from '../../../carbonio-ui-commons/store/zustand/folder';
 import { folderWorker } from '../../../carbonio-ui-commons/worker';
@@ -39,7 +40,30 @@ import {
 	updateConversationsOnly,
 	updateMessagesOnly
 } from '../../../store/zustand/search/store';
-import type { Conversation } from '../../../types';
+import type { Conversation, FolderState } from '../../../types';
+
+function handleFoldersNotify(
+	notifyList: Array<SoapNotify>,
+	notify: SoapNotify,
+	worker: Worker,
+	store: UseBoundStore<StoreApi<FolderState>>
+): void {
+	const isNotifyRelatedToFolders =
+		!isEmpty(notifyList) &&
+		(notify?.created?.folder ||
+			notify?.modified?.folder ||
+			notify.deleted ||
+			notify?.created?.link ||
+			notify?.modified?.link);
+
+	if (isNotifyRelatedToFolders) {
+		worker.postMessage({
+			op: 'notify',
+			notify,
+			state: store.getState().folders
+		});
+	}
+}
 
 export const useSyncDataHandler = (): void => {
 	const notifyList = useNotify();
@@ -64,27 +88,12 @@ export const useSyncDataHandler = (): void => {
 			}
 		});
 	}, [currentFolder, dispatch, notifyList]);
-
 	useEffect(() => {
 		if (initialized) {
 			if (notifyList.length > 0) {
 				forEach(sortBy(notifyList, 'seq'), (notify: any) => {
 					if (!isEmpty(notify) && (notify.seq > seq || (seq > 1 && notify.seq === 1))) {
-						const isNotifyRelatedToFolders =
-							!isEmpty(notifyList) &&
-							(notify?.created?.folder ||
-								notify?.modified?.folder ||
-								notify.deleted ||
-								notify?.created?.link ||
-								notify?.modified?.link);
-
-						if (isNotifyRelatedToFolders) {
-							folderWorker.postMessage({
-								op: 'notify',
-								notify,
-								state: useFolderStore.getState().folders
-							});
-						}
+						handleFoldersNotify(notifyList, notify, folderWorker, useFolderStore);
 
 						const tags = getTags();
 						if (notify.created) {

--- a/src/views/sidebar/sidebar.tsx
+++ b/src/views/sidebar/sidebar.tsx
@@ -24,6 +24,7 @@ import type { Folder } from '../../carbonio-ui-commons/types/folder';
 import { LOCAL_STORAGES } from '../../constants';
 import { useFolders } from '../../hooks/use-folders';
 import useGetTagsAccordion from '../../hooks/use-get-tags-accordions';
+import { StoreProvider } from '../../store/redux';
 import type { SidebarComponentProps } from '../../types/sidebar';
 
 const SidebarComponent: FC<SidebarComponentProps> = memo(function SidebarComponent({ accordions }) {
@@ -59,7 +60,7 @@ const SidebarComponent: FC<SidebarComponentProps> = memo(function SidebarCompone
 });
 
 const Sidebar: FC<SecondaryBarComponentProps> = ({ expanded }) => {
-	useInitializeFolders(FOLDER_VIEW.message);
+	useInitializeFolders({ view: FOLDER_VIEW.message, StoreProvider });
 	const { path } = useRouteMatch();
 	const accordions = useFolders();
 

--- a/src/views/sidebar/sidebar.tsx
+++ b/src/views/sidebar/sidebar.tsx
@@ -16,7 +16,9 @@ import AccordionCustomComponent from './accordion-custom-component';
 import { ButtonFindShares } from './button-find-shares';
 import CollapsedSideBarItems from './collapsed-sidebar-items';
 import { SidebarAccordionMui } from '../../carbonio-ui-commons/components/sidebar/sidebar-accordion-mui';
+import { FOLDER_VIEW } from '../../carbonio-ui-commons/constants';
 import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
+import { useInitializeFolders } from '../../carbonio-ui-commons/hooks/use-initialize-folders';
 import { themeMui } from '../../carbonio-ui-commons/theme/theme-mui';
 import type { Folder } from '../../carbonio-ui-commons/types/folder';
 import { LOCAL_STORAGES } from '../../constants';
@@ -57,6 +59,7 @@ const SidebarComponent: FC<SidebarComponentProps> = memo(function SidebarCompone
 });
 
 const Sidebar: FC<SecondaryBarComponentProps> = ({ expanded }) => {
+	useInitializeFolders(FOLDER_VIEW.message);
 	const { path } = useRouteMatch();
 	const accordions = useFolders();
 

--- a/src/views/sidebar/tests/mark-read.test.tsx
+++ b/src/views/sidebar/tests/mark-read.test.tsx
@@ -5,13 +5,13 @@
  */
 import React from 'react';
 
-import { fireEvent, screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 import { FolderActionsType, FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
+import { useFolderStore } from '../../../carbonio-ui-commons/store/zustand/folder';
 import * as shellMock from '../../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
 import { useLocalStorage } from '../../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
 import { createSoapAPIInterceptor } from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
-import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/store/folders';
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
 import { MAIL_APP_ID, MAILS_ROUTE } from '../../../constants';
 import { generateStore } from '../../../tests/generators/store';
@@ -29,17 +29,54 @@ describe('Mark all as read', () => {
 		const folderId = FOLDERS.INBOX;
 		useLocalStorage.mockReturnValue([[FOLDERS.USER_ROOT], jest.fn()]);
 
-		populateFoldersStore();
+		useFolderStore.setState({ folders: {} });
 		const options = {
 			store: generateStore(),
 			initialEntries: [`/mails/folder/${folderId}`],
 			path: '/mails'
 		};
 
+		const getFolderInterceptor = createSoapAPIInterceptor('GetFolder', {
+			folder: [
+				{
+					id: '1',
+					name: 'USER_ROOT',
+					folder: [
+						{
+							id: '2',
+							isLink: false,
+							uuid: 'eb4d8118-ea4f-488c-a4ad-293bb11f7495',
+							deletable: false,
+							name: 'INBOX',
+							absFolderPath: '/INBOX',
+							l: '1',
+							luuid: '86c8fdd1-f993-43d5-ae5c-06631f9150c5',
+							view: 'message',
+							rev: 1,
+							ms: 1,
+							webOfflineSyncDays: 0,
+							activesyncdisabled: false,
+							n: 0,
+							s: 0,
+							i4ms: 1,
+							i4next: 15
+						}
+					]
+				}
+			]
+		});
+
+		const getShareInfoInterceptor = createSoapAPIInterceptor('GetShareInfo', undefined);
+
 		const { user } = setupTest(<Sidebar expanded />, options);
+		await getFolderInterceptor;
+		await getShareInfoInterceptor;
 
 		const inboxItem = screen.getByTestId(`accordion-folder-item-${folderId}`);
-		fireEvent.contextMenu(inboxItem);
+
+		act(() => {
+			user.rightClick(inboxItem);
+		});
 		await screen.findByTestId(`folder-context-menu-${folderId}`);
 		const actionMenuItem = await screen.findByTestId(
 			`folder-action-${FolderActionsType.MARK_ALL_READ}`
@@ -48,7 +85,9 @@ describe('Mark all as read', () => {
 			'FolderAction'
 		);
 
-		await user.click(actionMenuItem);
+		await act(async () => {
+			await user.click(actionMenuItem);
+		});
 
 		const { action } = await folderActionInterceptor;
 		expect(action.l).toBe(folderId);

--- a/src/views/sidebar/tests/mark-read.test.tsx
+++ b/src/views/sidebar/tests/mark-read.test.tsx
@@ -24,7 +24,7 @@ import Sidebar from '../sidebar';
 // I think we should consider removing that mock or redefine it or make it configurable
 jest.mock('../../../carbonio-ui-commons/worker', () => ({
 	folderWorker: {
-		postMessage: (msg: string): void => {}
+		postMessage: jest.fn()
 	}
 }));
 describe('Mark all as read', () => {
@@ -76,15 +76,13 @@ describe('Mark all as read', () => {
 		});
 
 		const getShareInfoInterceptor = createSoapAPIInterceptor('GetShareInfo', undefined);
-
 		const { user } = setupTest(<Sidebar expanded />, options);
 		await getFolderInterceptor;
 		await getShareInfoInterceptor;
 
 		const inboxItem = screen.getByTestId(`accordion-folder-item-${folderId}`);
-
-		act(() => {
-			user.rightClick(inboxItem);
+		await act(async () => {
+			await user.rightClick(inboxItem);
 		});
 		await screen.findByTestId(`folder-context-menu-${folderId}`);
 		const actionMenuItem = await screen.findByTestId(
@@ -97,7 +95,6 @@ describe('Mark all as read', () => {
 		await act(async () => {
 			await user.click(actionMenuItem);
 		});
-
 		const { action } = await folderActionInterceptor;
 		expect(action.l).toBe(folderId);
 		expect(action.op).toBe('read');


### PR DESCRIPTION
- replace useFoldersController with useInitializeFolders
- move useInitializeFolders inside sidebar
- add folders notify logic to sync-data-handler