### PR TITLE
[CO-1815] improve regex for header parsing

### DIFF
--- a/src/commons/get-quoted-text-util.ts
+++ b/src/commons/get-quoted-text-util.ts
@@ -647,7 +647,7 @@ export function getQuotedTextFromOriginalContent(body: string, originalContent: 
 			htmlDoc.getElementsByClassName('OutlookMessageHeader').length > 0 &&
 			htmlDoc.getElementsByClassName('OutlookMessageHeader')[0]
 		) {
-			const zimbraQuoted = htmlBody.split(/class="OutlookMessageHeader"\s*[^>]*>/i);
+			const zimbraQuoted = htmlBody.split(/class="OutlookMessageHeader"[^>]*?>/i);
 			htmlDoc.body.innerHTML = '';
 			zimbraQuoted.splice(1).forEach((item) => {
 				const div = htmlDoc.createElement('div');

--- a/src/commons/get-quoted-text-util.ts
+++ b/src/commons/get-quoted-text-util.ts
@@ -647,7 +647,7 @@ export function getQuotedTextFromOriginalContent(body: string, originalContent: 
 			htmlDoc.getElementsByClassName('OutlookMessageHeader').length > 0 &&
 			htmlDoc.getElementsByClassName('OutlookMessageHeader')[0]
 		) {
-			const zimbraQuoted = htmlBody.split('class="OutlookMessageHeader">');
+			const zimbraQuoted = htmlBody.split(/class="OutlookMessageHeader"\s*[^>]*>/i);
 			htmlDoc.body.innerHTML = '';
 			zimbraQuoted.splice(1).forEach((item) => {
 				const div = htmlDoc.createElement('div');

--- a/src/commons/tests/get-quoted-text-utils.test.tsx
+++ b/src/commons/tests/get-quoted-text-utils.test.tsx
@@ -144,5 +144,15 @@ describe('Get Quoted Test Utils', () => {
 				`<div class="quoted_text"></div>`
 			);
 		});
+
+		it('should return empty quoted div if it contains a div with OutlookMessageHeader and attributes', () => {
+			const originalContent = '<div>Original content</div>';
+			const extraContent =
+				'<DIV class="OutlookMessageHeader" lang="it" dir="ltr" align="left"></DIV>';
+			const body = originalContent + extraContent;
+			expect(getQuotedTextFromOriginalContent(body, originalContent)).toBe(
+				`<div class="quoted_text"></div>`
+			);
+		});
 	});
 });


### PR DESCRIPTION
Updated the regex in `getQuotedTextFromOriginalContent` to handle attributes in `OutlookMessageHeader` class.

test(get-quoted-text-utils.test.tsx): add test for header attributes

Added a test case to validate handling of `OutlookMessageHeader` with attributes in `getQuotedTextFromOriginalContent`.