### PR TITLE
refactor(html-message-renderer): simplify image handling

### DIFF
--- a/src/commons/mail-message-renderer/html-message-renderer.tsx
+++ b/src/commons/mail-message-renderer/html-message-renderer.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button, Row } from '@zextras/carbonio-design-system';
 import { editSettings, t, useUserSettings } from '@zextras/carbonio-shell-ui';
-import { filter, forEach, isArray, reduce, some } from 'lodash';
+import { filter, forEach, isArray, some } from 'lodash';
 import { Trans } from 'react-i18next';
 
 import { BannerMessageTruncated } from './banner-message-truncated';
@@ -18,7 +18,7 @@ import { getAttachmentParts } from '../../helpers/attachments';
 import { getNoIdentityPlaceholder } from '../../helpers/identities';
 import { BodyPart, MailMessage } from '../../types';
 import { getOriginalHtmlContent, getQuotedTextFromOriginalContent } from '../get-quoted-text-util';
-import { _CI_REGEX, _CI_SRC_REGEX, isAvailableInTrusteeList } from '../utils';
+import { buildImageMap, isAvailableInTrusteeList, updateImageSrc } from '../utils';
 import { ShadowDomWrapper } from './shadow-dom-wrapper';
 import { getFullMessageEmailStoreAction } from '../../store/emails/actions/get-message';
 
@@ -129,32 +129,15 @@ export const HtmlMessageRenderer = ({ message }: HtmlMessageRendererType): React
 		() => showExternalImage && displayBanner,
 		[displayBanner, showExternalImage]
 	);
-
 	const msgId = message.id;
+
 	const contentWithImages = useMemo(() => {
-		const imgMap = reduce(
-			parts,
-			(r, v) => {
-				if (!_CI_REGEX.test(v.ci ?? '')) return r;
-				r[_CI_REGEX.exec(v.ci ?? '')?.[1] ?? ''] = v;
-				return r;
-			},
-			{} as any
-		);
-		forEach(images, (p: HTMLImageElement) => {
-			if (p.hasAttribute('dfsrc') && showImage) {
-				p.setAttribute('src', p.getAttribute('dfsrc') ?? '');
-			}
-			if (!_CI_SRC_REGEX.test(p.src)) return;
-			const ci = _CI_SRC_REGEX.exec(p.getAttribute('src') ?? '')?.[1] ?? '';
-			if (imgMap[ci]) {
-				const part = imgMap[ci];
-				p.setAttribute('pnsrc', p.getAttribute('src') ?? '');
-				p.setAttribute('src', `/service/home/~/?auth=co&id=${msgId}&part=${part.name}`);
-			}
+		const imgMap = buildImageMap(parts);
+		forEach(images, (img) => {
+			updateImageSrc(img, imgMap, showImage, msgId);
 		});
-		return htmlDoc.body.innerHTML;
-	}, [htmlDoc.body.innerHTML, images, msgId, parts, showImage]);
+		return htmlDoc.documentElement.outerHTML;
+	}, [htmlDoc.documentElement.outerHTML, images, msgId, parts, showImage]);
 
 	const loadMessage = async (): Promise<void> => {
 		setIsLoadingMessage(true);

--- a/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
@@ -236,4 +236,30 @@ describe('HTML message renderer', () => {
 			expect(shadowParagraph?.textContent).toContain('font-size: 20px');
 		});
 	});
+
+	it('it should keep the html with all its properties', async () => {
+		const message = {
+			id: '1',
+			body: {
+				contentType: 'text/html',
+				content: `<style>.my-styled-paragraph {color: purple;font-size: 20px;}</style><p class="my-styled-paragraph">test component</p>
+    `
+			},
+			truncated: false
+		} as unknown as MailMessage;
+
+		setupTest(<HtmlMessageRenderer message={message} />, {
+			initialEntries: ['/mails']
+		});
+
+		const shadowDomWrapper = screen.getByTestId('shadow-dom-wrapper');
+		const { shadowRoot } = shadowDomWrapper;
+
+		// eslint-disable-next-line testing-library/no-node-access
+		const shadowParagraph = shadowRoot?.querySelector('p');
+
+		expect(shadowParagraph).toBeInTheDocument();
+
+		expect(shadowParagraph?.outerHTML).toBe('<p class="my-styled-paragraph">test component</p>');
+	});
 });

--- a/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
@@ -5,14 +5,14 @@
  */
 import React from 'react';
 
-import { act, screen, waitFor, within } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 import { createSoapAPIInterceptor } from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
 import { updateMessages } from '../../../store/emails/store';
 import { generateCompleteMessageFromAPI } from '../../../tests/generators/api';
 import { generateMessage } from '../../../tests/generators/generateMessage';
