### PR TITLE
fix: [CO-1902] translation key for attachment

### DIFF
--- a/src/views/search/parts/toggle-filters.tsx
+++ b/src/views/search/parts/toggle-filters.tsx
@@ -142,7 +142,7 @@ const ToggleFilters: FC<ToggleFiltersProps> = ({ compProps }): ReactElement => {
 							<Switch onClick={toggleAttachment} value={hasAttachment} />
 						</Padding>
 						<Text size="large" weight="bold">
-							{t('label.attachment', 'Attachment')}
+							{t('label.attachment_one', 'Attachment')}
 						</Text>
 					</Container>
 					<Padding bottom="small" />

--- a/src/views/settings/filters/parts/utils.tsx
+++ b/src/views/settings/filters/parts/utils.tsx
@@ -425,7 +425,7 @@ export const getStatusOptions = (t: TFunction): StatusOption[] => [
 	{ label: t('settings.date', 'Date'), value: 'date' },
 	{ label: t('settings.body', 'Body'), value: 'body' },
 	{
-		label: t('label.attachment', 'Attachment'),
+		label: t('label.attachment_one', 'Attachment'),
 		value: 'attachment'
 	},
 	{


### PR DESCRIPTION
The translation key for "Attachment" was updated from `label.attachment` to `label.attachment_one` in `toggle-filters.tsx` and `utils.tsx`.