### PR TITLE
refactor(search-panel): update hook for message fetching

### DIFF
--- a/src/views/search/panel/conversation/search-conversation-message-panel.tsx
+++ b/src/views/search/panel/conversation/search-conversation-message-panel.tsx
@@ -7,7 +7,7 @@ import React, { useCallback } from 'react';
 
 import { Padding } from '@zextras/carbonio-design-system';
 
-import { useMessageById } from '../../../../store/emails/store';
+import { useCompleteMessageOrFetch } from '../../../../store/emails/hooks/hooks';
 import MailPreview from '../../../app/detail-panel/preview/mail-preview';
 
 export type SearchConversationMessagePreviewProps = {
@@ -23,7 +23,7 @@ export const SearchConversationMessagePanel = ({
 	isAlone,
 	isInsideExtraWindow
 }: SearchConversationMessagePreviewProps): React.JSX.Element => {
-	const message = useMessageById(convMessageId);
+	const { message } = useCompleteMessageOrFetch(convMessageId);
 
 	const messagePreviewFactory = useCallback(
 		() => (


### PR DESCRIPTION
Updated the hook used for fetching messages in the SearchConversationMessagePanel component to use
`useCompleteMessageOrFetch` instead of `useMessageById`.