-import { GetMsgRequest, GetMsgResponse, MailMessage } from '../../../types';
+import { GetMsgRequest, GetMsgResponse } from '../../../types';
 import { HtmlMessageRenderer } from '../html-message-renderer';
 
 describe('HTML message renderer', () => {
@@ -206,44 +206,6 @@ describe('HTML message renderer', () => {
 			await interceptor;
 			await act(async () => {
 				expect(screen.queryByText('warningBanner.truncatedMessage.button')).not.toBeInTheDocument();
-			});
-		});
-
-		it('it should keep the css style when available', async () => {
-			const message = {
-				id: '1',
-				body: {
-					contentType: 'text/html',
-					content:
-						'<style>.styleclass{color: red; font-family: "Comic Sans";}</style><p class="styleclass">Initial body</p>'
-				},
-				truncated: false
-			} as unknown as MailMessage;
-
-			setupTest(<HtmlMessageRenderer message={message} />, {
-				initialEntries: ['/mails']
-			});
-
-			const shadowDomWrapper = screen.getByTestId('shadow-dom-wrapper');
-			expect(shadowDomWrapper).toBeInTheDocument();
-
-			const { shadowRoot } = shadowDomWrapper;
-
-			// const paragraph = shadowRoot?.querySelector('.styleclass');
-			// expect(paragraph).toHaveTextContent('Initial body');
-
-			// Use `within` to query elements inside the shadowRoot
-			const shadowParagraph = within(shadowRoot!).getByText('Initial body');
-			expect(shadowParagraph).toBeInTheDocument();
-
-			// Check if color style is red and font-family is Comic Sans using toHaveStyle
-			await waitFor(() => {
-				const computedStyle = getComputedStyle(shadowParagraph!);
-				console.clear();
-				console.log('computedStyle:', computedStyle);
-				expect(computedStyle.color).toBe('red'); // Check the color
-				// eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
-				expect(computedStyle.fontFamily).toMatch(/Comic Sans/i); // Check font-family
 			});
 		});
 	});

--- a/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
@@ -5,14 +5,14 @@
  */
 import React from 'react';
 
-import { act, screen } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 
 import { createSoapAPIInterceptor } from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
 import { updateMessages } from '../../../store/emails/store';
 import { generateCompleteMessageFromAPI } from '../../../tests/generators/api';
 import { generateMessage } from '../../../tests/generators/generateMessage';
-import { GetMsgRequest, GetMsgResponse } from '../../../types';
+import { GetMsgRequest, GetMsgResponse, MailMessage } from '../../../types';
 import { HtmlMessageRenderer } from '../html-message-renderer';
 
 describe('HTML message renderer', () => {
@@ -206,6 +206,44 @@ describe('HTML message renderer', () => {
 			await interceptor;
 			await act(async () => {
 				expect(screen.queryByText('warningBanner.truncatedMessage.button')).not.toBeInTheDocument();
+			});
+		});
+
+		it('it should keep the css style when available', async () => {
+			const message = {
+				id: '1',
+				body: {
+					contentType: 'text/html',
+					content:
+						'<style>.styleclass{color: red; font-family: "Comic Sans";}</style><p class="styleclass">Initial body</p>'
+				},
+				truncated: false
+			} as unknown as MailMessage;
+
+			setupTest(<HtmlMessageRenderer message={message} />, {
+				initialEntries: ['/mails']
+			});
+
+			const shadowDomWrapper = screen.getByTestId('shadow-dom-wrapper');
+			expect(shadowDomWrapper).toBeInTheDocument();
+
+			const { shadowRoot } = shadowDomWrapper;
+
+			// const paragraph = shadowRoot?.querySelector('.styleclass');
+			// expect(paragraph).toHaveTextContent('Initial body');
+
+			// Use `within` to query elements inside the shadowRoot
+			const shadowParagraph = within(shadowRoot!).getByText('Initial body');
+			expect(shadowParagraph).toBeInTheDocument();
+
+			// Check if color style is red and font-family is Comic Sans using toHaveStyle
+			await waitFor(() => {
+				const computedStyle = getComputedStyle(shadowParagraph!);
+				console.clear();
+				console.log('computedStyle:', computedStyle);
+				expect(computedStyle.color).toBe('red'); // Check the color
+				// eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
+				expect(computedStyle.fontFamily).toMatch(/Comic Sans/i); // Check font-family
 			});
 		});
 	});

--- a/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
@@ -12,7 +12,7 @@ import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
 import { updateMessages } from '../../../store/emails/store';
 import { generateCompleteMessageFromAPI } from '../../../tests/generators/api';
 import { generateMessage } from '../../../tests/generators/generateMessage';
