### PR TITLE
feat: [CO-1547] add msg move constrains in move conversation action

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -565,7 +565,6 @@ export const MAIL_SENSITIVITY_HEADER = {
 	companyConfidential: 'Company-Confidential'
 } as const;
 
-export const MAIL_SENSITIVITY_HEADER_VALUES = ['Personal', 'Private', 'Company-Confidential'];
-
 export const SENSITIVITY_VALUES = ['Private', 'Company-Confidential'] as const;
 export const VALID_MAIL_AUTHENTICATION_HEADERS = ['dkim', 'spf', 'dmarc'] as const;
+export const CONV_ACTION_CONSTRAINS = '-stdj';

--- a/src/store/actions/conv-action.ts
+++ b/src/store/actions/conv-action.ts
@@ -18,7 +18,7 @@ import type {
 export const convAction = createAsyncThunk<ConvActionResult, ConvActionParameters>(
 	'convAction',
 	async ({ ids, operation, parent, tagName, constrains }) => {
-		const { action } = (await soapFetch<ConvActionRequest, ConvActionResponse>('ConvAction', {
+		const { action } = await soapFetch<ConvActionRequest, ConvActionResponse>('ConvAction', {
 			_jsns: 'urn:zimbraMail',
 
 			action: omitBy(
@@ -31,7 +31,7 @@ export const convAction = createAsyncThunk<ConvActionResult, ConvActionParameter
 				},
 				isNil
 			)
-		})) as ConvActionResponse;
+		});
 		return {
 			ids: action.id.split(','),
 			operation: action.op

--- a/src/store/actions/conv-action.ts
+++ b/src/store/actions/conv-action.ts
@@ -6,6 +6,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { soapFetch } from '@zextras/carbonio-shell-ui';
 import { isNil } from 'lodash';
+
 import { omitBy } from '../../commons/utils';
 import type {
 	ConvActionParameters,
@@ -16,7 +17,7 @@ import type {
 
 export const convAction = createAsyncThunk<ConvActionResult, ConvActionParameters>(
 	'convAction',
-	async ({ ids, operation, parent, tagName }) => {
+	async ({ ids, operation, parent, tagName, constrains }) => {
 		const { action } = (await soapFetch<ConvActionRequest, ConvActionResponse>('ConvAction', {
 			_jsns: 'urn:zimbraMail',
 
@@ -25,7 +26,8 @@ export const convAction = createAsyncThunk<ConvActionResult, ConvActionParameter
 					id: ids.join(','),
 					op: operation,
 					l: parent,
-					tn: tagName
+					tn: tagName,
+					tcon: constrains
 				},
 				isNil
 			)

--- a/src/types/conversations/index.d.ts
+++ b/src/types/conversations/index.d.ts
@@ -51,6 +51,7 @@ export type ConvActionParameters = {
 	operation: ConvActionOperation;
 	parent?: string;
 	tagName?: string;
+	constrains?: string;
 };
 
 export type ConvActionResult = {

--- a/src/types/soap/conv-action.ts
+++ b/src/types/soap/conv-action.ts
@@ -25,6 +25,7 @@ export type ConvActionRequest = ZimbraRequest & {
 		op?: ConvActionOperation;
 		tn?: string;
 		l?: string;
+		tcon?: string;
 	};
 };
 

--- a/src/ui-actions/move-conv-msg.tsx
+++ b/src/ui-actions/move-conv-msg.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import ModalFooter from '../carbonio-ui-commons/components/modals/modal-footer';
 import ModalHeader from '../carbonio-ui-commons/components/modals/modal-header';
 import { Folder } from '../carbonio-ui-commons/types/folder';
+import { CONV_ACTION_CONSTRAINS } from '../constants';
 import { isRoot } from '../helpers/folders';
 import { useUiUtilities } from '../hooks/use-ui-utilities';
 import { convAction, msgAction } from '../store/actions';
@@ -58,7 +59,8 @@ const MoveConvMessage = ({
 				convAction({
 					operation: `move`,
 					ids: selectedIDs,
-					parent: id
+					parent: id,
+					constrains: CONV_ACTION_CONSTRAINS
 				})
 			)
 				.then((res) => {

--- a/src/ui-actions/tests/move-conv-msg.test.tsx
+++ b/src/ui-actions/tests/move-conv-msg.test.tsx
@@ -14,10 +14,17 @@ import { getFolder } from '../../carbonio-ui-commons/store/zustand/folder';
 import { createSoapAPIInterceptor } from '../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '../../carbonio-ui-commons/test/mocks/store/folders';
 import { makeListItemsVisible, setupTest } from '../../carbonio-ui-commons/test/test-setup';
-import { API_REQUEST_STATUS } from '../../constants';
+import { API_REQUEST_STATUS, CONV_ACTION_CONSTRAINS } from '../../constants';
+import { generateConversation } from '../../tests/generators/generateConversation';
 import { generateMessage } from '../../tests/generators/generateMessage';
 import { generateStore } from '../../tests/generators/store';
-import { MailMessage, MsgActionRequest, MsgActionResponse } from '../../types';
+import {
+	ConvActionRequest,
+	ConvActionResponse,
+	MailMessage,
+	MsgActionRequest,
+	MsgActionResponse
+} from '../../types';
 import MoveConvMessage from '../move-conv-msg';
 
 describe('MoveConvMsg', () => {
@@ -222,6 +229,88 @@ describe('MoveConvMsg', () => {
 			expect(requestParameter.action.op).toBe('move');
 			expect(requestParameter.action.l).toBe(destinationFolder);
 			expect(requestParameter.action.f).toBeUndefined();
+			expect(requestParameter.action.tn).toBeUndefined();
+		});
+
+		it('should call conv action api with default constrains when user clicks confirm', async () => {
+			populateFoldersStore({ view: FOLDER_VIEW.conversation });
+
+			const { children: inboxChildren } = getFolder(FOLDERS.INBOX) ?? {};
+			const sourceFolderId = inboxChildren?.[0].id ?? '';
+			const destinationFolder = FOLDERS.SENT;
+
+			const conversation = generateConversation({
+				folderId: sourceFolderId,
+				isSingleMessageConversation: false
+			});
+			const msgIdsInConversation = conversation.messages.map<string>((msg) => msg.id);
+
+			const store = generateStore({
+				conversations: {
+					currentFolder: sourceFolderId,
+					expandedStatus: {
+						[conversation.id]: API_REQUEST_STATUS.fulfilled
+					},
+					searchedInFolder: {},
+					conversations: {
+						[conversation.id]: conversation
+					},
+					searchRequestStatus: API_REQUEST_STATUS.fulfilled
+				}
+			});
+
+			const interceptor = createSoapAPIInterceptor<ConvActionRequest, ConvActionResponse>(
+				'ConvAction',
+				{
+					action: {
+						id: conversation.id,
+						op: 'move'
+					}
+				}
+			);
+
+			const component = (
+				<MoveConvMessage
+					folderId={sourceFolderId}
+					selectedIDs={msgIdsInConversation}
+					onClose={jest.fn()}
+					isMessageView={false}
+					isRestore={false}
+					deselectAll={jest.fn()}
+					dispatch={store.dispatch}
+				/>
+			);
+
+			const { user } = setupTest(component, { store });
+			makeListItemsVisible();
+
+			const inboxFolderListItem = await screen.findByTestId(
+				`folder-accordion-item-${destinationFolder}`,
+				{},
+				{ timeout: 10000 }
+			);
+
+			act(() => {
+				jest.advanceTimersByTime(1000);
+			});
+
+			await act(async () => {
+				await user.click(inboxFolderListItem);
+			});
+
+			const button = screen.getByRole('button', {
+				name: /Move/
+			});
+
+			await act(async () => {
+				await user.click(button);
+			});
+
+			const requestParameter = await interceptor;
+			expect(requestParameter.action.id).toBe(msgIdsInConversation.join(','));
+			expect(requestParameter.action.op).toBe('move');
+			expect(requestParameter.action.l).toBe(destinationFolder);
+			expect(requestParameter.action.tcon).toBe(CONV_ACTION_CONSTRAINS);
 			expect(requestParameter.action.tn).toBeUndefined();
 		});
 	});

--- a/src/views/sidebar/accordion-custom-component.tsx
+++ b/src/views/sidebar/accordion-custom-component.tsx
@@ -37,7 +37,7 @@ import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
 import { isSystemFolder } from '../../carbonio-ui-commons/helpers/folders';
 import type { Folder } from '../../carbonio-ui-commons/types/folder';
 import type { DragEnterAction, OnDropActionProps } from '../../carbonio-ui-commons/types/sidebar';
-import { LIST_LIMIT } from '../../constants';
+import { CONV_ACTION_CONSTRAINS, LIST_LIMIT } from '../../constants';
 import { isDraft, isSpam } from '../../helpers/folders';
 import { parseMessageSortingOptions } from '../../helpers/sorting';
 import { useAppDispatch } from '../../hooks/redux';
@@ -147,7 +147,8 @@ const AccordionCustomComponent: FC<{ item: Folder }> = ({ item }) => {
 				convAction({
 					operation: `move`,
 					ids: convMsgsIds,
-					parent: item.id
+					parent: item.id,
+					constrains: CONV_ACTION_CONSTRAINS
 				})
 			).then((res) => {
 				if (res.type.includes('fulfilled')) {


### PR DESCRIPTION
Constraints are applied when moving conversation items between folders. 

When moving conversation items between folders, if the original folder is one of the system folders Sent, Trash, Draft, or Junk, the item will be moved to the new folder but will also remain in the original folder. Note that messages are not duplicated in this process.