### PR TITLE
feat: [CO-1560] integrate i18next for translation support in edit-attachments-block

### DIFF
--- a/src/views/app/detail-panel/edit/edit-attachments-block.tsx
+++ b/src/views/app/detail-panel/edit/edit-attachments-block.tsx
@@ -88,7 +88,7 @@ export const EditAttachmentsBlock: FC<{
 											<Text color="primary">
 												{t('label.show_all_attachments', {
 													count: allAttachments.length,
-													defaultValue_other: 'Show all {{count}} attachments'
+													defaultValue: 'Show all {{count}} attachments'
 												})}
 											</Text>
 										</Padding>

--- a/src/views/app/detail-panel/edit/edit-attachments-block.tsx
+++ b/src/views/app/detail-panel/edit/edit-attachments-block.tsx
@@ -6,8 +6,8 @@
 import React, { FC, ReactElement, useMemo, useState } from 'react';
 
 import { Container, Icon, Link, Padding, Row, Text } from '@zextras/carbonio-design-system';
-import { t } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
+import { useTranslation } from 'react-i18next';
 
 import { AttachmentPreview } from './attachment-preview';
 import * as StyledComp from './parts/edit-view-styled-components';
@@ -18,6 +18,7 @@ export const EditAttachmentsBlock: FC<{
 	editorId: MailsEditorV2['id'];
 	setLargeFileUploadInfoBannerVisible: (visible: boolean) => void;
 }> = ({ editorId, setLargeFileUploadInfoBannerVisible }): ReactElement => {
+	const [t] = useTranslation();
 	const [expanded, setExpanded] = useState(false);
 	const { savedStandardAttachments, unsavedStandardAttachments, removeStandardAttachments } =
 		useEditorAttachments(editorId);

--- a/src/views/app/detail-panel/preview/attachments-block.tsx
+++ b/src/views/app/detail-panel/preview/attachments-block.tsx
@@ -715,8 +715,7 @@ const AttachmentsBlock = ({
 									<Text color="primary">
 										{t('label.show_all_attachments', {
 											count: attachmentsCount,
-											defaultValue_one: 'Show attachment',
-											defaultValue_other: 'Show all {{count}} attachments'
+											defaultValue: 'Show all {{count}} attachments'
 										})}
 									</Text>
 								</Padding>


### PR DESCRIPTION
requires: 
- [x] [CO-1810] add translation for label.show_all_attachments in mails project

[CO-1810]: https://zextras.atlassian.net/browse/CO-1810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