-import { GetMsgRequest, GetMsgResponse } from '../../../types';
+import { GetMsgRequest, GetMsgResponse, MailMessage } from '../../../types';
 import { HtmlMessageRenderer } from '../html-message-renderer';
 
 describe('HTML message renderer', () => {
@@ -207,6 +207,33 @@ describe('HTML message renderer', () => {
 			await act(async () => {
 				expect(screen.queryByText('warningBanner.truncatedMessage.button')).not.toBeInTheDocument();
 			});
+		});
+
+		it('it should keep the css style when available', async () => {
+			const message = {
+				id: '1',
+				body: {
+					contentType: 'text/html',
+					content: `<style>.my-styled-paragraph {color: purple;font-size: 20px;}</style><p class="my-styled-paragraph">test component</p>
+    `
+				},
+				truncated: false
+			} as unknown as MailMessage;
+
+			setupTest(<HtmlMessageRenderer message={message} />, {
+				initialEntries: ['/mails']
+			});
+
+			const shadowDomWrapper = screen.getByTestId('shadow-dom-wrapper');
+			const { shadowRoot } = shadowDomWrapper;
+
+			// eslint-disable-next-line testing-library/no-node-access
+			const shadowParagraph = shadowRoot?.querySelector('style');
+
+			expect(shadowParagraph).toBeInTheDocument();
+
+			expect(shadowParagraph?.textContent).toContain('color: purple');
+			expect(shadowParagraph?.textContent).toContain('font-size: 20px');
 		});
 	});
 });

--- a/src/commons/tests/utilis.test.tsx
+++ b/src/commons/tests/utilis.test.tsx
@@ -6,8 +6,10 @@
 
 import * as shell from '../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
 import defaultSettings from '../../carbonio-ui-commons/test/mocks/settings/default-settings';
+import { generateMessage } from '../../tests/generators/generateMessage';
+import { MailMessagePart } from '../../types';
 import { convertHtmlToPlainText } from '../utilities';
-import { getTimeLabel } from '../utils';
+import { buildImageMap, getTimeLabel, updateImageSrc } from '../utils';
 
 describe('getTimeLabel', () => {
 	describe('the date is formatted using local', () => {
@@ -106,5 +108,115 @@ describe('convertHtmlToPlainText', () => {
 				'lorem ipsum <img src="https://www.zextras.com/wp-content/uploads/2020/10/Logo_Zextras_2020.png" alt="Zextras">'
 			)
 		).toBe('lorem ipsum ');
+	});
+});
+
+describe('updateImageSrc', () => {
+	let img: HTMLImageElement;
+	let imgMap: Record<string, { name: string }>;
+	let msgId: string;
+
+	beforeEach(() => {
+		img = document.createElement('img');
+		imgMap = { cid123: { name: 'image1.png' } };
+		msgId = 'test-message-id';
+	});
+
+	it('should update src with dfsrc value when showImage is true', () => {
+		img.setAttribute('dfsrc', 'https://example.com/image.png');
+		updateImageSrc(img, imgMap, true, msgId);
+		expect(img).toHaveAttribute('src', 'https://example.com/image.png');
+	});
+
+	it('should not update src if dfsrc is missing', () => {
+		img.setAttribute('src', 'https://example.com/original.png');
+		updateImageSrc(img, imgMap, true, msgId);
+		expect(img).toHaveAttribute('src', 'https://example.com/original.png');
+	});
+
+	it('should not update src if showImage is false', () => {
+		img.setAttribute('dfsrc', 'https://example.com/image.png');
+		img.setAttribute('src', 'https://example.com/original.png');
+		updateImageSrc(img, imgMap, false, msgId);
+		expect(img).toHaveAttribute('src', 'https://example.com/original.png');
+	});
+
+	it('should update src if extracted content ID is found in imgMap', () => {
+		img.setAttribute('src', 'cid:cid123');
+		updateImageSrc(img, imgMap, true, msgId);
+		expect(img).toHaveAttribute('pnsrc', 'cid:cid123');
+		expect(img).toHaveAttribute(
+			'src',
+			'/service/home/~/?auth=co&id=test-message-id&part=image1.png'
+		);
+	});
+
+	it('should not update src if extracted content ID is not in imgMap', () => {
+		img.setAttribute('src', 'cid:unknown123');
+		updateImageSrc(img, imgMap, true, msgId);
+		expect(img).toHaveAttribute('src', 'cid:unknown123');
+	});
+
+	it('should set pnsrc attribute to previous src before updating', () => {
+		img.setAttribute('src', 'cid:cid123');
+		updateImageSrc(img, imgMap, true, msgId);
+		expect(img).toHaveAttribute('pnsrc', 'cid:cid123');
+	});
+
+	it('should not update src if no match is found in _CI_SRC_REGEX', () => {
+		img.setAttribute('src', 'https://example.com/not-a-cid.png');
+		updateImageSrc(img, imgMap, true, msgId);
+		expect(img).toHaveAttribute('src', 'https://example.com/not-a-cid.png');
+	});
+});
+
+describe('buildImageMap', () => {
+	test('should return correct map when ci values match regex', () => {
+		const parts = [
+			{ ci: '<ci-123>', name: 'part1' },
+			{ ci: '<ci-456>', name: 'part2' }
+		] as MailMessagePart[];
+
+		const expected = {
+			'ci-123': { ci: '<ci-123>', name: 'part1' },
+			'ci-456': { ci: '<ci-456>', name: 'part2' }
+		};
+
+		expect(buildImageMap(parts)).toEqual(expected);
+	});
+
+	test('should return an empty object when no ci values match regex', () => {
+		const parts = [
+			{ ci: 'invalid-123', name: 'part1' },
+			{ ci: 'another-invalid', name: 'part2' }
+		] as MailMessagePart[];
+
+		expect(buildImageMap(parts)).toEqual({});
+	});
+
+	test('should return an empty object when ci is missing or null', () => {
+		const parts = [
+			{ ci: null, name: 'part1' },
+			{ ci: undefined, name: 'part2' }
+		] as MailMessagePart[];
+
+		expect(buildImageMap(parts)).toEqual({});
+	});
+
+	test('should overwrite duplicate keys with the last occurrence', () => {
+		const parts = [
+			{ ci: '<ci-123>', name: 'part1' },
+			{ ci: '<ci-123>', name: 'part2' }
+		] as MailMessagePart[];
+
+		const expected = {
+			'ci-123': { ci: '<ci-123>', name: 'part2' }
+		};
+
+		expect(buildImageMap(parts)).toEqual(expected);
+	});
+
+	test('should handle an empty array input', () => {
+		expect(buildImageMap([])).toEqual({});
 	});
 });

