### PR TITLE
[CO-1491] when the user tries to accept a share invitation for a folder that already exists a generic error is raised

### DIFF
--- a/src/integrations/shared-invite-reply/parts/share-calendar-actions.ts
+++ b/src/integrations/shared-invite-reply/parts/share-calendar-actions.ts
@@ -159,6 +159,10 @@ const useMoveInviteToTrashFunc = (): ((arg: MoveInviteToTrashType) => any) => {
 	);
 };
 
+function isDuplicatedName(error: any): boolean {
+	return error?.message?.includes('mail.ALREADY_EXISTS');
+}
+
 export const useAccept = (): ((arg: Accept) => void) => {
 	const { createSnackbar } = useUiUtilities();
 	const moveInviteToTrashFunc = useMoveInviteToTrashFunc();
@@ -218,7 +222,12 @@ export const useAccept = (): ((arg: Accept) => void) => {
 						key: `share`,
 						replace: true,
 						severity: 'error',
-						label: t('label.error_try_again', 'Something went wrong, please try again'),
+						label: isDuplicatedName(res.error)
+							? t(
+									'label.error_folder_exists',
+									'A folder with the same name already exists, please choose a different one'
+								)
+							: t('label.error_try_again', 'Something went wrong, please try again'),
 						autoHideTimeout: 3000,
 						hideButton: true
 					});

--- a/src/integrations/shared-invite-reply/parts/share-calendar-actions.ts
+++ b/src/integrations/shared-invite-reply/parts/share-calendar-actions.ts
@@ -159,8 +159,8 @@ const useMoveInviteToTrashFunc = (): ((arg: MoveInviteToTrashType) => any) => {
 	);
 };
 
