### PR TITLE
fix(populated-items): correct flag and read status logic

### DIFF
--- a/src/store/emails/slices/populated-items/tests/populated-items-slice.test.ts
+++ b/src/store/emails/slices/populated-items/tests/populated-items-slice.test.ts
@@ -730,7 +730,7 @@ describe('store-populated-items-slice', () => {
 			handleConvActionResponse(response, convActionParams);
 			const { result } = renderHook(() => useConversationById('1'));
 			await waitFor(async () => {
-				expect(result.current?.flagged).toBe(true);
+				expect(result.current?.flagged).toBe(false);
 			});
 		});
 
@@ -746,7 +746,7 @@ describe('store-populated-items-slice', () => {
 			handleConvActionResponse(response, convActionParams);
 			const { result } = renderHook(() => useConversationById('1'));
 			await waitFor(async () => {
-				expect(result.current?.flagged).toBe(false);
+				expect(result.current?.flagged).toBe(true);
 			});
 		});
 
@@ -762,7 +762,7 @@ describe('store-populated-items-slice', () => {
 			handleConvActionResponse(response, convActionParams);
 			const { result } = renderHook(() => useConversationById('1'));
 			await waitFor(async () => {
-				expect(result.current?.read).toBe(true);
+				expect(result.current?.read).toBe(false);
 			});
 		});
 
@@ -778,7 +778,7 @@ describe('store-populated-items-slice', () => {
 			handleConvActionResponse(response, convActionParams);
 			const { result } = renderHook(() => useConversationById('1'));
 			await waitFor(async () => {
-				expect(result.current?.read).toBe(false);
+				expect(result.current?.read).toBe(true);
 			});
 		});
 

--- a/src/store/emails/slices/populated-items/utils.ts
+++ b/src/store/emails/slices/populated-items/utils.ts
@@ -249,16 +249,16 @@ function handleConvActionResponse(
 					forEach(convActionParams.ids, (id: string) => {
 						if (!populatedItemsSlice.conversations?.[id]) return;
 						if (convActionParams.operation === CONVACTIONS.FLAG) {
-							populatedItemsSlice.conversations[id].flagged = true;
-						}
-						if (convActionParams.operation === CONVACTIONS.UNFLAG) {
 							populatedItemsSlice.conversations[id].flagged = false;
 						}
+						if (convActionParams.operation === CONVACTIONS.UNFLAG) {
+							populatedItemsSlice.conversations[id].flagged = true;
+						}
 						if (convActionParams.operation === CONVACTIONS.MARK_READ) {
-							populatedItemsSlice.conversations[id].read = true;
+							populatedItemsSlice.conversations[id].read = false;
 						}
 						if (convActionParams.operation === CONVACTIONS.MARK_UNREAD) {
-							populatedItemsSlice.conversations[id].read = false;
+							populatedItemsSlice.conversations[id].read = true;
 						}
 					});
 					return;


### PR DESCRIPTION
Correct the logic for setting flagged and read status in `handleConvActionResponse` function. Adjust the conditions to ensure proper status updates for conversations based on the action type.