### PR TITLE
fix: dark mode white text on white background

### DIFF
--- a/src/commons/mail-message-renderer/html-message-renderer.tsx
+++ b/src/commons/mail-message-renderer/html-message-renderer.tsx
@@ -176,7 +176,7 @@ export const HtmlMessageRenderer: FC<HtmlMessageRendererType> = ({ msgId }) => {
 	};
 
 	return (
-		<div ref={divRef} className="force-white-bg" style={{ height: '100%' }}>
+		<div ref={divRef} style={{ height: '100%' }}>
 			{showBanner && !showExternalImage && (
 				<BannerViewExternalImages
 					setShowExternalImages={setShowExternalImage}


### PR DESCRIPTION
- since we removed the iframe we don't need the force-white-bg class anymore. This was causing dark mode to render white text on white background in email rendering