### PR TITLE
fix: unwanted duplication of conversation messages

### DIFF
--- a/src/store/emails/actions/search-conv-action.ts
+++ b/src/store/emails/actions/search-conv-action.ts
@@ -9,7 +9,7 @@ import { map } from 'lodash';
 import { searchConvSoapApi } from '../../../api/search-conv-soap-api';
 import { API_REQUEST_STATUS } from '../../../constants';
 import { normalizeCompleteMailMessageFromSoap } from '../../../normalizations/normalize-message';
-import { SearchConvResponse } from '../../../types';
+import { NormalizedConversation, SearchConvResponse } from '../../../types';
 import {
 	updateMessages,
 	getConversationById,
@@ -22,7 +22,11 @@ function handleSearchConvResponse(conversationId: string, response: SearchConvRe
 	updateMessages(messages);
 	const convMessagesIds: Array<string> = map(response?.m ?? [], (msg) => msg.id);
 	const conversation = getConversationById(conversationId);
-	const updatedConversation = { ...conversation, id: conversationId, messages: convMessagesIds };
+	const updatedConversation: NormalizedConversation = {
+		...conversation,
+		id: conversationId,
+		messageIds: convMessagesIds
+	};
 	updateConversations([updatedConversation]);
 }
 

--- a/src/store/emails/hooks/tests/hooks.test.tsx
+++ b/src/store/emails/hooks/tests/hooks.test.tsx
@@ -51,7 +51,7 @@ function awaitDebounce(): void {
 }
 
 describe('Searches store hooks', () => {
-	describe('useCompleteConversation', () => {
+	describe('useCompleteConversationOrFetch', () => {
 		it('should retrieve the conversation if no data available', async () => {
 			const message = generateMessage({ id: '1', subject: 'Test Message 1' });
 			const conversation = generateConversation({

--- a/src/store/emails/sync-data-handler/tests/sync-data-handler-store.test.ts
+++ b/src/store/emails/sync-data-handler/tests/sync-data-handler-store.test.ts
@@ -10,10 +10,14 @@ import { getUserSettings, SoapNotify, useRefresh } from '@zextras/carbonio-shell
 import { useNotify } from '../../../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
 import { populateFoldersStore } from '../../../../carbonio-ui-commons/test/mocks/store/folders';
 import { normalizeConversations } from '../../../../normalizations/normalize-conversation';
-import { generateConversation } from '../../../../tests/generators/generateConversation';
+import {
+	generateConversation,
+	populateConversationInEmailStore
+} from '../../../../tests/generators/generateConversation';
 import { generateMessage } from '../../../../tests/generators/generateMessage';
 import { SoapConversation, SoapIncompleteMessage, SoapMailMessage } from '../../../../types';
 import { useSyncDataHandler } from '../../../../views/sidebar/commons/sync-data-handler-hooks';
+import { useCompleteConversationOrFetch } from '../../hooks/hooks';
 import {
 	handleNotifyMessagesCreated,
 	setConversationsInEmailStore,
@@ -169,6 +173,22 @@ describe('sync-data-handler', () => {
 		});
 
 		describe('getOrderedMessagesForConversation', () => {
+			it('should not duplicate messages', async () => {
+				await waitFor(() =>
+					populateConversationInEmailStore({
+						conversationParams: { id: '123' },
+						messageIds: ['2']
+					})
+				);
+
+				const newMessage = { ...generateMessage({ id: '2' }), conversation: '123' };
+				handleNotifyMessagesCreated([newMessage]);
+				const { result } = renderHook(() => useCompleteConversationOrFetch('123'));
+				await waitFor(async () => {
+					expect(result.current.conversation.messageIds).toEqual(['2']);
+				});
+			});
+
 			it('should return messages in descending order when sortOrder is dateDesc', async () => {
 				(getUserSettings as jest.Mock).mockReturnValue({
 					prefs: { zimbraPrefConversationOrder: 'dateDesc' }

--- a/src/store/emails/sync-data-handler/utils.ts
+++ b/src/store/emails/sync-data-handler/utils.ts
@@ -174,9 +174,9 @@ function handleNotifyMessagesCreated(
 	): Array<string> {
 		const sortOrder = getUserSettings()?.prefs?.zimbraPrefConversationOrder || 'dateDesc';
 		if (sortOrder === 'dateDesc') {
-			return [message.id, ...convMessagesIds];
+			return Array.from(new Set([message.id, ...convMessagesIds]));
 		}
-		return [...convMessagesIds, message.id];
+		return Array.from(new Set([...convMessagesIds, message.id]));
 	}
 
 	function addMessagesToConversation(state: EmailsStoreState): void {


### PR DESCRIPTION
- Ensure unique message IDs when updating conversation messages in `search-conv-action.ts`.
- Update test descriptions and add a test case to verify no duplication of messages.
- Modify `getOrderedMessagesForConversation` to use `Set` for unique message IDs.