### PR TITLE
fix(conversations): handle missing conversation items

### DIFF
--- a/src/views/app/folder-panel/conversations/conversation-list-component.tsx
+++ b/src/views/app/folder-panel/conversations/conversation-list-component.tsx
@@ -31,6 +31,9 @@ const DragItems = ({ draggedIds }: { draggedIds: Record<string, boolean> }): Rea
 	<>
 		{map(Object.keys(draggedIds), (draggedItemId) => {
 			const conversation = getConversationById(draggedItemId);
+
+			if (!conversation) return <></>;
+
 			return (
 				<ConversationListItemComponent
 					conversationId={conversation.id}

--- a/src/views/app/folder-panel/messages/message-list-drag-component.tsx
+++ b/src/views/app/folder-panel/messages/message-list-drag-component.tsx
@@ -19,6 +19,9 @@ export const DragItems = ({
 	<>
 		{map(Object.keys(draggedIds), (draggedItemId) => {
 			const item = getMessageById(draggedItemId);
+
+			if (!item) return <></>;
+
 			return (
 				<MessageListItem
 					message={item}


### PR DESCRIPTION
Ensure the component gracefully handles cases where a conversation item is not found by returning an empty fragment. This prevents potential errors when rendering the conversation list.