### PR TITLE
fix: connection idle or issue may block the update of mail UI interface

### DIFF
--- a/src/views/sidebar/commons/sync-data-handler-hooks.ts
+++ b/src/views/sidebar/commons/sync-data-handler-hooks.ts
@@ -158,8 +158,17 @@ function processNotifications({
 	processedNotify
 }: ProcessNotificationsProps): void {
 	forEach(sortBy(notifyList, 'seq'), (notify) => {
+		/*
+		 * After a period of inactivity from the client, the server will reset the sequence number to 1.
+		 * In this case, if the client stored sequence number is greater than 1, the client must reset its sequence
+		 * number to 1 as well, to avoid missing any update.
+		 *
+		 * TODO probably the check on the "seq" state is redundant. We keep it at the moment, to avoid
+		 *  possible regressions, but we should remove it in the future
+		 */
+		const isSequenceReset = processedNotify.current > 1 && notify.seq === 1;
 		if (
-			processedNotify.current >= notify.seq ||
+			(processedNotify.current >= notify.seq && !isSequenceReset) ||
 			isEmpty(notify) ||
 			(notify.seq <= seq && !(seq > 1 && notify.seq === 1))
 		) {

--- a/src/views/sidebar/commons/tests/sync-data-handler-hooks.test.tsx
+++ b/src/views/sidebar/commons/tests/sync-data-handler-hooks.test.tsx
@@ -8,27 +8,31 @@ import { waitFor, renderHook, act } from '@testing-library/react';
 import { SoapNotify, useRefresh } from '@zextras/carbonio-shell-ui';
 import { http } from 'msw';
 
-import { generateConversationFromAPI, generateMessageFromAPI } from '../../tests/generators/api';
-import { SoapConversation, SoapIncompleteMessage } from '../../types';
-import { useSyncDataHandler } from './commons/sync-data-handler-hooks';
-import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
-import { useFolderStore } from '../../carbonio-ui-commons/store/zustand/folder';
-import { useTagStore } from '../../carbonio-ui-commons/store/zustand/tags';
-import { getSetupServer } from '../../carbonio-ui-commons/test/jest-setup';
-import { useNotify } from '../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
-import { generateFolder } from '../../carbonio-ui-commons/test/mocks/folders/folders-generator';
-import { handleGetFolderRequest } from '../../carbonio-ui-commons/test/mocks/network/msw/handle-get-folder';
-import { handleGetShareInfoRequest } from '../../carbonio-ui-commons/test/mocks/network/msw/handle-get-share-info';
-import { folderWorker, tagsWorker } from '../../carbonio-ui-commons/worker';
+import { FOLDERS } from '../../../../carbonio-ui-commons/constants/folders';
+import { useFolderStore } from '../../../../carbonio-ui-commons/store/zustand/folder';
+import { useTagStore } from '../../../../carbonio-ui-commons/store/zustand/tags';
+import { getSetupServer } from '../../../../carbonio-ui-commons/test/jest-setup';
+import { useNotify } from '../../../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
+import { generateFolder } from '../../../../carbonio-ui-commons/test/mocks/folders/folders-generator';
+import { handleGetFolderRequest } from '../../../../carbonio-ui-commons/test/mocks/network/msw/handle-get-folder';
+import { handleGetShareInfoRequest } from '../../../../carbonio-ui-commons/test/mocks/network/msw/handle-get-share-info';
+import { setupHook } from '../../../../carbonio-ui-commons/test/test-setup';
+import { folderWorker, tagsWorker } from '../../../../carbonio-ui-commons/worker';
 import {
 	useConversationById,
 	useMessageById,
 	setSearchResultsByMessage,
 	setSearchResultsByConversation,
 	getUseEmailStoreAndHooksForTesting
-} from '../../store/emails/store';
-import { generateConversation } from '../../tests/generators/generateConversation';
-import { generateMessage } from '../../tests/generators/generateMessage';
+} from '../../../../store/emails/store';
+import {
+	generateConversationFromAPI,
+	generateMessageFromAPI
+} from '../../../../tests/generators/api';
+import { generateConversation } from '../../../../tests/generators/generateConversation';
+import { generateMessage } from '../../../../tests/generators/generateMessage';
+import { SoapConversation, SoapIncompleteMessage } from '../../../../types';
+import { useSyncDataHandler } from '../sync-data-handler-hooks';
 
 const UNREAD = 'u';
 const READ = '';
@@ -85,7 +89,8 @@ function mockSoapModifyMessageAction(
 					f: `s${action}`
 				}
 			]
-		}
+		},
+		...(seq ? { seq } : {})
 	});
 	(useNotify as jest.Mock).mockReturnValue([soapNotify]);
 }