--- a/src/commons/utils.ts
+++ b/src/commons/utils.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { Account, getUserSettings, t } from '@zextras/carbonio-shell-ui';
-import { find, isArray } from 'lodash';
+import { find, isArray, reduce } from 'lodash';
 import moment from 'moment';
 
-import type { Participant } from '../types';
+import type { MailMessagePart, Participant } from '../types';
 
 export const getTimeLabel = (date: number): string => {
 	const { zimbraPrefLocale = 'en' } = getUserSettings().prefs;
@@ -131,3 +131,40 @@ export const replaceLinkToAnchor = (content: string): string => {
 		return url;
 	});
 };
+
+/**
+ * Builds a map of image content IDs to their corresponding mail message parts.
+ *
+ */
+export function buildImageMap(parts: Array<MailMessagePart>): Record<string, MailMessagePart> {
+	return reduce(
+		parts,
+		(acc, part) => {
+			const match = _CI_REGEX.exec(part.ci ?? '');
+			// eslint-disable-next-line no-param-reassign
+			if (match) acc[match[1]] = part;
+			return acc;
+		},
+		{} as Record<string, MailMessagePart>
+	);
+}
+
+export function updateImageSrc(
+	img: HTMLImageElement,
+	imgMap: Record<string, { name: string }>,
+	showImage: boolean,
+	msgId: string
+): void {
+	if (img.hasAttribute('dfsrc') && showImage) {
+		img.setAttribute('src', img.getAttribute('dfsrc') ?? '');
+	}
+
+	const match = _CI_SRC_REGEX.exec(img.getAttribute('src') ?? '');
+	if (!match) return;
+
+	const ci = match[1];
+	if (imgMap[ci]) {
+		img.setAttribute('pnsrc', img.getAttribute('src') ?? '');
+		img.setAttribute('src', `/service/home/~/?auth=co&id=${msgId}&part=${imgMap[ci].name}`);
+	}
+}


### PR DESCRIPTION
- Removed unused `reduce` import from `html-message-renderer.tsx`
- Replaced inline image handling logic with `buildImageMap` and `updateImageSrc`
- Updated `contentWithImages` to use `htmlDoc.documentElement.outerHTML`

test(utils): add tests for image handling functions

- Added tests for `updateImageSrc` in `utilis.test.tsx`
- Added tests for `buildImageMap` in `utilis.test.tsx`

feat(utils): add image handling functions

- Added `buildImageMap` function to `utils.ts`
- Added `updateImageSrc` function to `utils.ts`