### PR TITLE
[CO-1800]:  cannot open the emails in a separated window more than once

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"lint-check": "npm run lint-errors; npm run type-check",
 		"test": "TZ=Europe/Rome jest --testTimeout=20000 --maxWorkers=50%",
 		"build:dev": "sdk build --dev --pkgRel $(date +%s)",
-		"dev-deploy": "sdk build && sdk deploy"
+		"dev-deploy": "sdk build --dev --pkgRel $(date +%s) && sdk deploy"
 	},
 	"files": [
 		"src/types/"

--- a/src/views/app/extra-windows/extra-window-manager.tsx
+++ b/src/views/app/extra-windows/extra-window-manager.tsx
@@ -64,12 +64,31 @@ const ExtraWindowsManager = ({ children }: { children: ReactNode }): React.JSX.E
 		[windowsData]
 	);
 
+	function updateWindowData(
+		currentData: Array<ExtraWindowsCreationResult>,
+		updatedWindowData: ExtraWindowsCreationResult
+	): Array<ExtraWindowsCreationResult> {
+		const updatedData = [...currentData];
+		currentData.forEach((data, index) => {
+			if (data.id === updatedWindowData.id) {
+				updatedData[index] = updatedWindowData;
+			}
+		});
+		return updatedData;
+	}
+
 	/**
 	 * Adds a new window to the state
 	 * @param addedWindowData
 	 */
 	const addWindow = useCallback((addedWindowData: ExtraWindowsCreationResult): void => {
 		setWindowsData((currentData) => {
+			// CO-1800: in strict mode this function may be called twice.
+			// We should avoid addiing the same window twice.
+			const alreadyExists = currentData.some((data) => data.id === addedWindowData.id);
+			if (alreadyExists) {
+				return updateWindowData(currentData, addedWindowData);
+			}
 			currentData.push(addedWindowData);
 			return [...currentData];
 		});
@@ -80,15 +99,7 @@ const ExtraWindowsManager = ({ children }: { children: ReactNode }): React.JSX.E
 	 * @param updatedWindowData
 	 */
 	const updateWindow = useCallback((updatedWindowData: ExtraWindowsCreationResult): void => {
-		setWindowsData((currentData) => {
-			const updatedData = [...currentData];
-			currentData.forEach((data, index) => {
-				if (data.id === updatedWindowData.id) {
-					updatedData[index] = updatedWindowData;
-				}
-			});
-			return updatedData;
-		});
+		setWindowsData((currentData) => updateWindowData(currentData, updatedWindowData));
 	}, []);
 
 	/**

--- a/src/views/app/extra-windows/new-window.js
+++ b/src/views/app/extra-windows/new-window.js
@@ -294,7 +294,9 @@ class NewWindow extends React.PureComponent {
 			} else {
 				// Remove any existing content
 				const staticContainer = this.window.document.getElementById('new-window-container-static');
-				this.window.document.body.removeChild(staticContainer);
+				if (staticContainer) {
+					this.window.document.body.removeChild(staticContainer);
+				}
 			}
 
 			// If specified, copy styles from parent window's document.


### PR DESCRIPTION
This is only happening when mails-ui is built in dev mode, in that case ExtraWindowManager addWindow function may be called twice, and the second call will add the same window again. This breaks other code that is not expecting the same window (same id) to be initialized two times.
The fix avoids readding a window if the same id already exists in the windows registry.

**Note**: this problem will never happen in production because it is related to the React strict mode, that is disabled in production.