@@ -175,8 +180,8 @@ function mockSoapCreateMessageAndConversation(
 	(useNotify as jest.Mock).mockReturnValue([soapNotify]);
 }
 
-jest.mock('../../carbonio-ui-commons/store/zustand/tags', () => ({
-	...jest.requireActual('../../carbonio-ui-commons/store/zustand/tags'),
+jest.mock('../../../../carbonio-ui-commons/store/zustand/tags', () => ({
+	...jest.requireActual('../../../../carbonio-ui-commons/store/zustand/tags'),
 	getTags: jest.fn()
 }));
 
@@ -485,6 +490,71 @@ describe('sync data handler', () => {
 			expect(workerSpy).toHaveBeenCalledWith(
 				expect.objectContaining({ op: 'notify', notify, state: expect.any(Object) })
 			);
+		});
+	});
+
+	describe('sequence number logic', () => {
+		beforeAll(() => {
+			/*
+			 * Intercept and stop the postMessage calls to the workers because the current Worker mock is buggy
+			 * and it causes a call to the "onMessage" event listener of the worker without a proper payload.
+			 * This results in a reset of the stores (the tags store in this case) which leads to errors in the test execution
+			 */
+			jest.spyOn(tagsWorker, 'postMessage').mockImplementation(() => {});
+		});
+
+		it('should not process notify if seq is less than or equal to current seq (but not 1)', async () => {
+			const sequence = 5;
+
+			// First notify
+			setMessagesInSearchSlice([generateMessage({ id: '1', isRead: false })]);
+			mockSoapModifyMessageAction(mailboxNumber, '1', [READ], sequence);
+			const { rerender } = await act(async () => setupHook(useSyncDataHandler));
+
+			// Second notify with the same sequence number
+			mockSoapModifyMessageAction(mailboxNumber, '1', [UNREAD], sequence);
+			rerender();
+			const {
+				result: { current: message }
+			} = setupHook(useMessageById, { initialProps: ['1'] });
+
+			expect(message?.read).toBe(true);
+		});
+
+		it('should process notify if seq is 1 and current seq is greater than 1', async () => {
+			const lastSequence = 5;
+
+			// First notify
+			setMessagesInSearchSlice([generateMessage({ id: '1', isRead: false })]);
+			mockSoapModifyMessageAction(mailboxNumber, '1', [READ], lastSequence);
+			const { rerender } = await act(async () => setupHook(useSyncDataHandler));
+
+			// ...the backend resets the sequence number to 1...
+
+			// Next notify after the idle period
+			mockSoapModifyMessageAction(mailboxNumber, '1', [UNREAD], 1);
+			rerender();
+			const {
+				result: { current: message }
+			} = setupHook(useMessageById, { initialProps: ['1'] });
+
+			expect(message?.read).toBe(false);
+		});
+
+		it('should process notify if seq is greater than current seq', async () => {
+			// First notify
+			setMessagesInSearchSlice([generateMessage({ id: '1', isRead: false })]);
+			mockSoapModifyMessageAction(mailboxNumber, '1', [READ], 12);
+			const { rerender } = await act(async () => setupHook(useSyncDataHandler));
+
+			// Next notify
+			mockSoapModifyMessageAction(mailboxNumber, '1', [UNREAD], 13);
+			rerender();
+			const {
+				result: { current: message }
+			} = setupHook(useMessageById, { initialProps: ['1'] });
+
+			expect(message?.read).toBe(false);
 		});
 	});
 });

--- a/src/views/sidebar/commons/tests/sync-data-handler-hooks.test.tsx
+++ b/src/views/sidebar/commons/tests/sync-data-handler-hooks.test.tsx
@@ -67,10 +67,12 @@ function mockSoapModifyConversationAction(mailboxNumber: number, actions: Array<
 	});
 	(useNotify as jest.Mock).mockReturnValue([soapNotify]);
 }
+
 function mockSoapModifyMessageAction(
 	mailboxNumber: number,
 	messageId: string,
-	actions: Array<string>
+	actions: Array<string>,
+	seq?: number
 ): void {
 	mockSoapRefresh(mailboxNumber);
 	const action = actions.join('');


### PR DESCRIPTION
- Add tests to cover the sequence number logic cases
- Fix the `useSyncDataHandler` hook logic to handle the sequence number reset from the backend

Refs: CO-1829