### PR TITLE
CO-1488: improved mail-to integration to allow multiple recipients and subject

### DIFF
--- a/src/app-utils/register-shell-actions.ts
+++ b/src/app-utils/register-shell-actions.ts
@@ -21,7 +21,7 @@ interface MailToActionType extends Action {
 	disabled: boolean;
 }
 
-interface MailToReceiversActionType extends Action {
+interface MailToRecipientsActionType extends Action {
 	id: string;
 	icon: string;
 	execute: (e: SyntheticEvent<HTMLElement, Event> | KeyboardEvent) => void;
@@ -57,7 +57,7 @@ export const mailToAction = (contacts: unknown): MailToActionType => ({
 	disabled: isArray(contacts) && some(contacts, (contact) => !contact.address)
 });
 
-export type Receiver = {
+export type Recipient = {
 	email: string;
 	name: string;
 	carbonCopy?: boolean;
@@ -65,7 +65,7 @@ export type Receiver = {
 
 type MailDescription = {
 	subject: string;
-	receivers: Receiver[];
+	recipients: Recipient[];
 };
 
 function isMailDescription(mailDescription: unknown): mailDescription is MailDescription {
@@ -73,26 +73,26 @@ function isMailDescription(mailDescription: unknown): mailDescription is MailDes
 		typeof mailDescription === 'object' &&
 		mailDescription !== null &&
 		'subject' in mailDescription &&
-		'receivers' in mailDescription &&
-		isArray(mailDescription.receivers) &&
-		mailDescription.receivers.every(
-			(receiver) =>
-				typeof receiver === 'object' &&
-				receiver !== null &&
-				'email' in receiver &&
-				'name' in receiver
+		'recipients' in mailDescription &&
+		isArray(mailDescription.recipients) &&
+		mailDescription.recipients.every(
+			(recipient) =>
+				typeof recipient === 'object' &&
+				recipient !== null &&
+				'email' in recipient &&
+				'name' in recipient
 		) &&
 		isString(mailDescription.subject)
 	);
 }
 
-export const mailToReceiversActionOnClick = (
+export const mailToRecipientsActionOnClick = (
 	e: SyntheticEvent<HTMLElement, Event> | KeyboardEvent,
 	mailDescription: unknown
 ): void => {
 	e?.preventDefault?.();
 	if (isMailDescription(mailDescription)) {
-		const participants = mailDescription.receivers.map((receiver) => ({
+		const participants = mailDescription.recipients.map((receiver) => ({
 			type: receiver.carbonCopy ? ParticipantRole.CARBON_COPY : ParticipantRole.TO,
 			address: receiver.email,
 			fullName: receiver.name
@@ -102,11 +102,11 @@ export const mailToReceiversActionOnClick = (
 	}
 };
 
-export const mailToReceiversAction = (mailDescription: unknown): MailToReceiversActionType => ({
+export const mailToRecipientsAction = (mailDescription: unknown): MailToRecipientsActionType => ({
 	id: 'mail-to',
 	label: t('label.send_mail', 'Send Mail'),
 	icon: 'MailModOutline',
-	execute: (e) => mailToReceiversActionOnClick(e, mailDescription),
+	execute: (e) => mailToRecipientsActionOnClick(e, mailDescription),
 	disabled: false
 });
 
@@ -141,9 +141,9 @@ export const registerShellActions = (): void => {
 		id: 'mail-to',
 		type: 'contact-list'
 	});
-	registerActions<MailToReceiversActionType>({
-		action: mailToReceiversAction,
-		id: 'mail-to-receivers',
-		type: 'contact-list'
+	registerActions<MailToRecipientsActionType>({
+		action: mailToRecipientsAction,
+		id: 'mail-to',
+		type: 'recipients'
 	});
 };

--- a/src/app-utils/register-shell-actions.ts
+++ b/src/app-utils/register-shell-actions.ts
@@ -7,7 +7,7 @@
 import { SyntheticEvent } from 'react';
 
 import { Action, ACTION_TYPES, NewAction, registerActions, t } from '@zextras/carbonio-shell-ui';
-import { isArray, some } from 'lodash';
+import { isArray, isString, some } from 'lodash';
 
 import { ParticipantRole } from '../carbonio-ui-commons/constants/participants';
 import { EditViewActions, MAIL_APP_ID } from '../constants';
@@ -15,6 +15,13 @@ import { mailToSharedFunction } from '../integrations/shared-functions';
 import { createEditBoard } from '../views/app/detail-panel/edit/edit-view-board';
 
 interface MailToActionType extends Action {
+	id: string;
+	icon: string;
+	execute: (e: SyntheticEvent<HTMLElement, Event> | KeyboardEvent) => void;
+	disabled: boolean;
+}
+
+interface MailToReceiversActionType extends Action {
 	id: string;
 	icon: string;
 	execute: (e: SyntheticEvent<HTMLElement, Event> | KeyboardEvent) => void;
@@ -50,6 +57,59 @@ export const mailToAction = (contacts: unknown): MailToActionType => ({
 	disabled: isArray(contacts) && some(contacts, (contact) => !contact.address)
 });
 
+export type Receiver = {
+	email: string;
+	name: string;
+	carbonCopy?: boolean;
+};
+
+type MailDescription = {
+	subject: string;
+	receivers: Receiver[];
+};
+
+function isMailDescription(mailDescription: unknown): mailDescription is MailDescription {
+	return (
+		typeof mailDescription === 'object' &&
+		mailDescription !== null &&
+		'subject' in mailDescription &&
+		'receivers' in mailDescription &&
+		isArray(mailDescription.receivers) &&
+		mailDescription.receivers.every(
+			(receiver) =>
+				typeof receiver === 'object' &&
+				receiver !== null &&
+				'email' in receiver &&
+				'name' in receiver
+		) &&
+		isString(mailDescription.subject)
+	);
+}
+
+export const mailToReceiversActionOnClick = (
+	e: SyntheticEvent<HTMLElement, Event> | KeyboardEvent,
+	mailDescription: unknown
+): void => {
+	e?.preventDefault?.();
+	if (isMailDescription(mailDescription)) {
+		const participants = mailDescription.receivers.map((receiver) => ({
+			type: receiver.carbonCopy ? ParticipantRole.CARBON_COPY : ParticipantRole.TO,
+			address: receiver.email,
+			fullName: receiver.name
+		}));
+
+		mailToSharedFunction(participants, mailDescription.subject);
+	}
+};
+
+export const mailToReceiversAction = (mailDescription: unknown): MailToReceiversActionType => ({
+	id: 'mail-to',
+	label: t('label.send_mail', 'Send Mail'),
+	icon: 'MailModOutline',
+	execute: (e) => mailToReceiversActionOnClick(e, mailDescription),
+	disabled: false
+});
+
 export const newEmailActionOnClick = (
 	e: SyntheticEvent<HTMLElement, Event> | KeyboardEvent
 ): void => {
@@ -79,6 +139,11 @@ export const registerShellActions = (): void => {
 	registerActions<MailToActionType>({
 		action: mailToAction,
 		id: 'mail-to',
+		type: 'contact-list'
+	});
+	registerActions<MailToReceiversActionType>({
+		action: mailToReceiversAction,
+		id: 'mail-to-receivers',
 		type: 'contact-list'
 	});
 };

--- a/src/app-utils/register-shell-actions.ts
+++ b/src/app-utils/register-shell-actions.ts
@@ -107,7 +107,7 @@ export const mailToRecipientsAction = (mailDescription: unknown): MailToRecipien
 	label: t('label.send_mail', 'Send Mail'),
 	icon: 'MailModOutline',
 	execute: (e) => mailToRecipientsActionOnClick(e, mailDescription),
-	disabled: false
+	disabled: !isMailDescription(mailDescription) || mailDescription.recipients.length === 0
 });
 
 export const newEmailActionOnClick = (

--- a/src/app-utils/tests/register-shell-actions.test.ts
+++ b/src/app-utils/tests/register-shell-actions.test.ts
@@ -39,6 +39,49 @@ describe('registerShellActions', () => {
 	});
 });
 
+describe('mailToRecipientsAction', () => {
+	it('should return an object with disabled property set to false when arg is of MailDescription type', () => {
+		const expectedMailToActionResult = {
+			id: 'mail-to',
+			label: 'label.send_mail',
+			icon: 'MailModOutline',
+			execute: expect.any(Function),
+			disabled: false
+		};
+		expect(
+			mailToRecipientsAction({
+				recipients: [{ email: 'anymail', name: 'any', carbonCopy: false }],
+				subject: 'any'
+			})
+		).toMatchObject(expectedMailToActionResult);
+	});
+	it('should return an object with disabled property set to true when there is no recipient', () => {
+		const expectedMailToActionResult = {
+			id: 'mail-to',
+			label: 'label.send_mail',
+			icon: 'MailModOutline',
+			execute: expect.any(Function),
+			disabled: true
+		};
+		expect(
+			mailToRecipientsAction({
+				recipients: [],
+				subject: 'any'
+			})
+		).toMatchObject(expectedMailToActionResult);
+	});
+	it('should return an object with disabled property set to true when arg is not of MailDescription type', () => {
+		const expectedMailToActionResult = {
+			id: 'mail-to',
+			label: 'label.send_mail',
+			icon: 'MailModOutline',
+			execute: expect.any(Function),
+			disabled: true
+		};
+		expect(mailToRecipientsAction({})).toMatchObject(expectedMailToActionResult);
+	});
+});
+
 describe('mailToAction', () => {
 	it('should return an object with disabled property set to false when contacts is not an array', () => {
 		const expectedMailToActionResult = {

--- a/src/app-utils/tests/register-shell-actions.test.ts
+++ b/src/app-utils/tests/register-shell-actions.test.ts
@@ -10,6 +10,8 @@ import * as sharedFunctions from '../../integrations/shared-functions';
 import {
 	mailToAction,
 	mailToActionOnClick,
+	mailToRecipientsAction,
+	mailToRecipientsActionOnClick,
 	newEmailAction,
 	newEmailActionOnClick,
 	registerShellActions
@@ -23,6 +25,11 @@ describe('registerShellActions', () => {
 			action: expect.any(Function),
 			id: 'mail-to',
 			type: 'contact-list'
+		});
+		expect(registerActions).toHaveBeenCalledWith({
+			action: expect.any(Function),
+			id: 'mail-to',
+			type: 'recipients'
 		});
 		expect(registerActions).toHaveBeenCalledWith({
 			action: expect.any(Function),
@@ -74,6 +81,30 @@ describe('mailToActionOnClick', () => {
 		];
 		expect(sharedFunctions.mailToSharedFunction).toHaveBeenCalledWith(
 			expectedMailToSharedFunctionArgument
+		);
+	});
+});
+
+describe('mailToRecipientsActionOnClick', () => {
+	it('when called it should invoke mailToSharedFunction with the correct parameter', async () => {
+		jest.spyOn(sharedFunctions, 'mailToSharedFunction');
+
+		const recipients = [
+			{ email: 'anymail', name: 'any', carbonCopy: false },
+			{ email: 'anothermail', name: 'another', carbonCopy: true }
+		];
+
+		mailToRecipientsActionOnClick({} as KeyboardEvent, {
+			recipients,
+			subject: 'any subject'
+		});
+		const expectedRecipients = [
+			{ address: 'anymail', fullName: 'any', type: 't' },
+			{ address: 'anothermail', fullName: 'another', type: 'c' }
+		];
+		expect(sharedFunctions.mailToSharedFunction).toHaveBeenCalledWith(
+			expectedRecipients,
+			'any subject'
 		);
 	});
 });

--- a/src/integrations/shared-functions.ts
+++ b/src/integrations/shared-functions.ts
@@ -9,14 +9,14 @@ import { EditorPrefillData } from '../types';
 import type { Participant } from '../types';
 import { createEditBoard } from '../views/app/detail-panel/edit/edit-view-board';
 
-export const mailToSharedFunction: (contacts: Array<Participant>, subject?: string) => void = (
-	contacts,
+export const mailToSharedFunction: (recipients: Array<Participant>, subject?: string) => void = (
+	recipients,
 	subject
 ) => {
 	createEditBoard({
 		action: EditViewActions.MAIL_TO,
 		compositionData: {
-			recipients: contacts,
+			recipients,
 			subject
 		}
 	});

--- a/src/integrations/shared-functions.ts
+++ b/src/integrations/shared-functions.ts
@@ -9,11 +9,15 @@ import { EditorPrefillData } from '../types';
 import type { Participant } from '../types';
 import { createEditBoard } from '../views/app/detail-panel/edit/edit-view-board';
 
-export const mailToSharedFunction: (contacts: Array<Participant>) => void = (contacts) => {
+export const mailToSharedFunction: (contacts: Array<Participant>, subject?: string) => void = (
+	contacts,
+	subject
+) => {
 	createEditBoard({
 		action: EditViewActions.MAIL_TO,
 		compositionData: {
-			recipients: contacts
+			recipients: contacts,
+			subject
 		}
 	});
 };

--- a/src/store/editor/editor-generators.ts
+++ b/src/store/editor/editor-generators.ts
@@ -22,8 +22,7 @@ import {
 	getAddressOwnerAccount,
 	getDefaultIdentity,
 	getIdentityFromParticipant,
-	getRecipientReplyIdentity,
-	getRecipients
+	getRecipientReplyIdentity
 } from '../../helpers/identities';
 import { getFromParticipantFromMessage } from '../../helpers/messages';
 import { getMailBodyWithSignature } from '../../helpers/signatures';

--- a/src/store/editor/editor-generators.ts
+++ b/src/store/editor/editor-generators.ts
@@ -22,7 +22,8 @@ import {
 	getAddressOwnerAccount,
 	getDefaultIdentity,
 	getIdentityFromParticipant,
-	getRecipientReplyIdentity
+	getRecipientReplyIdentity,
+	getRecipients
 } from '../../helpers/identities';
 import { getFromParticipantFromMessage } from '../../helpers/messages';
 import { getMailBodyWithSignature } from '../../helpers/signatures';
@@ -33,7 +34,8 @@ import {
 	MailsEditorV2,
 	UnsavedAttachment,
 	Participant,
-	EditorText
+	EditorText,
+	EditorRecipients
 } from '../../types';
 import {
 	extractBody,
@@ -138,6 +140,35 @@ const normalizeParticipants = (
 		? abstractParticipants.map((abstractParticipant) => normalizeParticipant(abstractParticipant))
 		: [];
 
+const byType =
+	(type: string) =>
+	(participant: Participant): boolean =>
+		participant.type === type;
+
+function getMsgRecipients(compositionData?: EditorPrefillData): EditorRecipients {
+	if (compositionData?.recipients) {
+		return {
+			to: compositionData.recipients.filter(byType(ParticipantRole.TO)),
+			cc: compositionData.recipients.filter(byType(ParticipantRole.CARBON_COPY)),
+			bcc: compositionData.recipients.filter(byType(ParticipantRole.BLIND_CARBON_COPY))
+		};
+	}
+
+	if (compositionData?.to) {
+		return {
+			to: normalizeParticipants(compositionData.to),
+			cc: [],
+			bcc: []
+		};
+	}
+
+	return {
+		to: [],
+		cc: [],
+		bcc: []
+	};
+}
+
 /**
  *
  */
@@ -148,9 +179,7 @@ export const generateIntegratedNewEditor = (compositionData?: EditorPrefillData)
 	const richText =
 		compositionData?.text?.[1] ?? `<p></p><div class="${LineType.SIGNATURE_CLASS}"></div>`;
 
-	const recipients: Array<Participant> = compositionData?.recipients
-		? compositionData.recipients
-		: normalizeParticipants(compositionData?.to);
+	const recipients = getMsgRecipients(compositionData);
 
 	const text = {
 		plainText,
@@ -179,11 +208,7 @@ export const generateIntegratedNewEditor = (compositionData?: EditorPrefillData)
 		savedAttachments: [],
 		isRichText,
 		isUrgent: false,
-		recipients: {
-			to: recipients ?? [],
-			cc: [],
-			bcc: []
-		},
+		recipients,
 		subject: compositionData?.subject ?? '',
 		text: textWithSignature,
 		requestReadReceipt: false,


### PR DESCRIPTION
With this PR a new type (recipients) of the mail-to action is registered. This type of action allows sending an email to many receivers (either as to or cc) and to specify a subject:

```javascript
const [mailTo, available] = getAction('recipients', 'mail-to', {
	recipients: [{
               email: "email@zextras.com",
               name: "Full Name",
               carbonCopy: true/false
        }],
	subject: "MySubject"
});
```