### PR TITLE
feat: [CO-1411] Allow previewing image/tiff file types using preview service

### DIFF
--- a/src/views/app/detail-panel/preview/tests/attachments-block.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/attachments-block.test.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+// noinspection DuplicatedCode
+
 /*
  * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
  *
@@ -331,4 +334,40 @@ describe('Attachment actions visualization', () => {
 			});
 		}
 	);
+});
+
+describe('Attachment link validation', () => {
+	test('preview is available, should call image preview endpoint when content type is image/tiff', async () => {
+		useAppContext.mockReturnValue({ servicesCatalog: ['carbonio-preview'] });
+		const store = generateStore();
+		const messageAttachments = [
+			{
+				cd: 'attachment',
+				name: 'test',
+				filename: 'image.tiff',
+				size: 12345,
+				contentType: 'image/tiff',
+				requiresSmartLinkConversion: false
+			} as const
+		];
+		const { user } = setupTest(
+			<AttachmentsBlock
+				messageId={'1'}
+				messageSubject={'test'}
+				messageAttachments={messageAttachments}
+			/>,
+			{ store }
+		);
+
+		await user.hover(screen.getByText('image.tiff'));
+		expect(await screen.findByText('Click to preview')).toBeVisible();
+
+		await user.click(screen.getByText('image.tiff'));
+		expect(previewContextMock.createPreview).toHaveBeenCalledTimes(1);
+
+		const createPreviewParam = previewContextMock.createPreview.mock.calls[0][0];
+		expect(createPreviewParam.src).toBe(
+			'http://localhost/service/preview/image/1/test/0x0/?quality=high'
+		);
+	});
 });

--- a/src/views/app/detail-panel/preview/tests/utils.test.ts
+++ b/src/views/app/detail-panel/preview/tests/utils.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { includes } from 'lodash';
+
+import { getAttachmentsLink } from '../utils';
+
+jest.mock('lodash', () => ({
+	includes: jest.fn()
+}));
+
+describe('getAttachmentsLink', () => {
+	const messageId = '12345';
+	const messageSubject = 'testSubject';
+	const getLocationOrigin = jest.fn().mockReturnValue('http://localhost');
+
+	beforeEach(() => {
+		getLocationOrigin.mockClear();
+	});
+
+	it('should return a zip link when there are multiple attachments', () => {
+		const attachments = ['file1', 'file2'];
+		const result = getAttachmentsLink({
+			messageId,
+			messageSubject,
+			attachments,
+			attachmentType: 'application/zip'
+		});
+		expect(result).toBe(
+			'http://localhost/service/home/~/?auth=co&id=12345&filename=testSubject&charset=UTF-8&part=file1,file2&disp=a&fmt=zip'
+		);
+	});
+
+	it('should return an image preview link for image attachment types', () => {
+		(includes as unknown as jest.Mock).mockReturnValueOnce(true); // Simulating image type
+
+		const attachments = ['image1'];
+		const result = getAttachmentsLink({
+			messageId,
+			messageSubject,
+			attachments,
+			attachmentType: 'image/tiff'
+		});
+		expect(result).toBe('http://localhost/service/preview/image/12345/image1/0x0/?quality=high');
+		expect(includes).toHaveBeenCalledWith(
+			['image/gif', 'image/png', 'image/jpeg', 'image/jpg', 'image/tiff'],
+			'image/tiff'
+		);
+	});
+
+	it('should return a pdf preview link for pdf attachment type', () => {
+		(includes as unknown as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(true); // Simulating pdf type
+
+		const attachments = ['pdf1'];
+		const result = getAttachmentsLink({
+			messageId,
+			messageSubject,
+			attachments,
+			attachmentType: 'application/pdf'
+		});
+		expect(result).toBe('http://localhost/service/preview/pdf/12345/pdf1/?first_page=1');
+		expect(includes).toHaveBeenCalledWith(['application/pdf'], 'application/pdf');
+	});
+
+	it('should return a document preview link for document attachment types', () => {
+		(includes as unknown as jest.Mock)
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(true); // Simulating document type
+
+		const attachments = ['doc1'];
+		const result = getAttachmentsLink({
+			messageId,
+			messageSubject,
+			attachments,
+			attachmentType: 'application/msword'
+		});
+		expect(result).toBe('http://localhost/service/preview/document/12345/doc1');
+		expect(includes).toHaveBeenCalledWith(
+			[
+				'text/csv',
+				'text/plain',
+				'application/msword',
+				'application/vnd.ms-excel',
+				'application/vnd.ms-powerpoint',
+				'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+				'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+				'application/vnd.oasis.opendocument.spreadsheet',
+				'application/vnd.oasis.opendocument.presentation',
+				'application/vnd.oasis.opendocument.text'
+			],
+			'application/msword'
+		);
+	});
+
+	it('should return a default attachment link for unrecognized attachment types', () => {
+		(includes as unknown as jest.Mock)
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(false); // No match for any type
+
+		const attachments = ['file1'];
+		const result = getAttachmentsLink({
+			messageId,
+			messageSubject,
+			attachments,
+			attachmentType: 'unknown/type'
+		});
+		expect(result).toBe('http://localhost/service/home/~/?auth=co&id=12345&part=file1&disp=a');
+	});
+});

--- a/src/views/app/detail-panel/preview/utils/index.ts
+++ b/src/views/app/detail-panel/preview/utils/index.ts
@@ -34,7 +34,9 @@ export const getAttachmentsLink = ({
 			','
 		)}&disp=a&fmt=zip`;
 	}
-	if (includes(['image/gif', 'image/png', 'image/jpeg', 'image/jpg'], attachmentType)) {
+	if (
+		includes(['image/gif', 'image/png', 'image/jpeg', 'image/jpg', 'image/tiff'], attachmentType)
+	) {
 		return `${getLocationOrigin()}/service/preview/image/${messageId}/${
 			attachments[0]
 		}/0x0/?quality=high`;


### PR DESCRIPTION
**What's changed:**
- `getAttachmentsLink` helper function now return image preview endpoint for `image/tiff` file types, this allows previewing tiff images using preview service. 
- add unit test for `getAttachmentsLink` and component integration test for `AttachmentsBlock`