### PR TITLE
fix: [CO-1996] avoid showing browser notifications in focus mode

### DIFF
--- a/src/store/emails/sync-data-handler/tests/sync-data-handler-store.test.ts
+++ b/src/store/emails/sync-data-handler/tests/sync-data-handler-store.test.ts
@@ -21,6 +21,7 @@ import {
 	useMessageById,
 	useMessageIndexSlice
 } from '../../store';
+import { triggerNotification } from '../trigger-notification';
 
 jest.mock('../../../../carbonio-ui-commons/store/zustand/tags', () => ({
 	...jest.requireActual('../../../../carbonio-ui-commons/store/zustand/tags'),
@@ -103,5 +104,39 @@ describe('handleNotifyMessagesCreated', () => {
 				expect(messagesIds).toEqual(['1', '2']);
 			});
 		});
+	});
+});
+
+let mockIsFocusMode = false;
+
+const mockedMultipleNotify = jest.fn();
+
+jest.mock('@zextras/carbonio-shell-ui', () => ({
+	get IS_FOCUS_MODE(): boolean {
+		return mockIsFocusMode;
+	},
+	getNotificationManager: jest.fn(() => ({
+		multipleNotify: mockedMultipleNotify
+	})),
+	getUserSettings: jest.fn(() => ({
+		props: [],
+		prefs: {
+			zimbraPrefMailToasterEnabled: 'TRUE',
+			zimbraPrefShowAllNewMailNotifications: 'TRUE'
+		}
+	}))
+}));
+
+describe('triggerNotification', () => {
+	it('multipleNotify is not called if IS_FOCUS_MODE is true', () => {
+		mockIsFocusMode = true;
+		triggerNotification([generateMessage({ id: 'id-1' })], jest.fn());
+		expect(mockedMultipleNotify).not.toHaveBeenCalled();
+	});
+
+	it('multipleNotify is called if IS_FOCUS_MODE is false', () => {
+		mockIsFocusMode = false;
+		triggerNotification([generateMessage({ id: 'id-1' })], jest.fn());
+		expect(mockedMultipleNotify).toHaveBeenCalled();
 	});
 });

--- a/src/store/emails/sync-data-handler/trigger-notification.tsx
+++ b/src/store/emails/sync-data-handler/trigger-notification.tsx
@@ -6,6 +6,7 @@
 import {
 	getNotificationManager,
 	getUserSettings,
+	IS_FOCUS_MODE,
 	NotificationConfig,
 	t
 } from '@zextras/carbonio-shell-ui';
@@ -37,7 +38,11 @@ export const triggerNotification = (
 		)
 	);
 
-	if (!messagesToNotify?.length || !(isAudioEnabled || isShowNotificationEnabled)) {
+	if (
+		!messagesToNotify?.length ||
+		!(isAudioEnabled || isShowNotificationEnabled) ||
+		IS_FOCUS_MODE
+	) {
 		return;
 	}
 


### PR DESCRIPTION
Avoid calling `getNotificationManager().multipleNotify()` if mails zapp is loaded in focus mode