### PR TITLE
remove overflowX from HTML-message-renderer

### DIFF
--- a/src/commons/mail-message-renderer/html-message-renderer-container.tsx
+++ b/src/commons/mail-message-renderer/html-message-renderer-container.tsx
@@ -12,7 +12,7 @@ export const HtmlMessageRendererContainer = ({ html }: { html: string }): React.
 		width={'fit'}
 		height={'100%'}
 		data-testid="message-renderer-container"
-		style={{ overflowY: 'auto', overflowX: 'hidden', padding: '0.75rem 0px' }}
+		style={{ overflowY: 'auto', padding: '0.75rem 0px' }}
 		dangerouslySetInnerHTML={{
 			__html: html
 		}}


### PR DESCRIPTION
The overflowX style was removed from the HtmlMessageRendererContainer component in the html-message-renderer-container.tsx file.