### PR TITLE
fix: [CO-1598] do not crop attachments names in print preview and print

### DIFF
--- a/src/commons/print-conversation/get-attachments.ts
+++ b/src/commons/print-conversation/get-attachments.ts
@@ -6,6 +6,7 @@
 
 import { t } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
+
 import type { MailMessage } from '../../types';
 
 export const getAttachments = ({ msg }: { msg: MailMessage }): string =>
@@ -24,7 +25,7 @@ export const getAttachments = ({ msg }: { msg: MailMessage }): string =>
          display: flex;
          font-family: Roboto, sans-serif;
          font-size: 1rem;
-         width: fill-content">
+         width: fit-content">
          ${t('label.attachment_plural', 'Attachments')}:
       </div>
    </td>
@@ -60,7 +61,6 @@ export const getAttachments = ({ msg }: { msg: MailMessage }): string =>
             font-family: Roboto, sans-serif;
             font-size: 0.75rem;
             display: flex;
-            line-height: 0;
             ">
             ${item.filename}
          </p>


### PR DESCRIPTION
**What has changed:**

- fixing the CSS by adjusting the `line-height` property (previously set to 0) ensures each attachment takes its default height, preventing them from overlapping or being improperly displayed
- fix wrongly assigned  width property 