### PR TITLE
refactor: add items to index slice when updating them

### DIFF
--- a/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/tests/html-message-renderer.test.tsx
@@ -9,7 +9,7 @@ import { act, screen } from '@testing-library/react';
 
 import { createSoapAPIInterceptor } from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
-import { updateMessages } from '../../../store/emails/store';
+import { createOrUpdateMessages } from '../../../store/emails/store';
 import { generateCompleteMessageFromAPI } from '../../../tests/generators/api';
 import { generateMessage } from '../../../tests/generators/generateMessage';
 import { GetMsgRequest, GetMsgResponse, MailMessage } from '../../../types';
@@ -24,7 +24,7 @@ describe('HTML message renderer', () => {
 					body: 'Test',
 					truncated: true
 				});
-				updateMessages([message]);
+				createOrUpdateMessages([message]);
 
 				setupTest(<HtmlMessageRenderer message={message} />, {
 					initialEntries: ['/search']
@@ -39,7 +39,7 @@ describe('HTML message renderer', () => {
 					body: 'Test',
 					truncated: false
 				});
-				updateMessages([message]);
+				createOrUpdateMessages([message]);
 
 				setupTest(<HtmlMessageRenderer message={message} />, {
 					initialEntries: ['/search']
@@ -61,7 +61,7 @@ describe('HTML message renderer', () => {
 					body: 'Test',
 					truncated: true
 				});
-				updateMessages([message]);
+				createOrUpdateMessages([message]);
 
 				const { user } = setupTest(<HtmlMessageRenderer message={message} />, {
 					initialEntries: ['/search']
@@ -79,7 +79,7 @@ describe('HTML message renderer', () => {
 
 			it('should remove message too large banner after clicking load message', async () => {
 				const message = generateMessage({ id: '1', body: 'Initial body', truncated: true });
-				updateMessages([message]);
+				createOrUpdateMessages([message]);
 				const interceptor = createSoapAPIInterceptor<GetMsgRequest, GetMsgResponse>('GetMsg', {
 					m: [
 						generateCompleteMessageFromAPI({

--- a/src/store/emails/actions/get-conv-action.ts
+++ b/src/store/emails/actions/get-conv-action.ts
@@ -5,7 +5,7 @@
  */
 
 import { getConvSoapApi } from '../../../api/get-conv-soap-api';
-import { updateConversations, updateMessages } from '../store';
+import { createOrUpdateConversations, createOrUpdateMessages } from '../store';
 
 export async function getConvEmailStoreAction({
 	id,
@@ -15,6 +15,6 @@ export async function getConvEmailStoreAction({
 	onConversationIdChange?: (id: string) => void;
 }): Promise<void> {
 	const getConvResponse = await getConvSoapApi({ conversationId: id, onConversationIdChange });
-	updateMessages(getConvResponse.messages);
-	updateConversations(getConvResponse.conversation);
+	createOrUpdateMessages(getConvResponse.messages);
+	createOrUpdateConversations(getConvResponse.conversation);
 }

--- a/src/store/emails/actions/get-message-with-existing-participants.ts
+++ b/src/store/emails/actions/get-message-with-existing-participants.ts
@@ -12,7 +12,7 @@ import {
 	normalizeMailMessageFromSoap
 } from '../../../normalizations/normalize-message';
 import { GetMsgResponse, MailMessage, Participant } from '../../../types';
-import { updateMessages, updateMessageStatus } from '../store';
+import { createOrUpdateMessages, updateMessageStatus } from '../store';
 
 async function handleRetrieveMessageWithParticipants(
 	messageId: string,
@@ -31,7 +31,7 @@ async function handleRetrieveMessageWithParticipants(
 		...normalizeCompleteMailMessageFromSoap(msg),
 		participants
 	}));
-	updateMessages(messages);
+	createOrUpdateMessages(messages);
 	updateMessageStatus(messageId, API_REQUEST_STATUS.fulfilled);
 	return normalizeMailMessageFromSoap(response.m[0], true) as MailMessage;
 }

--- a/src/store/emails/actions/get-message.ts
+++ b/src/store/emails/actions/get-message.ts
@@ -14,11 +14,11 @@ import {
 	normalizeMailMessageFromSoap
 } from '../../../normalizations/normalize-message';
 import { GetMsgResponse, MailMessage } from '../../../types';
-import { updateMessages, updateMessageStatus } from '../store';
+import { createOrUpdateMessages, updateMessageStatus } from '../store';
 
 function handleGetMsgResponse(response: GetMsgResponse): void {
 	const messages = map(response?.m ?? [], (msg) => normalizeCompleteMailMessageFromSoap(msg));
-	updateMessages(messages);
+	createOrUpdateMessages(messages);
 }
 
 async function handleRetrieveMessage(

--- a/src/store/emails/actions/save-draft-action.ts
+++ b/src/store/emails/actions/save-draft-action.ts
@@ -8,7 +8,7 @@ import { saveDraftSoapApi } from '../../../api/save-draft-soap-api';
 import { API_REQUEST_STATUS } from '../../../constants';
 import { normalizeMailMessageFromSoap } from '../../../normalizations/normalize-message';
 import { SaveDraftParameters } from '../../../types';
-import { updateMessages, updateMessageStatus } from '../store';
+import { createOrUpdateMessages, updateMessageStatus } from '../store';
 
 export async function saveDraftEmailStoreAction({
 	editor,
@@ -18,7 +18,7 @@ export async function saveDraftEmailStoreAction({
 	if (result.m)
 		result.m.forEach((message) => {
 			const normalizedMessage = normalizeMailMessageFromSoap(message);
-			updateMessages([normalizedMessage]);
+			createOrUpdateMessages([normalizedMessage]);
 			updateMessageStatus(normalizedMessage.id, API_REQUEST_STATUS.fulfilled);
 		});
 	return result;

--- a/src/store/emails/actions/search-conv-action.ts
+++ b/src/store/emails/actions/search-conv-action.ts
@@ -11,15 +11,15 @@ import { API_REQUEST_STATUS } from '../../../constants';
 import { normalizeCompleteMailMessageFromSoap } from '../../../normalizations/normalize-message';
 import { NormalizedConversation, SearchConvResponse } from '../../../types';
 import {
-	updateMessages,
+	createOrUpdateMessages,
 	getConversationById,
-	updateConversations,
+	createOrUpdateConversations,
 	updateConversationStatus
 } from '../store';
 
 function handleSearchConvResponse(conversationId: string, response: SearchConvResponse): void {
 	const messages = map(response?.m ?? [], (msg) => normalizeCompleteMailMessageFromSoap(msg));
-	updateMessages(messages);
+	createOrUpdateMessages(messages);
 	const convMessagesIds: Array<string> = map(response?.m ?? [], (msg) => msg.id);
 	const conversation = getConversationById(conversationId);
 	const updatedConversation: NormalizedConversation = {
@@ -27,7 +27,7 @@ function handleSearchConvResponse(conversationId: string, response: SearchConvRe
 		id: conversationId,
 		messageIds: convMessagesIds
 	};
-	updateConversations([updatedConversation]);
+	createOrUpdateConversations([updatedConversation]);
 }
 
 export async function searchConvEmailStoreAction(

--- a/src/store/emails/actions/tests/get-conv-action.test.ts
+++ b/src/store/emails/actions/tests/get-conv-action.test.ts
@@ -10,13 +10,13 @@ import {
 	generateConvMessageFromAPI
 } from '../../../../tests/generators/api';
 import { GetConvResponse } from '../../../../types/soap/get-conv';
-import { updateConversations, updateMessages } from '../../store';
+import { createOrUpdateConversations, createOrUpdateMessages } from '../../store';
 import { getConvEmailStoreAction } from '../get-conv-action';
 
 jest.mock('../../store', () => ({
 	...jest.requireActual('../../store'),
-	updateMessages: jest.fn(),
-	updateConversations: jest.fn()
+	createOrUpdateMessages: jest.fn(),
+	createOrUpdateConversations: jest.fn()
 }));
 
 describe('getConvEmailStoreAction', () => {
@@ -41,7 +41,7 @@ describe('getConvEmailStoreAction', () => {
 				c: expect.objectContaining({ id: '123' })
 			})
 		);
-		expect(updateMessages).toHaveBeenCalledTimes(1);
-		expect(updateConversations).toHaveBeenCalledTimes(1);
+		expect(createOrUpdateMessages).toHaveBeenCalledTimes(1);
+		expect(createOrUpdateConversations).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/store/emails/actions/tests/get-message-with-existing-participants.test.ts
+++ b/src/store/emails/actions/tests/get-message-with-existing-participants.test.ts
@@ -9,7 +9,7 @@ import { ParticipantRole } from '../../../../carbonio-ui-commons/constants/parti
 import { API_REQUEST_STATUS } from '../../../../constants';
 import { normalizeMailMessageFromSoap } from '../../../../normalizations/normalize-message';
 import { GetMsgResponse } from '../../../../types';
-import { updateMessages, updateMessageStatus } from '../../store';
+import { createOrUpdateMessages, updateMessageStatus } from '../../store';
 import { getMessageWithExistingParticipantsEmailStoreAction } from '../get-message-with-existing-participants';
 import { getSoapMailMessage } from './test-utils';
 
@@ -44,7 +44,7 @@ describe('getMessageWithExistingParticipantsEmailStoreAction', () => {
 
 		expect(updateMessageStatus).toHaveBeenCalledWith(messageId, API_REQUEST_STATUS.pending);
 		expect(getMsgSoapApi).toHaveBeenCalledWith({ msgId: messageId, max: 250_000 });
-		expect(updateMessages).toHaveBeenCalledWith(expect.any(Array));
+		expect(createOrUpdateMessages).toHaveBeenCalledWith(expect.any(Array));
 		expect(updateMessageStatus).toHaveBeenCalledWith(messageId, API_REQUEST_STATUS.fulfilled);
 		expect(result).toEqual({
 			id: '1',
@@ -102,7 +102,7 @@ describe('getMessageWithExistingParticipantsEmailStoreAction', () => {
 		);
 
 		expect(updateMessageStatus).toHaveBeenCalledWith(messageId, API_REQUEST_STATUS.pending);
-		expect(updateMessages).toHaveBeenCalledWith([]);
+		expect(createOrUpdateMessages).toHaveBeenCalledWith([]);
 		expect(updateMessageStatus).toHaveBeenCalledWith(messageId, API_REQUEST_STATUS.fulfilled);
 		expect(result).toBeUndefined();
 	});

--- a/src/store/emails/actions/tests/get-message.test.ts
+++ b/src/store/emails/actions/tests/get-message.test.ts
@@ -9,7 +9,7 @@ import { getMsgDecryptSoapApi } from '../../../../api/get-msg-soap-api-decrypt';
 import { API_REQUEST_STATUS } from '../../../../constants';
 import { normalizeMailMessageFromSoap } from '../../../../normalizations/normalize-message';
 import { GetMsgResponse } from '../../../../types';
-import { updateMessages, updateMessageStatus } from '../../store';
+import { createOrUpdateMessages, updateMessageStatus } from '../../store';
 import {
 	getMessageEmailStoreAction,
 	getFullMessageEmailStoreAction,
@@ -68,7 +68,7 @@ describe('get-message', () => {
 
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.pending);
 			expect(getMsgSoapApi).toHaveBeenCalledWith({ msgId: mockMessageId, max: 250_000 });
-			expect(updateMessages).toHaveBeenCalledWith(expect.any(Array));
+			expect(createOrUpdateMessages).toHaveBeenCalledWith(expect.any(Array));
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.fulfilled);
 			expect(result).toEqual({ id: '1', subject: 'message 1 Subject' });
 		});
@@ -101,7 +101,7 @@ describe('get-message', () => {
 			const result = await getMessageEmailStoreAction(mockMessageId);
 
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.pending);
-			expect(updateMessages).toHaveBeenCalledWith([]);
+			expect(createOrUpdateMessages).toHaveBeenCalledWith([]);
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.fulfilled);
 			expect(result).toBeUndefined();
 		});
@@ -121,7 +121,7 @@ describe('get-message', () => {
 				max: 250_000,
 				smimePassword: 'smimePassword'
 			});
-			expect(updateMessages).toHaveBeenCalledWith(expect.any(Array));
+			expect(createOrUpdateMessages).toHaveBeenCalledWith(expect.any(Array));
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.fulfilled);
 			expect(result).toEqual({ id: '1', subject: 'message 1 Subject' });
 		});
@@ -144,7 +144,7 @@ describe('get-message', () => {
 			const result = await getMessageDecryptEmailStoreAction(mockMessageId, 'smimePassword');
 
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.pending);
-			expect(updateMessages).toHaveBeenCalledWith([]);
+			expect(createOrUpdateMessages).toHaveBeenCalledWith([]);
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.fulfilled);
 			expect(result).toBeUndefined();
 		});
@@ -185,7 +185,7 @@ describe('get-message', () => {
 
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.pending);
 			expect(getMsgSoapApi).toHaveBeenCalledWith({ msgId: mockMessageId });
-			expect(updateMessages).toHaveBeenCalledWith(expect.any(Array));
+			expect(createOrUpdateMessages).toHaveBeenCalledWith(expect.any(Array));
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.fulfilled);
 			expect(result).toEqual({ id: '1', subject: 'message 1 Subject' });
 		});
@@ -218,7 +218,7 @@ describe('get-message', () => {
 			const result = await getFullMessageEmailStoreAction(mockMessageId);
 
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.pending);
-			expect(updateMessages).toHaveBeenCalledWith([]);
+			expect(createOrUpdateMessages).toHaveBeenCalledWith([]);
 			expect(updateMessageStatus).toHaveBeenCalledWith(mockMessageId, API_REQUEST_STATUS.fulfilled);
 			expect(result).toBeUndefined();
 		});

--- a/src/store/emails/actions/tests/search-conv-action.test.ts
+++ b/src/store/emails/actions/tests/search-conv-action.test.ts
@@ -7,9 +7,9 @@ import { searchConvSoapApi } from '../../../../api/search-conv-soap-api';
 import { API_REQUEST_STATUS } from '../../../../constants';
 import { normalizeCompleteMailMessageFromSoap } from '../../../../normalizations/normalize-message';
 import {
-	updateMessages,
+	createOrUpdateMessages,
 	getConversationById,
-	updateConversations,
+	createOrUpdateConversations,
 	updateConversationStatus
 } from '../../store';
 import { searchConvEmailStoreAction } from '../search-conv-action';
@@ -49,8 +49,8 @@ describe('searchConvEmailStoreAction', () => {
 			conversationId: mockConversationId,
 			fetch: 'all'
 		});
-		expect(updateMessages).toHaveBeenCalledWith(expect.any(Array));
-		expect(updateConversations).toHaveBeenCalledWith(expect.any(Array));
+		expect(createOrUpdateMessages).toHaveBeenCalledWith(expect.any(Array));
+		expect(createOrUpdateConversations).toHaveBeenCalledWith(expect.any(Array));
 		expect(updateConversationStatus).toHaveBeenCalledWith(
 			mockConversationId,
 			API_REQUEST_STATUS.fulfilled
@@ -102,8 +102,8 @@ describe('searchConvEmailStoreAction', () => {
 			mockConversationId,
 			API_REQUEST_STATUS.pending
 		);
-		expect(updateMessages).toHaveBeenCalledWith([]);
-		expect(updateConversations).toHaveBeenCalledWith(expect.any(Array));
+		expect(createOrUpdateMessages).toHaveBeenCalledWith([]);
+		expect(createOrUpdateConversations).toHaveBeenCalledWith(expect.any(Array));
 		expect(updateConversationStatus).toHaveBeenCalledWith(
 			mockConversationId,
 			API_REQUEST_STATUS.fulfilled

--- a/src/store/emails/slices/conversations/tests/conversation-index-slice.test.ts
+++ b/src/store/emails/slices/conversations/tests/conversation-index-slice.test.ts
@@ -17,7 +17,7 @@ import {
 	useConversationIndexSlice,
 	useConversationsByIds,
 	useConversationsIdsByFolder,
-	updateConversations,
+	createOrUpdateConversations,
 	getUseEmailStoreAndHooksForTesting,
 	setMessagesInEmailStore
 } from '../../../store';
@@ -161,7 +161,7 @@ describe('conversation-index-slice', () => {
 			});
 
 			it('should set populatedItemsSlice.conversations as an empty object', async () => {
-				updateConversations([conversation1]);
+				createOrUpdateConversations([conversation1]);
 				const { result: initialState } = renderHook(() => useConversationsByIds(['1']));
 				expect(initialState.current).toEqual([conversation1]);
 				await act(async () => setConversationsInEmailStore([], false));

--- a/src/store/emails/slices/messages/tests/message-slice.test.ts
+++ b/src/store/emails/slices/messages/tests/message-slice.test.ts
@@ -12,7 +12,7 @@ import {
 	appendMessagesToMessagesSlice,
 	resetMessagesAndPopulatedItems,
 	setMessagesInEmailStore,
-	updateMessages,
+	createOrUpdateMessages,
 	updateMessagesResultsLoadingStatus,
 	useMessageById,
 	useMessagesByIds,
@@ -154,7 +154,7 @@ describe('message-slice-utils', () => {
 			});
 
 			it('should set populatedItemsSlice.messages as an empty object', async () => {
-				updateMessages([message1]);
+				createOrUpdateMessages([message1]);
 				const { result: initialState } = renderHook(() => useMessagesByIds(['1']));
 				expect(initialState.current).toEqual([message1]);
 				await act(async () => setMessagesInEmailStore([], false));

--- a/src/store/emails/slices/populated-items/tests/populated-items-slice.test.ts
+++ b/src/store/emails/slices/populated-items/tests/populated-items-slice.test.ts
@@ -39,9 +39,9 @@ import {
 	setMessagesInEmailStore,
 	setSearchResultsByConversation,
 	setSearchResultsByMessage,
-	updateConversations,
+	createOrUpdateConversations,
 	updateConversationStatus,
-	updateMessages,
+	createOrUpdateMessages,
 	updateMessageStatus,
 	useConversationById,
 	useConversationIndexSlice,
@@ -65,7 +65,7 @@ describe('store-populated-items-slice', () => {
 		it('updates messages correctly', async () => {
 			const messages = [generateMessage({ id: '1' }), generateMessage({ id: '2' })];
 			act(() => {
-				updateMessages(messages);
+				createOrUpdateMessages(messages);
 			});
 
 			const { result: message1 } = renderHook(() => useMessageById('1'));
@@ -82,7 +82,7 @@ describe('store-populated-items-slice', () => {
 			];
 
 			act(() => {
-				updateMessages(messages);
+				createOrUpdateMessages(messages);
 			});
 
 			// @ts-ignore
@@ -96,7 +96,7 @@ describe('store-populated-items-slice', () => {
 		it('updates message status to fulfilled if complete', () => {
 			const messages = [generateMessage({ id: '1', isComplete: true })];
 			act(() => {
-				updateMessages(messages);
+				createOrUpdateMessages(messages);
 			});
 
 			const { result: message1 } = renderHook(() => useMessageById('1'));
@@ -109,7 +109,7 @@ describe('store-populated-items-slice', () => {
 		it('does not update message status if not complete', () => {
 			const messages = [generateMessage({ id: '1', isComplete: false })];
 			act(() => {
-				updateMessages(messages);
+				createOrUpdateMessages(messages);
 			});
 
 			const { result: message1 } = renderHook(() => useMessageById('1'));
@@ -142,7 +142,7 @@ describe('store-populated-items-slice', () => {
 			});
 
 			await act(async () => {
-				updateConversations([updatedConversation]);
+				createOrUpdateConversations([updatedConversation]);
 			});
 
 			const { result: updatedConversationFromStore } = renderHook(() =>
@@ -160,7 +160,7 @@ describe('store-populated-items-slice', () => {
 			const message2 = generateMessage({ id: '2' });
 			const messages = [message1, message2];
 
-			updateMessages(messages);
+			createOrUpdateMessages(messages);
 
 			const { result } = renderHook(() => useMessagesByIds([message2.id, message1.id]));
 
@@ -225,7 +225,7 @@ describe('store-populated-items-slice', () => {
 			const conversation2 = generateConversation({ id: '2' });
 			const conversations = [conversation1, conversation2];
 
-			updateConversations(conversations);
+			createOrUpdateConversations(conversations);
 
 			const { result } = renderHook(() =>
 				useConversationsByIds([conversation2.id, conversation1.id])
@@ -266,7 +266,7 @@ describe('store-populated-items-slice', () => {
 	describe('useMessageById', () => {
 		it('should update populated store messages', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 
 			const { result } = renderHook(() => useMessageById('1'));
 
@@ -325,7 +325,7 @@ describe('store-populated-items-slice', () => {
 			setMessagesInSearchSlice([...conversation1Messages, ...conversation2Messages]);
 
 			await act(async () => {
-				updateMessages([generateMessage({ id: '100' })]);
+				createOrUpdateMessages([generateMessage({ id: '100' })]);
 			});
 
 			const { result: conversation2StoreMessages } = renderHook(() => useConversationMessages('2'));
@@ -419,7 +419,7 @@ describe('store-populated-items-slice', () => {
 			};
 
 			await act(async () => {
-				updateConversations([newConversation]);
+				createOrUpdateConversations([newConversation]);
 			});
 			const { result } = renderHook(() => useConversationById('1'));
 			expect(result.current.tags).toEqual([]);
@@ -462,7 +462,7 @@ describe('store-populated-items-slice', () => {
 	describe('handleDeleteAttachments', () => {
 		it('should delete attachment from message', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 
 			await act(async () => {
 				handleDeleteAttachments({ m: [generateCompleteMessageFromAPI({ id: '1', mp: [] })] });
@@ -474,7 +474,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should not delete attachment from message if API response contains FAULT', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			const attachmentCountsBeforeAPICall = message?.parts?.length;
 
 			const response: ErrorSoapBodyResponse = buildSoapErrorResponseBody({ reason: 'any reason' });
@@ -489,7 +489,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should not affect other messages in the store if there is no message in the store to update', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 
 			await act(async () => {
 				handleDeleteAttachments({ m: [generateCompleteMessageFromAPI({ id: '2', mp: [] })] });
@@ -503,7 +503,7 @@ describe('store-populated-items-slice', () => {
 	describe('optimisticallyHandleMessageActions', () => {
 		it('should flag a message when operation is FLAG', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([{ ...message, flagged: false }]);
+			createOrUpdateMessages([{ ...message, flagged: false }]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.FLAG
@@ -515,7 +515,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should un-flag a message when operation is UNFLAG', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([{ ...message, flagged: true }]);
+			createOrUpdateMessages([{ ...message, flagged: true }]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.UNFLAG
@@ -527,7 +527,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should mark a message as read when operation is MARK_READ', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([{ ...message, read: false }]);
+			createOrUpdateMessages([{ ...message, read: false }]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.MARK_READ
@@ -539,7 +539,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should mark a message as unread when operation is MARK_AS_UNREAD', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([{ ...message, read: true }]);
+			createOrUpdateMessages([{ ...message, read: true }]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.MARK_UNREAD
@@ -551,7 +551,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should move a message to trash when operation is TRASH', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.TRASH
@@ -563,7 +563,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should delete a message when operation is DELETE', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.DELETE
@@ -575,7 +575,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should move a message to a specified folder when operation is MOVE', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				parent: '77',
@@ -588,7 +588,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should move a message to inbox when operation is MOVE and no parent is specified', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.MOVE
@@ -600,7 +600,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should mark a message as spam when operation is MARK_SPAM', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([{ ...message, parent: FOLDERS.INBOX }]);
+			createOrUpdateMessages([{ ...message, parent: FOLDERS.INBOX }]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.MARK_SPAM
@@ -612,7 +612,7 @@ describe('store-populated-items-slice', () => {
 
 		it('should mark a message as not spam when operation is MARK_NOT_SPAM', async () => {
 			const message = generateMessage({ id: '1' });
-			updateMessages([{ ...message, parent: FOLDERS.SPAM }]);
+			createOrUpdateMessages([{ ...message, parent: FOLDERS.SPAM }]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.MARK_NOT_SPAM
@@ -625,7 +625,7 @@ describe('store-populated-items-slice', () => {
 		it('should tag a message when operation is TAG and tagName is provided', async () => {
 			(useTags as jest.Mock).mockReturnValue(mockTags);
 			const message = generateMessage({ id: '1' });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.TAG,
@@ -639,7 +639,7 @@ describe('store-populated-items-slice', () => {
 		it('should untag a message when operation is UNTAG and tagName is provided', async () => {
 			(useTags as jest.Mock).mockReturnValue(mockTags);
 			const message = generateMessage({ id: '1', tags: ['Test555', 'AnotherTag'] });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.UNTAG,
@@ -653,7 +653,7 @@ describe('store-populated-items-slice', () => {
 		it('should not untag a message when operation is UNTAG but tagName is not provided or is undefined', async () => {
 			(useTags as jest.Mock).mockReturnValue(mockTags);
 			const message = generateMessage({ id: '1', tags: ['Test555', 'AnotherTag'] });
-			updateMessages([message]);
+			createOrUpdateMessages([message]);
 			optimisticallyHandleMessageActions({
 				ids: ['1'],
 				operation: CONVACTIONS.UNTAG

--- a/src/store/emails/slices/populated-items/utils.ts
+++ b/src/store/emails/slices/populated-items/utils.ts
@@ -60,13 +60,17 @@ function getConversationMessages(
 		.filter(Boolean);
 }
 
-function updateConversations(
-	updatedConversations: Array<NormalizedConversation>,
+function createOrUpdateConversations(
+	conversations: Array<NormalizedConversation>,
 	useEmailsStore: UseBoundStore<StoreApi<EmailsStoreState>>
 ): void {
+	const conversationIds = conversations.map((conv) => conv.id);
 	useEmailsStore.setState(
-		produce(({ populatedItemsSlice }: EmailsStoreState) => {
-			updatedConversations.forEach((conversation) => {
+		produce(({ populatedItemsSlice, conversationIndexSlice }: EmailsStoreState) => {
+			conversationIndexSlice.conversationListIndex = Array.from(
+				new Set([...conversationIds, ...conversationIndexSlice.conversationListIndex])
+			);
+			conversations.forEach((conversation) => {
 				if (populatedItemsSlice.conversations[conversation.id]) {
 					populatedItemsSlice.conversations[conversation.id] = {
 						...merge(populatedItemsSlice.conversations[conversation.id], conversation),
@@ -80,12 +84,16 @@ function updateConversations(
 	);
 }
 
-function updateMessages(
+function createOrUpdateMessages(
 	messages: Array<MailMessage>,
 	useEmailsStore: UseBoundStore<StoreApi<EmailsStoreState>>
 ): void {
+	const messageIds = messages.map((message) => message.id);
 	useEmailsStore.setState(
-		produce(({ populatedItemsSlice }: EmailsStoreState) => {
+		produce(({ populatedItemsSlice, messageIndexSlice }: EmailsStoreState) => {
+			messageIndexSlice.messageListIndex = Array.from(
+				new Set([...messageIds, ...messageIndexSlice.messageListIndex])
+			);
 			messages.forEach((message) => {
 				if (!message?.id) return;
 				const existingMessage = populatedItemsSlice.messages?.[message.id] || {};
@@ -303,13 +311,12 @@ function optimisticallyHandleConvActions({
 		})
 	);
 }
-
 export const populatedItemsSliceUtils = {
 	optimisticallyHandleMessageActions,
-	updateConversations,
+	createOrUpdateConversations,
 	updateMessageStatus,
 	updateConversationStatus,
-	updateMessages,
+	createOrUpdateMessages,
 	useConversationMessages,
 	getConversationMessages,
 	useMessagesByIds,

--- a/src/store/emails/store.ts
+++ b/src/store/emails/store.ts
@@ -314,9 +314,9 @@ export function getMessageById(id: string): IncompleteMessage | MailMessage {
 /**
  * Updates the state with modified conversation data.
  */
-export function updateConversations(updatedConversations: Array<NormalizedConversation>): void {
+export function createOrUpdateConversations(conversations: Array<NormalizedConversation>): void {
 	addTask(async () => {
-		populatedItemsSliceUtils.updateConversations(updatedConversations, useEmailsStore);
+		populatedItemsSliceUtils.createOrUpdateConversations(conversations, useEmailsStore);
 	});
 }
 
@@ -369,9 +369,9 @@ export function useConversationStatus(id: string): SearchRequestStatus {
  * by merging each message with its existing entry (if any), if the message is complete
  * the API_REQUEST_STATUS for the message is also updated to 'fulfilled'.
  */
-export function updateMessages(messages: MailMessage[]): void {
+export function createOrUpdateMessages(messages: MailMessage[]): void {
 	addTask(async () => {
-		populatedItemsSliceUtils.updateMessages(messages, useEmailsStore);
+		populatedItemsSliceUtils.createOrUpdateMessages(messages, useEmailsStore);
 	});
 }
 
@@ -586,34 +586,6 @@ export function setConversationsInEmailStore(
 export function handleNotifyDeleted(ids: string[]): void {
 	addTask(async () => {
 		syncDataHandlerUtils.handleNotifyDeleted(ids, useEmailsStore);
-	});
-}
-
-/**
- * Queues a task to update the email store state with modified conversation data.
- *
- * @param updatedConversations - An array of `NormalizedConversation` objects,
- * each containing an `id` and other properties to be updated in the state.
- */
-export function handleNotifyConversationsModified(
-	updatedConversations: Array<NormalizedConversation>
-): void {
-	addTask(async () => {
-		syncDataHandlerUtils.handleNotifyConversationsModified(updatedConversations, useEmailsStore);
-	});
-}
-
-/**
- * Queues a task to handle the addition of new conversations by updating the email store state.
- *
- * @param conversations - An array of `NormalizedConversation` objects to be
- * added to the conversation slice and index in the email store.
- */
-export function handleNotifyConversationsCreated(
-	conversations: Array<NormalizedConversation>
-): void {
-	addTask(async () => {
-		syncDataHandlerUtils.handleNotifyConversationsCreated(conversations, useEmailsStore);
 	});
 }
 

--- a/src/store/emails/sync-data-handler/utils.ts
+++ b/src/store/emails/sync-data-handler/utils.ts
@@ -9,12 +9,7 @@ import produce from 'immer';
 import { filter, find, forEach, merge } from 'lodash';
 import { StoreApi, UseBoundStore } from 'zustand';
 
-import {
-	EmailsStoreState,
-	IncompleteMessage,
-	MailMessage,
-	NormalizedConversation
-} from '../../../types';
+import { EmailsStoreState, IncompleteMessage, MailMessage } from '../../../types';
 
 function deleteConversationsInSearch(
 	state: EmailsStoreState,
@@ -89,36 +84,6 @@ function handleNotifyDeleted(
 			deleteConversationsInConversationIndexSlice(state, ids);
 			deleteMessagesInPopulatedItems(state, ids);
 			deleteConversationsInPopulatedItems(state, ids);
-		})
-	);
-}
-
-/**
- * Updates the conversations in the application state with the modified conversation data.
- *
- * @param updatedConversations - An array of normalized conversation objects containing the updates.
- * Each conversation must include an `id` and any other properties to merge with the existing state.
- *
- * @param useEmailsStore - A state management hook based on Zustand, which provides access
- * to and updates the `EmailsStoreState`. The store maintains the `populatedItemsSlice`
- * that tracks the conversation data.
- *
- * @remarks
- * - The `tags` property is explicitly replaced with the value from the `conversation` parameter.
- * - Other properties are merged into the existing data for the corresponding conversation.
- */
-function handleNotifyConversationsModified(
-	updatedConversations: Array<NormalizedConversation>,
-	useEmailsStore: UseBoundStore<StoreApi<EmailsStoreState>>
-): void {
-	useEmailsStore.setState(
-		produce(({ populatedItemsSlice }: EmailsStoreState) => {
-			updatedConversations.forEach((conversation) => {
-				populatedItemsSlice.conversations[conversation.id] = {
-					...merge(populatedItemsSlice.conversations[conversation.id], conversation),
-					tags: conversation.tags
-				};
-			});
 		})
 	);
 }
@@ -219,33 +184,8 @@ function handleNotifyMessagesCreated(
 	);
 }
 
-/**
- * Handles the creation of notify conversations by updating the application's email store state.
- * This function processes incoming conversations and updates the conversation slice and index
- * to include the new conversations.
- */
-function handleNotifyConversationsCreated(
-	conversations: Array<NormalizedConversation>,
-	useEmailsStore: UseBoundStore<StoreApi<EmailsStoreState>>
-): void {
-	const newConversationIds = conversations.map((conv) => conv.id);
-	useEmailsStore.setState(
-		produce(({ populatedItemsSlice, conversationIndexSlice }: EmailsStoreState) => {
-			populatedItemsSlice.conversations = conversations.reduce((acc, conversation) => {
-				acc[conversation.id] = conversation;
-				return acc;
-			}, populatedItemsSlice.conversations);
-			conversationIndexSlice.conversationListIndex = Array.from(
-				new Set([...newConversationIds, ...conversationIndexSlice.conversationListIndex])
-			);
-		})
-	);
-}
-
 export const syncDataHandlerUtils = {
 	handleNotifyDeleted,
 	handleNotifyMessagesModified,
-	handleNotifyConversationsModified,
-	handleNotifyConversationsCreated,
 	handleNotifyMessagesCreated
 };

--- a/src/tests/generators/generateConversation.ts
+++ b/src/tests/generators/generateConversation.ts
@@ -13,7 +13,7 @@ import {
 	ParticipantRole,
 	ParticipantRoleType
 } from '../../carbonio-ui-commons/constants/participants';
-import { updateConversations, updateMessages } from '../../store/emails/store';
+import { createOrUpdateConversations, createOrUpdateMessages } from '../../store/emails/store';
 import type { MailMessage, NormalizedConversation, Participant } from '../../types';
 
 /**
@@ -140,7 +140,7 @@ export const populateConversationInEmailStore = ({
 
 	const generatedMessages =
 		messagesFromMessageIds ?? messagesFromMessageGeneratorParams ?? defaultMessages;
-	updateMessages(generatedMessages);
+	createOrUpdateMessages(generatedMessages);
 
 	const generatedConversation = generateConversation({
 		...conversationParams,
@@ -150,6 +150,6 @@ export const populateConversationInEmailStore = ({
 	});
 	const messagesInConversation =
 		messageGeneratorParams?.length ?? messageIds?.length ?? conversationMessagesNumber;
-	updateConversations([{ ...generatedConversation, messagesInConversation }]);
+	createOrUpdateConversations([{ ...generatedConversation, messagesInConversation }]);
 	return { conversation: generatedConversation, messages: generatedMessages };
 };

--- a/src/tests/generators/generateMessage.ts
+++ b/src/tests/generators/generateMessage.ts
@@ -9,7 +9,7 @@ import { faker } from '@faker-js/faker';
 import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
 import { ParticipantRole } from '../../carbonio-ui-commons/constants/participants';
 import { convertHtmlToPlainText } from '../../commons/utilities';
-import { updateMessages } from '../../store/emails/store';
+import { createOrUpdateMessages } from '../../store/emails/store';
 import { MailMessage, Participant, Sensitivity } from '../../types';
 
 export type MessageGenerationParams = {
@@ -180,7 +180,7 @@ export const populateMessagesInEmailStore = ({
 	const generatedMessages =
 		messagesFromMessageIds ?? messagesFromMessageGeneratorParams ?? defaultMessages;
 
-	updateMessages(generatedMessages);
+	createOrUpdateMessages(generatedMessages);
 
 	return generatedMessages;
 };

--- a/src/views/app/detail-panel/preview/tests/conversation-preview-panel.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/conversation-preview-panel.test.tsx
@@ -9,7 +9,10 @@ import React from 'react';
 import { waitFor } from '@testing-library/react';
 
 import { setupTest, screen } from '../../../../../carbonio-ui-commons/test/test-setup';
-import { updateConversations, updateMessages } from '../../../../../store/emails/store';
+import {
+	createOrUpdateConversations,
+	createOrUpdateMessages
+} from '../../../../../store/emails/store';
 import { generateConversation } from '../../../../../tests/generators/generateConversation';
 import { generateMessage } from '../../../../../tests/generators/generateMessage';
 import { ConversationPreviewPanel } from '../../conversation-preview-panel';
@@ -23,12 +26,12 @@ describe('Conversation Preview Panel', () => {
 		const message2 = generateMessage({ id: '2' });
 		const messages = [message1, message2];
 
-		updateMessages(messages);
+		createOrUpdateMessages(messages);
 		const conversation = generateConversation({
 			id: '123',
 			messageIds: messages.map((m) => m.id)
 		});
-		updateConversations([conversation]);
+		createOrUpdateConversations([conversation]);
 		setupTest(<ConversationPreviewPanel conversation={conversation} isInsideExtraWindow={false} />);
 
 		await waitFor(async () => {

--- a/src/views/app/folder-panel/conversations/conversation-list-hooks.ts
+++ b/src/views/app/folder-panel/conversations/conversation-list-hooks.ts
@@ -13,7 +13,7 @@ import { normalizeConversations } from '../../../../normalizations/normalize-con
 import {
 	appendConversationsToConversationIndexSlice,
 	updateConversationsResultsLoadingStatus,
-	updateMessages
+	createOrUpdateMessages
 } from '../../../../store/emails/store';
 import { SearchResponse } from '../../../../types';
 import { extractConvMessage } from '../../../sidebar/commons/use-sync-data-handler';
@@ -28,7 +28,7 @@ function handleLoadMoreResults({
 	if (searchResponse.c && searchResponse.c.length > 0) {
 		const normalizedConversations = normalizeConversations(searchResponse.c);
 		const messages = extractConvMessage(searchResponse.c);
-		if (messages.length > 0) updateMessages(messages);
+		if (messages.length > 0) createOrUpdateMessages(messages);
 		appendConversationsToConversationIndexSlice(
 			normalizedConversations,
 			offset,

--- a/src/views/app/folder-panel/conversations/tests/conversations-multiple-selection-actions.test.tsx
+++ b/src/views/app/folder-panel/conversations/tests/conversations-multiple-selection-actions.test.tsx
@@ -13,7 +13,7 @@ import { FOLDERS } from '../../../../../carbonio-ui-commons/constants/folders';
 import { useTagStore } from '../../../../../carbonio-ui-commons/store/zustand/tags';
 import { tags } from '../../../../../carbonio-ui-commons/test/mocks/tags/tags';
 import { setupTest } from '../../../../../carbonio-ui-commons/test/test-setup';
-import { updateConversations } from '../../../../../store/emails/store';
+import { createOrUpdateConversations } from '../../../../../store/emails/store';
 import { generateConversation } from '../../../../../tests/generators/generateConversation';
 import { ConversationsMultipleSelectionActions } from '../conversations-multiple-selection-actions';
 
@@ -21,7 +21,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 	describe('Mark as read action', () => {
 		it('should display "mark as unread" action if all selected items are read', async () => {
 			await waitFor(() => {
-				updateConversations([
+				createOrUpdateConversations([
 					generateConversation({ id: '1', isRead: true }),
 					generateConversation({ id: '2', isRead: true }),
 					generateConversation({ id: '3', isRead: true })
@@ -39,7 +39,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 		});
 		it('should display "mark as read" action if any selected items is unread', async () => {
 			await act(async () => {
-				updateConversations([
+				createOrUpdateConversations([
 					generateConversation({ id: '1', isRead: true }),
 					generateConversation({ id: '2', isRead: false }),
 					generateConversation({ id: '3', isRead: true })
@@ -60,7 +60,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 	describe('Delete action', () => {
 		it('should display "delete" action', async () => {
 			await act(async () => {
-				updateConversations([
+				createOrUpdateConversations([
 					generateConversation({ id: '1' }),
 					generateConversation({ id: '2' }),
 					generateConversation({ id: '3' })
@@ -80,7 +80,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 	describe('More actions', () => {
 		it('should contain "add flag" action if at least one conversation is not flagged', async () => {
 			await act(async () => {
-				updateConversations([
+				createOrUpdateConversations([
 					generateConversation({ id: '1', isFlagged: true }),
 					generateConversation({ id: '2', isFlagged: false }),
 					generateConversation({ id: '3', isFlagged: true })
@@ -100,7 +100,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 			expect(within(actionsDropdown).getByTestId('icon: FlagOutline')).toBeVisible();
 		});
 		it('should contain "remove flag" action if all conversations are flagged', async () => {
-			updateConversations([
+			createOrUpdateConversations([
 				generateConversation({ id: '1', isFlagged: true }),
 				generateConversation({ id: '2', isFlagged: true }),
 				generateConversation({ id: '3', isFlagged: true })
@@ -119,7 +119,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 			expect(within(actionsDropdown).getByTestId('icon: Flag')).toBeVisible();
 		});
 		it('should contain "move" action', async () => {
-			updateConversations([
+			createOrUpdateConversations([
 				generateConversation({ id: '1' }),
 				generateConversation({ id: '2' }),
 				generateConversation({ id: '3' })
@@ -139,7 +139,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 		});
 		it('should contain "delete permanently" action when in trash folder', async () => {
 			await act(async () => {
-				updateConversations([
+				createOrUpdateConversations([
 					generateConversation({ id: '1' }),
 					generateConversation({ id: '2' }),
 					generateConversation({ id: '3' })
@@ -156,7 +156,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 			expect(screen.getByTestId('icon: DeletePermanentlyOutline')).toBeVisible();
 		});
 		it('should contain "mark as spam" action', async () => {
-			updateConversations([
+			createOrUpdateConversations([
 				generateConversation({ id: '1' }),
 				generateConversation({ id: '2' }),
 				generateConversation({ id: '3' })
@@ -175,7 +175,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 			expect(await within(actionsDropdown).findByText('Mark as spam')).toBeVisible();
 		});
 		it('should contain "mark as not spam" action when a conversation is in spam folder', async () => {
-			updateConversations([
+			createOrUpdateConversations([
 				generateConversation({ id: '1' }),
 				generateConversation({ id: '2' }),
 				generateConversation({ id: '3' })
@@ -195,7 +195,7 @@ describe('ConversationsMultipleSelectionActions', () => {
 		});
 		it('should contain "tag" submenu item', async () => {
 			const tagItems = map(tags, (tag) => tag.name);
-			updateConversations([
+			createOrUpdateConversations([
 				generateConversation({ id: '1', tags: tagItems }),
 				generateConversation({ id: '2', tags: tagItems }),
 				generateConversation({ id: '3' })

--- a/src/views/sidebar/commons/types.ts
+++ b/src/views/sidebar/commons/types.ts
@@ -4,12 +4,40 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { SoapNotify } from '@zextras/carbonio-shell-ui';
 import { StoreApi, UseBoundStore } from 'zustand';
 
-import { TagState } from '../../../carbonio-ui-commons/types/tags';
-import { FolderState } from '../../../types';
+import { Tag, TagState } from '../../../carbonio-ui-commons/types/tags';
+import {
+	FolderState,
+	SoapConversation,
+	SoapFolder,
+	SoapIncompleteMessage,
+	SoapLink
+} from '../../../types';
 
+export type SoapNotify = {
+	seq: number;
+	created?: {
+		m?: Array<SoapIncompleteMessage>;
+		c?: Array<SoapConversation>;
+		folder?: Array<SoapFolder>;
+		link?: Array<SoapLink>;
+		tag?: Array<Tag>;
+	};
+	modified?: {
+		m?: Array<SoapIncompleteMessage>;
+		c?: Array<SoapConversation>;
+		folder?: Array<Partial<SoapFolder>>;
+		link?: Array<Partial<SoapLink>>;
+		tag?: Array<Partial<Tag>>;
+		mbx: [
+			{
+				s: number;
+			}
+		];
+	};
+	deleted: Array<string>;
+};
 export type HandleFoldersNotifyProps = {
 	notifyList: Array<SoapNotify>;
 	notify: SoapNotify;

--- a/src/views/sidebar/commons/use-sync-data-handler.ts
+++ b/src/views/sidebar/commons/use-sync-data-handler.ts
@@ -7,25 +7,19 @@
 
 import { MutableRefObject, useEffect, useRef, useState } from 'react';
 
-import { SoapNotify, useNotify, useRefresh } from '@zextras/carbonio-shell-ui';
+import { useNotify, useRefresh } from '@zextras/carbonio-shell-ui';
 import { flatten, forEach, isEmpty, map, sortBy } from 'lodash';
 
-import { HandleFoldersNotifyProps, HandleTagsNotifyProps } from './types';
+import { HandleFoldersNotifyProps, HandleTagsNotifyProps, SoapNotify } from './types';
 import { useFolderStore } from '../../../carbonio-ui-commons/store/zustand/folder';
 import { useTagStore } from '../../../carbonio-ui-commons/store/zustand/tags';
 import { folderWorker, tagsWorker } from '../../../carbonio-ui-commons/worker';
-import {
-	mapToNormalizedConversation,
-	normalizeConversations
-} from '../../../normalizations/normalize-conversation';
+import { mapToNormalizedConversation } from '../../../normalizations/normalize-conversation';
 import { normalizeMailMessageFromSoap } from '../../../normalizations/normalize-message';
 import {
-	handleNotifyConversationsCreated,
-	handleNotifyMessagesCreated,
-	handleNotifyConversationsModified,
-	handleNotifyMessagesModified,
 	handleNotifyDeleted,
-	updateMessages
+	createOrUpdateConversations,
+	createOrUpdateMessages
 } from '../../../store/emails/store';
 import { IncompleteMessage, SoapConversation, SoapIncompleteMessage } from '../../../types';
 
@@ -68,48 +62,6 @@ function handleTagsNotify({ notify, worker, store }: HandleTagsNotifyProps): voi
 	});
 }
 
-function processCreatedNotifications(notify: SoapNotify): void {
-	const { c: createdConversations, m: createdMessages } = notify.created || {};
-	const { m: modifiedMessages } = notify.modified || {};
-	const newConversations = createdConversations as Array<SoapConversation>;
-	const newMessages = createdMessages as Array<SoapIncompleteMessage>;
-	const changedMessages = modifiedMessages as Array<SoapIncompleteMessage>;
-	const allReceivedMessages = [...changedMessages, ...newMessages];
-	// in case of created, we have SoapConversation
-	if (createdConversations && createdMessages) {
-		const conversationsWithMessageIds = map(newConversations, (conversation) =>
-			mapToNormalizedConversation({ conversation, messages: allReceivedMessages })
-		);
-		handleNotifyConversationsCreated(conversationsWithMessageIds);
-		const normalizedMessages = allReceivedMessages.map((message) =>
-			normalizeMailMessageFromSoap(message)
-		);
-		updateMessages(normalizedMessages);
-	}
-
-	if (newMessages) {
-		const messages = map(newMessages, (message) => normalizeMailMessageFromSoap(message));
-		handleNotifyMessagesCreated(messages);
-	}
-}
-
-function processModifiedNotifications(notify: SoapNotify): void {
-	const modifiedConversations = notify.modified?.c as Array<SoapConversation>;
-	if (modifiedConversations) {
-		const updatedConversations = normalizeConversations(modifiedConversations);
-		handleNotifyConversationsModified(updatedConversations);
-
-		const convMessages = extractConvMessage(modifiedConversations);
-		updateMessages(convMessages);
-	}
-
-	const modifiedMessages = notify.modified?.m as Array<SoapIncompleteMessage>;
-	if (modifiedMessages) {
-		const messages = map(modifiedMessages, (message) => normalizeMailMessageFromSoap(message));
-		handleNotifyMessagesModified(messages);
-	}
-}
-
 type ProcessNotificationsProps = {
 	notifyList: SoapNotify[];
 	seq: number;
@@ -136,18 +88,32 @@ function processNotifications({
 		handleFoldersNotify({ notifyList, notify, worker: folderWorker, store: useFolderStore });
 		handleTagsNotify({ notify, worker: tagsWorker, store: useTagStore });
 
-		if (notify.created) {
-			processCreatedNotifications(notify);
-		}
+		const { created, modified } = notify;
+		// TODO: what if we just collect conversation and messages (modified and created) and just call updateMessages and updateConversatioss?
 
-		if (notify.modified) {
-			processModifiedNotifications(notify);
-		}
+		const allReceivedMessages = [] as Array<SoapIncompleteMessage>;
+		const allReceivedConversations = [] as Array<SoapConversation>;
+		const { c: createdConversations, m: createdMessages } = created || {};
+		createdMessages && allReceivedMessages.push(...createdMessages);
+		createdConversations && allReceivedConversations.push(...createdConversations);
+
+		const { c: modifiedConversations, m: modifiedMessages } = modified || {};
+		modifiedMessages && allReceivedMessages.push(...modifiedMessages);
+		modifiedConversations && allReceivedConversations.push(...modifiedConversations);
+
+		const messagesToStore = map(allReceivedMessages, (message) =>
+			normalizeMailMessageFromSoap(message)
+		);
+		const conversationsWithMessageIdsToStore = map(allReceivedConversations, (conversation) =>
+			mapToNormalizedConversation({ conversation, messages: allReceivedMessages })
+		);
+		conversationsWithMessageIdsToStore.length > 0 &&
+			createOrUpdateConversations(conversationsWithMessageIdsToStore);
+		messagesToStore.length > 0 && createOrUpdateMessages(messagesToStore);
 
 		const deletedIds = notify.deleted;
 		if (deletedIds) {
-			const idsToDelete = deletedIds;
-			handleNotifyDeleted(idsToDelete);
+			handleNotifyDeleted(deletedIds);
 		}
 
 		setSeq(notify.seq);


### PR DESCRIPTION
- update is actually creating messages, it does not only update existing messages/conversations. I just updated the store to also add the new items to the index slice
- this is just a proposal, but depending on the strategy there may be functions we don't need anymore
- we could get rid of specific store functions suited for specific business needs (decoupling). For example in the data sync handler we need to just update the message/conversations. We add them to the index slice if the notify is "created". However since the "update" functions in the store merge the results and create the result if it does not exist we can use the already existing functions. Essentially sync-data-handler-store can be removed.