### PR TITLE
feat: refactor Tag import in message list items

### DIFF
--- a/src/views/app/folder-panel/messages/message-list-item.tsx
+++ b/src/views/app/folder-panel/messages/message-list-item.tsx
@@ -14,13 +14,7 @@ import {
 	Text,
 	Tooltip
 } from '@zextras/carbonio-design-system';
-import {
-	Tag,
-	replaceHistory,
-	t,
-	useUserAccounts,
-	useUserSettings
-} from '@zextras/carbonio-shell-ui';
+import { replaceHistory, t, useUserAccounts, useUserSettings } from '@zextras/carbonio-shell-ui';
 import { debounce, find, includes, isEmpty, noop, reduce } from 'lodash';
 import moment from 'moment';
 import { useParams } from 'react-router-dom';
@@ -29,6 +23,7 @@ import { MessageListItemActionWrapper } from './message-list-item-action-wrapper
 import { ZIMBRA_STANDARD_COLORS } from '../../../../carbonio-ui-commons/constants';
 import { useFolder } from '../../../../carbonio-ui-commons/store/zustand/folder';
 import { useTags } from '../../../../carbonio-ui-commons/store/zustand/tags';
+import { Tag } from '../../../../carbonio-ui-commons/types/tags';
 import { getTimeLabel, participantToString } from '../../../../commons/utils';
 import { EditViewActions } from '../../../../constants';
 import { useMsgPreviewOnSeparatedWindowFn } from '../../../../hooks/actions/use-msg-preview-on-separated-window';

--- a/src/views/search/list/conversation/search-conversation-list-item.tsx
+++ b/src/views/search/list/conversation/search-conversation-list-item.tsx
@@ -17,13 +17,14 @@ import {
 	Text,
 	Tooltip
 } from '@zextras/carbonio-design-system';
-import { Tag, pushHistory, t, useUserAccounts, useUserSettings } from '@zextras/carbonio-shell-ui';
+import { pushHistory, t, useUserAccounts, useUserSettings } from '@zextras/carbonio-shell-ui';
 import { filter, forEach, includes, isEmpty, reduce, trimStart, uniqBy } from 'lodash';
 import styled from 'styled-components';
 
 import { SearchConversationMessagesList } from './search-conversation-messages-list';
 import { ZIMBRA_STANDARD_COLORS } from '../../../../carbonio-ui-commons/constants';
 import { useTags } from '../../../../carbonio-ui-commons/store/zustand/tags';
+import { Tag } from '../../../../carbonio-ui-commons/types/tags';
 import { participantToString } from '../../../../commons/utils';
 import { API_REQUEST_STATUS } from '../../../../constants';
 import { useConvPreviewOnSeparatedWindowFn } from '../../../../hooks/actions/use-conv-preview-on-separated-window';


### PR DESCRIPTION
Refactored the import statements for the `Tag` component in
`message-list-item.tsx` and `search-conversation-list-item.tsx` to
import it from `carbonio-commons/types/tags` instead of
`carbonio-shell-ui`. This change improves code organization and
maintainability.