-function isDuplicatedName(error: any): boolean {
-	return error?.message?.includes('mail.ALREADY_EXISTS');
+function isDuplicatedName(error: { message?: string }): boolean {
+	return error?.message?.includes('mail.ALREADY_EXISTS') ?? false;
 }
 
 export const useAccept = (): ((arg: Accept) => void) => {

--- a/src/integrations/shared-invite-reply/parts/tests/share-calendar-actions.test.ts
+++ b/src/integrations/shared-invite-reply/parts/tests/share-calendar-actions.test.ts
@@ -1,0 +1,50 @@
+import { Dispatch } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react';
+
+import { useAccept } from '../share-calendar-actions';
+
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+describe('share calendar actions', () => {
+	it('should mount shared calendar on accept', () => {
+		const dispatch = jest.fn(() =>
+			Promise.resolve({
+				type: 'fullfilled'
+			})
+		) as Dispatch<any>;
+		jest.spyOn(console, 'error').mockImplementation(jest.fn());
+		const zid = 'zid';
+		const view = 'view';
+		const rid = 'rid';
+		const calendarName = 'calendarName';
+		const color = 1;
+		const accounts = {};
+		const { result } = renderHook(() => useAccept());
+		const { current: accept } = result;
+		renderHook(() =>
+			accept({
+				zid,
+				view,
+				rid,
+				calendarName,
+				color,
+				accounts,
+				dispatch,
+				msgId: 'msgId',
+				sharedCalendarName: calendarName,
+				owner: 'owner',
+				participants: [],
+				grantee: 'grantee',
+				customMessage: 'customMessage',
+				role: 'role',
+				allowedActions: 'allowedActions',
+				notifyOrganizer: true,
+				t: jest.fn()
+			})
+		);
+		expect(dispatch).toHaveBeenCalled();
+	});
+});

--- a/src/integrations/shared-invite-reply/parts/tests/share-calendar-actions.test.ts
+++ b/src/integrations/shared-invite-reply/parts/tests/share-calendar-actions.test.ts
@@ -1,28 +1,46 @@
-import { Dispatch } from '@reduxjs/toolkit';
-import { renderHook } from '@testing-library/react';
-
-import { useAccept } from '../share-calendar-actions';
-
 /*
  * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { Dispatch } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react';
+import { CreateSnackbarFn, useSnackbar } from '@zextras/carbonio-design-system';
+
+import { setupHook } from '../../../../carbonio-ui-commons/test/test-setup';
+import { useAccept } from '../share-calendar-actions';
+
+const createSnackbar = (arg: any): CreateSnackbarFn => arg;
+const createSnackbarSpy = jest.fn(createSnackbar);
+
+jest.mock('@zextras/carbonio-design-system', () => ({
+	...jest.requireActual('@zextras/carbonio-design-system'),
+	useSnackbar: jest.fn()
+}));
+
+beforeEach(() => {
+	(useSnackbar as jest.Mock).mockReturnValue(createSnackbarSpy);
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
 describe('share calendar actions', () => {
-	it('should mount shared calendar on accept', () => {
+	it('should mount shared calendar on accept', async () => {
 		const dispatch = jest.fn(() =>
 			Promise.resolve({
-				type: 'fullfilled'
+				type: 'fulfilled'
 			})
 		) as Dispatch<any>;
-		jest.spyOn(console, 'error').mockImplementation(jest.fn());
+		const { unmount, result } = setupHook(useAccept);
 		const zid = 'zid';
 		const view = 'view';
 		const rid = 'rid';
 		const calendarName = 'calendarName';
 		const color = 1;
 		const accounts = {};
-		const { result } = renderHook(() => useAccept());
+
 		const { current: accept } = result;
 		renderHook(() =>
 			accept({
@@ -42,9 +60,69 @@ describe('share calendar actions', () => {
 				role: 'role',
 				allowedActions: 'allowedActions',
 				notifyOrganizer: true,
-				t: jest.fn()
+				t: (msg, _) => msg
 			})
 		);
+		await unmount();
 		expect(dispatch).toHaveBeenCalled();
+		expect(createSnackbarSpy).toHaveBeenCalledWith({
+			key: 'share_accepted',
+			replace: true,
+			autoHideTimeout: 3000,
+			hideButton: true,
+			label: 'message.snackbar.share.accepted',
+			severity: 'info'
+		});
+	});
+
+	it('should display an error on existing folder', async () => {
+		const dispatch = jest.fn(() =>
+			Promise.resolve({
+				type: 'error',
+				error: {
+					message: 'mail.ALREADY_EXISTS'
+				}
+			})
+		) as Dispatch<any>;
+		const { unmount, result } = setupHook(useAccept);
+		const zid = 'zid';
+		const view = 'view';
+		const rid = 'rid';
+		const calendarName = 'calendarName';
+		const color = 1;
+		const accounts = {};
+		const { current: accept } = result;
+
+		renderHook(() =>
+			accept({
+				zid,
+				view,
+				rid,
+				calendarName,
+				color,
+				accounts,
+				dispatch,
+				msgId: 'msgId',
+				sharedCalendarName: calendarName,
+				owner: 'owner',
+				participants: [],
+				grantee: 'grantee',
+				customMessage: 'customMessage',
+				role: 'role',
+				allowedActions: 'allowedActions',
+				notifyOrganizer: true,
+				t: (msg, _) => msg
+			})
+		);
+		await unmount();
+		expect(dispatch).toHaveBeenCalled();
+		expect(createSnackbarSpy).toHaveBeenCalledWith({
+			key: 'share',
+			replace: true,
+			autoHideTimeout: 3000,
+			hideButton: true,
+			label: 'label.error_folder_exists',
+			severity: 'error'
+		});
 	});
 });

--- a/src/store/actions/mount-share-calendar.ts
+++ b/src/store/actions/mount-share-calendar.ts
@@ -34,7 +34,7 @@ export const mountSharedCalendar = createAsyncThunk(
 		});
 		const response = await res.json();
 		if (response.Body.Fault) {
-			throw new Error(response.Body.Fault.Reason.Text);
+			throw new Error(response.Body.Fault.Detail.Error.Code);
 		}
 
 		return { response };

--- a/src/store/actions/tests/mount-share-calendar.test.ts
+++ b/src/store/actions/tests/mount-share-calendar.test.ts
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { http } from 'msw';
+
+import { getSetupServer } from '../../../carbonio-ui-commons/test/jest-setup';
+import { generateStore } from '../../../tests/generators/store';
+import { handleCreateMountpointRequest } from '../../../tests/mocks/network/msw/handle-create-mountpoint';
+import { mountSharedCalendar } from '../mount-share-calendar';
+
+describe('mountShareCalendar', () => {
+	it('returns error if the folder already exists', async () => {
+		getSetupServer().use(
+			http.post('/service/soap/CreateMountpointRequest', handleCreateMountpointRequest)
+		);
+		const store = generateStore();
+
+		expect(
+			store.dispatch(
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				mountSharedCalendar({
+					calendarName: 'existing',
+					accounts: [{ name: 'account' }]
+				})
+			)
+		).resolves.toMatchObject({
+			payload: {
+				response: {
+					Body: {
+						CreateMountpointResponse: {
+							_jsns: 'urn:zimbraMail',
+							Fault: {
+								Detail: {
+									Error: {
+										Code: 'mail.ALREADY_EXISTS'
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		});
+	});
+	it('returns success if the folder does not exist', async () => {
+		getSetupServer().use(
+			http.post('/service/soap/CreateMountpointRequest', handleCreateMountpointRequest)
+		);
+		const store = generateStore();
+
+		expect(
+			store.dispatch(
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				mountSharedCalendar({
+					calendarName: 'new',
+					accounts: [{ name: 'account' }]
+				})
+			)
+		).resolves.toMatchObject({
+			payload: {
+				response: {
+					Body: {
+						CreateMountpointResponse: {
+							_jsns: 'urn:zimbraMail',
+							link: [
+								{
+									name: 'new',
+									absFolderPath: '/new'
+								}
+							]
+						}
+					}
+				}
+			}
+		});
+	});
+});

--- a/src/tests/mocks/network/msw/handle-create-mountpoint.ts
+++ b/src/tests/mocks/network/msw/handle-create-mountpoint.ts
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { faker } from '@faker-js/faker';
+import { HttpResponse, HttpResponseResolver } from 'msw';
+
+type Response = { Header: any; Body: any };
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const getSuccessfulBody = ({ name }): Response['Body'] => ({
+	CreateMountpointResponse: {
+		_jsns: 'urn:zimbraMail',
+		link: [
+			{
+				id: faker.string.numeric(),
+				uuid: faker.string.uuid(),
+				deletable: true,
+				name,
+				absFolderPath: `/${name}`,
+				l: faker.string.numeric(),
+				luuid: faker.string.uuid(),
+				f: '#',
+				view: 'message',
+				rev: faker.number.int({ min: 1, max: 999999 }),
+				ms: faker.number.int({ min: 1, max: 999999 }),
+				webOfflineSyncDays: 0,
+				activesyncdisabled: false,
+				zid: faker.string.uuid(),
+				rid: faker.number.int({ min: 1, max: 999999 }),
+				ruuid: faker.string.uuid(),
+				owner: faker.internet.email(),
+				reminder: false,
+				n: 0,
+				s: 0,
+				oname: faker.string.alpha(),
+				rest: faker.string.alpha(),
+				perm: 'r'
+			}
+		]
+	}
+});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const getExistingFolderBody = (): Response['Body'] => ({
+	CreateMountpointResponse: {
+		_jsns: 'urn:zimbraMail',
+		Fault: {
+			Detail: {
+				Error: {
+					Code: 'mail.ALREADY_EXISTS'
+				}
+			}
+		}
+	}
+});
+
+const getDefaultCreateMountpointResponse = (
+	{ name } = {} as {
+		name?: string;
+	}
+): Response['Body'] => {
+	if (name === 'existing') {
+		return getExistingFolderBody();
+	}
+	return getSuccessfulBody({ name });
+};
+
+const getCreateMountpointResponse = (
+	{ name } = {} as {
+		name?: string;
+	}
+): Response => ({
+	Header: {
+		context: {
+			session: {
+				id: faker.number.int({ min: 1, max: 999999 }),
+				_content: faker.number.int({ min: 1, max: 999999 })
+			}
+		}
+	},
+	Body: getDefaultCreateMountpointResponse({ name })
+});
+
+export const handleCreateMountpointRequest: HttpResponseResolver<never, string> = async ({
+	request
+}) => {
+	const requestContent = await request.text();
+	const parser = new DOMParser();
+	const xmlRequest = parser.parseFromString(requestContent, 'text/xml');
+	const link = xmlRequest.getElementsByTagName('link').item(0);
+
+	const response = getCreateMountpointResponse({
+		name: link?.getAttribute('name') || ''
+	});
+
+	return HttpResponse.json(response);
+};


### PR DESCRIPTION
The proposed solution is composed of two steps:
 - a more precise error code is thrown in mount-share-calendar.ts, instead of the error description text (in case of existing folder the error code returned by the backend is "mail.ALREADY_EXISTS")
 - the error code is intercepted in useAccept (share-calendar-actions) to use a different error label (label.error_folder_exists) instead of the generic one for this scenario
