### PR TITLE
Removing tags from emails in function accounts does not refresh view

### DIFF
--- a/src/normalizations/normalize-conversation.ts
+++ b/src/normalizations/normalize-conversation.ts
@@ -16,8 +16,9 @@ import type {
 } from '../types';
 
 const getTagIdsFromName = (names: string | undefined, tags?: Tags): Array<string | undefined> =>
-	map(names?.split(','), (name) =>
-		find(tags, { name }) ? find(tags, { name })?.id : `nil:${name}`
+	map(
+		(names?.split(',') ?? []).filter((n) => n),
+		(name) => (find(tags, { name }) ? find(tags, { name })?.id : `nil:${name}`)
 	);
 const getTagIds = (
 	t: string | undefined,

--- a/src/views/sidebar/commons/sync-data-handler-hooks.ts
+++ b/src/views/sidebar/commons/sync-data-handler-hooks.ts
@@ -31,6 +31,7 @@ import {
 import {
 	handleCreatedMessages,
 	handleDeletedMessages,
+	handleModifiedMessages,
 	selectMessages
 } from '../../../store/messages-slice';
 import {
@@ -130,7 +131,7 @@ export const useSyncDataHandler = (): void => {
 									);
 									// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 									// @ts-ignore
-									// dispatch(handleModifiedMessages(messages));
+									dispatch(handleModifiedMessages(messages));
 									updateMessagesOnly(messages);
 
 									// the condition filters messages with parent property (the only ones we need to update)


### PR DESCRIPTION
Refs CO-1706

This one fixes two different issues with tags:
 - removal of tag in functional account is not reflected in the UI in conversations mode
 - adding / removing tags in message mode is not reflected on the UI
