### PR TITLE
fix: remove unnecessary class from div element

### DIFF
--- a/src/commons/mail-message-renderer/html-message-renderer.tsx
+++ b/src/commons/mail-message-renderer/html-message-renderer.tsx
@@ -176,7 +176,7 @@ export const HtmlMessageRenderer: FC<HtmlMessageRendererType> = ({ msgId }) => {
 	};
 
 	return (
-		<div ref={divRef} className="force-white-bg" style={{ height: '100%' }}>
+		<div ref={divRef} style={{ height: '100%' }}>
 			{showBanner && !showExternalImage && (
 				<BannerViewExternalImages
 					setShowExternalImages={setShowExternalImage}


### PR DESCRIPTION
The class "force-white-bg" was removed from the div element as it was unnecessary. This change simplifies the code and ensures that the background color is not forcibly set to white, allowing for more flexible styling.