### PR TITLE
[hotfix] correct size calculation in smart link warning banner

### DIFF
--- a/src/views/app/detail-panel/edit/parts/size-exceeded-waring-banner.tsx
+++ b/src/views/app/detail-panel/edit/parts/size-exceeded-waring-banner.tsx
@@ -20,9 +20,10 @@ function calculateTotalSmartLinksSize(savedAttachments: MailsEditorV2['savedAtta
 	);
 }
 export const calculateMailSize = (editor: MailsEditorV2): number => {
+	const base64conversionRate = 1.33;
 	const saveDraftSize = editor?.size ?? 0;
 	const totalSmartLinksSize = calculateTotalSmartLinksSize(editor.savedAttachments);
-	return saveDraftSize - totalSmartLinksSize * 0.9;
+	return saveDraftSize - totalSmartLinksSize * base64conversionRate;
 };
 
 export const SizeExceededWarningBanner = ({

--- a/src/views/app/detail-panel/edit/parts/test/size-exceeded-warning-banner.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/test/size-exceeded-warning-banner.test.tsx
@@ -67,9 +67,9 @@ describe('sizeExceededWarningBanner', () => {
 
 	it('does not render a warning banner when a smartLink is marked for convertion', async () => {
 		setupEditorStore({ editors: [] });
-		const attachment = { requiresSmartLinkConversion: true, size: 150 } as SavedAttachment;
+		const attachment = { requiresSmartLinkConversion: true, size: 5_000 } as SavedAttachment;
 		const editor = await generateEditorV2Case(1);
-		editor.size = 200;
+		editor.size = 50 + 5_000 * 1.33;
 		editor.savedAttachments = [attachment];
 		addEditor({ id: editor.id, editor });
 

--- a/src/views/app/detail-panel/edit/parts/test/size-exceeded-warning-banner.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/test/size-exceeded-warning-banner.test.tsx
@@ -158,7 +158,7 @@ describe('sizeExceededWarningBanner', () => {
 				size: 1000,
 				savedAttachments: [attachment]
 			};
-			expect(calculateMailSize(editor)).toBe(820);
+			expect(calculateMailSize(editor)).toBe(734);
 		});
 
 		it('returns correct size when editor size is zero', async () => {
@@ -168,7 +168,7 @@ describe('sizeExceededWarningBanner', () => {
 				size: 0,
 				savedAttachments: [attachment]
 			};
-			expect(calculateMailSize(editor)).toBe(-180);
+			expect(calculateMailSize(editor)).toBe(-266);
 		});
 
 		it('returns correct size when totalSmartLinksSize is zero', async () => {


### PR DESCRIPTION
Update `calculateMailSize` to use a base64 conversion rate for totalSmartLinksSize calculation. Adjust tests in
`size-exceeded-warning-banner.test.tsx` accordingly.