### PR TITLE
fix: edit folder modal use folder translated name + "bytes" renamed to "B"

### DIFF
--- a/src/integrations/shared-invite-reply/parts/color-select.tsx
+++ b/src/integrations/shared-invite-reply/parts/color-select.tsx
@@ -18,42 +18,46 @@ const LabelFactory = ({
 	label,
 	open,
 	focus
-}: CustomLabelFactoryProps): React.JSX.Element => (
-	<ColorContainer
-		orientation="horizontal"
-		width="fill"
-		crossAlignment="center"
-		mainAlignment="space-between"
-		borderRadius="half"
-		background="gray5"
-		padding={{
-			all: 'small'
-		}}
-	>
-		<Row width="100%" takeAvailableSpace mainAlignment="space-between">
-			<Row
-				orientation="vertical"
-				crossAlignment="flex-start"
-				mainAlignment="flex-start"
-				padding={{ left: 'small' }}
-			>
-				<Text size="small" color={open || focus ? 'primary' : 'secondary'}>
-					{label}
-				</Text>
-				<TextUpperCase>{selected[0].label}</TextUpperCase>
+}: CustomLabelFactoryProps): React.JSX.Element => {
+	// FIXME: potential unsafe access to array, how do you know that selectedColor is not undefined and array is not empty?
+	const selectedColor = selected[0];
+	return (
+		<ColorContainer
+			orientation="horizontal"
+			width="fill"
+			crossAlignment="center"
+			mainAlignment="space-between"
+			borderRadius="half"
+			background="gray5"
+			padding={{
+				all: 'small'
+			}}
+		>
+			<Row width="100%" takeAvailableSpace mainAlignment="space-between">
+				<Row
+					orientation="vertical"
+					crossAlignment="flex-start"
+					mainAlignment="flex-start"
+					padding={{ left: 'small' }}
+				>
+					<Text size="small" color={open || focus ? 'primary' : 'secondary'}>
+						{label}
+					</Text>
+					<TextUpperCase>{selectedColor.label}</TextUpperCase>
+				</Row>
+				<Padding right="small">
+					<Square $color={ZIMBRA_STANDARD_COLORS[parseInt(selectedColor.value, 10)].hex} />
+				</Padding>
 			</Row>
-			<Padding right="small">
-				<Square $color={ZIMBRA_STANDARD_COLORS[parseInt(selected[0].value, 10)].hex} />
-			</Padding>
-		</Row>
-		<Icon
-			size="large"
-			icon={open ? 'ChevronUpOutline' : 'ChevronDownOutline'}
-			color={open || focus ? 'primary' : 'secondary'}
-			style={{ alignSelf: 'center' }}
-		/>
-	</ColorContainer>
-);
+			<Icon
+				size="large"
+				icon={open ? 'ChevronUpOutline' : 'ChevronDownOutline'}
+				color={open || focus ? 'primary' : 'secondary'}
+				style={{ alignSelf: 'center' }}
+			/>
+		</ColorContainer>
+	);
+};
 
 function getColorLabel(color: string): string {
 	/* i18next-extract-disable-next-line */
@@ -67,7 +71,7 @@ function getColorLabel(color: string): string {
 
 export default function ColorSelect({
 	onChange,
-	defaultColor = 0,
+	defaultColor,
 	label
 }: Readonly<{
 	onChange: SingleSelectionOnChange;
@@ -95,6 +99,7 @@ export default function ColorSelect({
 			})),
 		[]
 	);
+	// FIXME: potential unsafe access to array, how do you know that colors[defaultColor] is not undefined and array is not empty?
 	const defaultSelection = useMemo(() => colors[defaultColor], [colors, defaultColor]);
 	return (
 		<Select

--- a/src/views/sidebar/edit-modal.tsx
+++ b/src/views/sidebar/edit-modal.tsx
@@ -3,10 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { Container } from '@zextras/carbonio-design-system';
 import React, { FC, useCallback, useState } from 'react';
-import type { ModalProps } from '../../types';
+
+import { Container } from '@zextras/carbonio-design-system';
+
 import EditPermissionsModal from './edit-permissions-modal';
+import type { ModalProps } from '../../types';
 import { Context } from './parts/edit/edit-context';
 import MainEditModal from './parts/edit/edit-default-modal';
 import ShareRevokeModal from './parts/edit/share-revoke-modal';

--- a/src/views/sidebar/new-modal.tsx
+++ b/src/views/sidebar/new-modal.tsx
@@ -30,8 +30,9 @@ export const NewModal: FC<ModalProps> = ({ folder, onClose }) => {
 	const [errorMsg, setErrorMsg] = useState<string>(
 		t('folder.modal.edit.rename_warning', 'You cannot rename a folder as a system one.')
 	);
+	const systemFolderNames = useTranslatedSystemFolders();
 	const showWarning = useMemo(() => {
-		if (includes(useTranslatedSystemFolders(), inputValue)) {
+		if (includes(systemFolderNames, inputValue)) {
 			setErrorMsg(
 				t('folder.modal.edit.rename_warning', 'You cannot rename a folder as a system one.')
 			);
@@ -47,7 +48,7 @@ export const NewModal: FC<ModalProps> = ({ folder, onClose }) => {
 			return true;
 		}
 		return false;
-	}, [inputValue]);
+	}, [inputValue, systemFolderNames]);
 
 	const { createSnackbar } = useUiUtilities();
 

--- a/src/views/sidebar/new-modal.tsx
+++ b/src/views/sidebar/new-modal.tsx
@@ -10,7 +10,7 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { find, includes, noop } from 'lodash';
 
 import { FolderSelector } from './commons/folder-selector';
-import { translatedSystemFolders } from './utils';
+import { useTranslatedSystemFolders } from './utils';
 import { createFolderSoapApi } from '../../api/create-folder-soap-api';
 import ModalFooter from '../../carbonio-ui-commons/components/modals/modal-footer';
 import ModalHeader from '../../carbonio-ui-commons/components/modals/modal-header';
@@ -31,7 +31,7 @@ export const NewModal: FC<ModalProps> = ({ folder, onClose }) => {
 		t('folder.modal.edit.rename_warning', 'You cannot rename a folder as a system one.')
 	);
 	const showWarning = useMemo(() => {
-		if (includes(translatedSystemFolders(), inputValue)) {
+		if (includes(useTranslatedSystemFolders(), inputValue)) {
 			setErrorMsg(
 				t('folder.modal.edit.rename_warning', 'You cannot rename a folder as a system one.')
 			);

--- a/src/views/sidebar/parts/edit/edit-default-modal.tsx
+++ b/src/views/sidebar/parts/edit/edit-default-modal.tsx
@@ -264,14 +264,15 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 		createSnackbar
 	]);
 
-	const title = t('label.edit_folder_properties', {
-		name: getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }),
-		defaultValue: 'Edit {{name}} properties'
-	});
-
 	return (
 		<>
-			<ModalHeader onClose={onClose} title={title} />
+			<ModalHeader
+				onClose={onClose}
+				title={t('label.edit_folder_properties', {
+					name: getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }),
+					defaultValue: 'Edit {{name}} properties'
+				})}
+			/>
 
 			<NameInputRow
 				showWarning={showWarning}
@@ -283,7 +284,7 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 			/>
 			<Container mainAlignment="flex-start" crossAlignment="flex-start" padding={{ top: 'medium' }}>
 				<FolderDetails folder={folder} />
-				{!isEmpty(folder?.acl) && !folder.owner && (
+				{!isEmpty(folder?.acl) && (
 					<ShareFolderProperties folder={folder} setActiveModal={setActiveModal} />
 				)}
 				<RetentionPolicies

--- a/src/views/sidebar/parts/edit/edit-default-modal.tsx
+++ b/src/views/sidebar/parts/edit/edit-default-modal.tsx
@@ -17,13 +17,13 @@ import { folderActionSoapApi } from '../../../../api/folder-action-soap-api';
 import ModalFooter from '../../../../carbonio-ui-commons/components/modals/modal-footer';
 import ModalHeader from '../../../../carbonio-ui-commons/components/modals/modal-header';
 import { FolderActionsType, FOLDERS } from '../../../../carbonio-ui-commons/constants/folders';
-import type { MainEditModalPropType } from '../../../../carbonio-ui-commons/types/sidebar';
 import {
 	allowedActionOnSharedAccount,
 	isValidFolderName
 } from '../../../../carbonio-ui-commons/utils/utils';
 import { useUiUtilities } from '../../../../hooks/use-ui-utilities';
-import { translatedSystemFolders } from '../../utils';
+import { ModalProps } from '../../../../types';
+import { getFolderTranslatedName, translatedSystemFolders } from '../../utils';
 
 const numberRegex = /^\d+$/;
 const DAYS_LABEL = 'label.days';
@@ -31,7 +31,10 @@ const WEEKS_LABEL = 'label.weeks';
 const MONTHS_LABEL = 'label.months';
 const YEARS_LABEL = 'label.years';
 
-const MainEditModal: FC<MainEditModalPropType> = ({ folder, onClose, setActiveModal }) => {
+type MainEditModalProps = ModalProps & {
+	setActiveModal: (modal: string) => void;
+};
+const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal }) => {
 	const [inputValue, setInputValue] = useState(folder.name);
 	const [showPolicy, setShowPolicy] = useState(false);
 	const [rtnValue, setRtnValue] = useState<number | string>(0);
@@ -44,7 +47,7 @@ const MainEditModal: FC<MainEditModalPropType> = ({ folder, onClose, setActiveMo
 	const [dsblMsgRet, setDsblMsgRet] = useState(false);
 	const [emptyRtnValue, setEmptyRtnValue] = useState(false);
 	const [emptyDisValue, setEmptyDisValue] = useState(false);
-	const [folderColor, setFolderColor] = useState(folder?.color ?? 0);
+	const [folderColor, setFolderColor] = useState<number>(folder.color ?? 0);
 
 	const retentionPeriod = [
 		{
@@ -141,9 +144,7 @@ const MainEditModal: FC<MainEditModalPropType> = ({ folder, onClose, setActiveMo
 	}, [folder.retentionPolicy]);
 
 	const showWarning = useMemo(
-		() =>
-			includes(translatedSystemFolders(), inputValue) ||
-			(inputValue && !isValidFolderName(inputValue)),
+		() => includes(translatedSystemFolders(), inputValue) || !isValidFolderName(inputValue),
 		[inputValue]
 	);
 	const inpDisable = useMemo(
@@ -199,8 +200,6 @@ const MainEditModal: FC<MainEditModalPropType> = ({ folder, onClose, setActiveMo
 				folder: {
 					...folder,
 					parent: folder.l || '',
-					path: folder.absFolderPath,
-					absParent: '2',
 					children: []
 				},
 				name: inputValue,
@@ -266,7 +265,7 @@ const MainEditModal: FC<MainEditModalPropType> = ({ folder, onClose, setActiveMo
 	]);
 
 	const title = t('label.edit_folder_properties', {
-		name: folder.name,
+		name: getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }),
 		defaultValue: 'Edit {{name}} properties'
 	});
 
@@ -279,12 +278,11 @@ const MainEditModal: FC<MainEditModalPropType> = ({ folder, onClose, setActiveMo
 				setInputValue={setInputValue}
 				inputValue={inputValue}
 				inpDisable={inpDisable}
-				folderColor={String(folderColor)}
+				folderColor={folderColor}
 				setFolderColor={setFolderColor}
 			/>
 			<Container mainAlignment="flex-start" crossAlignment="flex-start" padding={{ top: 'medium' }}>
 				<FolderDetails folder={folder} />
-
 				{!isEmpty(folder?.acl) && !folder.owner && (
 					<ShareFolderProperties folder={folder} setActiveModal={setActiveModal} />
 				)}

--- a/src/views/sidebar/parts/edit/edit-default-modal.tsx
+++ b/src/views/sidebar/parts/edit/edit-default-modal.tsx
@@ -147,6 +147,7 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 		() => includes(translatedSystemFolders(), inputValue) || !isValidFolderName(inputValue),
 		[inputValue]
 	);
+
 	const inpDisable = useMemo(
 		() =>
 			includes(

--- a/src/views/sidebar/parts/edit/edit-default-modal.tsx
+++ b/src/views/sidebar/parts/edit/edit-default-modal.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../../../carbonio-ui-commons/utils/utils';
 import { useUiUtilities } from '../../../../hooks/use-ui-utilities';
 import { ModalProps } from '../../../../types';
-import { getFolderTranslatedName, translatedSystemFolders } from '../../utils';
+import { getFolderTranslatedName, useTranslatedSystemFolders } from '../../utils';
 
 const numberRegex = /^\d+$/;
 const DAYS_LABEL = 'label.days';
@@ -35,7 +35,7 @@ type MainEditModalProps = ModalProps & {
 	setActiveModal: (modal: string) => void;
 };
 const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal }) => {
-	const [inputValue, setInputValue] = useState(folder.name);
+	const [folderNameInputValue, setFolderNameInputValue] = useState(folder.name);
 	const [showPolicy, setShowPolicy] = useState(false);
 	const [rtnValue, setRtnValue] = useState<number | string>(0);
 	const [purgeValue, setPurgeValue] = useState<number | string>(0);
@@ -143,9 +143,16 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 		}
 	}, [folder.retentionPolicy]);
 
-	const showWarning = useMemo(
-		() => includes(translatedSystemFolders(), inputValue) || !isValidFolderName(inputValue),
-		[inputValue]
+	const isFolderNameInputEmpty = useMemo(
+		() => isEmpty(folderNameInputValue),
+		[folderNameInputValue]
+	);
+	const systemFolderNames = useTranslatedSystemFolders();
+	const showIsSystemFolderNameWarning = useMemo(
+		() =>
+			includes(systemFolderNames, folderNameInputValue) ||
+			(!isFolderNameInputEmpty && !isValidFolderName(folderNameInputValue)),
+		[folderNameInputValue, isFolderNameInputEmpty, systemFolderNames]
 	);
 
 	const inpDisable = useMemo(
@@ -158,8 +165,8 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 	);
 
 	const disableSubmit = useMemo(
-		() => (showWarning || emptyRtnValue) && !inpDisable,
-		[showWarning, emptyRtnValue, inpDisable]
+		() => (isFolderNameInputEmpty || showIsSystemFolderNameWarning || emptyRtnValue) && !inpDisable,
+		[isFolderNameInputEmpty, showIsSystemFolderNameWarning, emptyRtnValue, inpDisable]
 	);
 
 	const onConfirm = useCallback(() => {
@@ -183,7 +190,7 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 				return;
 			}
 		}
-		if (inputValue && submit) {
+		if (folderNameInputValue && submit) {
 			let lt;
 			let pr;
 
@@ -203,7 +210,7 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 					parent: folder.l || '',
 					children: []
 				},
-				name: inputValue,
+				name: folderNameInputValue,
 				op: 'update',
 				color: Number(folderColor),
 				retentionPolicy:
@@ -249,12 +256,12 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 				}
 			});
 		}
-		setInputValue('');
+		setFolderNameInputValue('');
 		onClose();
 	}, [
 		dsblMsgRet,
 		dsblMsgDis,
-		inputValue,
+		folderNameInputValue,
 		onClose,
 		rtnValue,
 		purgeValue,
@@ -276,9 +283,9 @@ const MainEditModal: FC<MainEditModalProps> = ({ folder, onClose, setActiveModal
 			/>
 
 			<NameInputRow
-				showWarning={showWarning}
-				setInputValue={setInputValue}
-				inputValue={inputValue}
+				showWarning={showIsSystemFolderNameWarning}
+				setInputValue={setFolderNameInputValue}
+				inputValue={folderNameInputValue}
 				inpDisable={inpDisable}
 				folderColor={folderColor}
 				setFolderColor={setFolderColor}

--- a/src/views/sidebar/parts/edit/folder-details.tsx
+++ b/src/views/sidebar/parts/edit/folder-details.tsx
@@ -3,14 +3,22 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import React, { FC } from 'react';
+
 import { Container, Divider, Padding, Row, Text } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
-import React, { FC } from 'react';
+
 import type { Folder } from '../../../../carbonio-ui-commons/types/folder';
 
 const bytesToSize = (bytes: number): string => {
-	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-	if (bytes === 0) return '0 Byte';
+	const sizes = [
+		t('settings.b', 'B'),
+		t('settings.kb', 'KB'),
+		t('settings.mb', 'Mb'),
+		t('settings.gb', 'GB'),
+		t('settings.tb', 'TB')
+	];
+	if (bytes === 0) return `0 ${sizes[0]}`;
 	const i = Math.floor(Math.log(bytes) / Math.log(1024));
 	return `${Math.round(bytes / 1024 ** i)} ${sizes[i]}`;
 };

--- a/src/views/sidebar/parts/edit/name-input.tsx
+++ b/src/views/sidebar/parts/edit/name-input.tsx
@@ -8,10 +8,17 @@ import React, { ChangeEvent, FC } from 'react';
 import { Container, Input, Padding, Text } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
 
-import type { NameInputRowProps } from '../../../../carbonio-ui-commons/types/sidebar';
 import { isValidFolderName } from '../../../../carbonio-ui-commons/utils/utils';
 import ColorPicker from '../../../../integrations/shared-invite-reply/parts/color-select';
 
+type NameInputRowProps = {
+	setInputValue: (value: string) => void;
+	inputValue: string;
+	showWarning: boolean;
+	inpDisable: boolean;
+	folderColor: number;
+	setFolderColor: (value: number) => void;
+};
 const NameInputRow: FC<NameInputRowProps> = ({
 	setInputValue,
 	inpDisable,
@@ -43,9 +50,9 @@ const NameInputRow: FC<NameInputRowProps> = ({
 		)}
 		<Padding top="small" />
 		<ColorPicker
-			onChange={(color: string | null): void => setFolderColor(color ?? '')}
+			onChange={(color: string | null): void => setFolderColor(Number(color))}
 			label={t('label.select_color', 'Select Color')}
-			defaultColor={parseInt(folderColor ?? '0', 10)}
+			defaultColor={folderColor}
 			data-testid="folder-color"
 		/>
 	</Container>

--- a/src/views/sidebar/parts/edit/name-input.tsx
+++ b/src/views/sidebar/parts/edit/name-input.tsx
@@ -6,7 +6,7 @@
 import React, { ChangeEvent, FC } from 'react';
 
 import { Container, Input, Padding, Text } from '@zextras/carbonio-design-system';
-import { t } from '@zextras/carbonio-shell-ui';
+import { useTranslation } from 'react-i18next';
 
 import { isValidFolderName } from '../../../../carbonio-ui-commons/utils/utils';
 import ColorPicker from '../../../../integrations/shared-invite-reply/parts/color-select';
@@ -26,36 +26,39 @@ const NameInputRow: FC<NameInputRowProps> = ({
 	inputValue,
 	folderColor,
 	setFolderColor
-}) => (
-	<Container mainAlignment="center" crossAlignment="flex-start">
-		<Input
-			label={t('label.folder_name', 'Folder name')}
-			onChange={(e: ChangeEvent<HTMLInputElement>): void => setInputValue(e.target.value)}
-			disabled={inpDisable}
-			value={inputValue}
-			hasError={showWarning && !inpDisable}
-			data-testid="folder-name"
-		/>
-		{showWarning && !inpDisable && (
-			<Padding all="small">
-				<Text size="small" color="error" data-testid="rename-error-msg">
-					{inputValue && !isValidFolderName(inputValue)
-						? t(
-								'folder.modal.edit.invalid_folder_name_warning_msg',
-								'Special characters not allowed. Max lenght is 128 characters.'
-							)
-						: t('folder.modal.edit.rename_warning', 'You cannot rename a folder as a system one')}
-				</Text>
-			</Padding>
-		)}
-		<Padding top="small" />
-		<ColorPicker
-			onChange={(color: string | null): void => setFolderColor(Number(color))}
-			label={t('label.select_color', 'Select Color')}
-			defaultColor={folderColor}
-			data-testid="folder-color"
-		/>
-	</Container>
-);
+}) => {
+	const [t] = useTranslation();
+	return (
+		<Container mainAlignment="center" crossAlignment="flex-start">
+			<Input
+				label={t('label.folder_name', 'Folder name')}
+				onChange={(e: ChangeEvent<HTMLInputElement>): void => setInputValue(e.target.value)}
+				disabled={inpDisable}
+				value={inputValue}
+				hasError={showWarning && !inpDisable}
+				data-testid="folder-name"
+			/>
+			{showWarning && !inpDisable && (
+				<Padding all="small">
+					<Text size="small" color="error" data-testid="rename-error-msg">
+						{inputValue && !isValidFolderName(inputValue)
+							? t(
+									'folder.modal.edit.invalid_folder_name_warning_msg',
+									'Special characters not allowed. Max lenght is 128 characters.'
+								)
+							: t('folder.modal.edit.rename_warning', 'You cannot rename a folder as a system one')}
+					</Text>
+				</Padding>
+			)}
+			<Padding top="small" />
+			<ColorPicker
+				onChange={(color: string | null): void => setFolderColor(Number(color))}
+				label={t('label.select_color', 'Select Color')}
+				defaultColor={folderColor}
+				data-testid="folder-color"
+			/>
+		</Container>
+	);
+};
 
 export default NameInputRow;

--- a/src/views/sidebar/parts/edit/tests/name-input.test.tsx
+++ b/src/views/sidebar/parts/edit/tests/name-input.test.tsx
@@ -5,9 +5,9 @@
  */
 import React from 'react';
 
+import { ZIMBRA_STANDARD_COLORS } from '../../../../../carbonio-ui-commons/constants';
 import { setupTest, screen } from '../../../../../carbonio-ui-commons/test/test-setup';
 import NameInputRow from '../name-input';
-import { ZIMBRA_STANDARD_COLORS } from '../../../../../carbonio-ui-commons/constants';
 
 describe('NameInputRow', () => {
 	const inputValue = 'Test Folder';
@@ -31,11 +31,11 @@ describe('NameInputRow', () => {
 			/>
 		);
 
-		expect(screen.getByText('label.select_color')).toBeVisible();
+		expect(screen.getByText(/select color/i)).toBeVisible();
 		expect(screen.getByText('color.blue')).toBeVisible();
 
-		expect(screen.getByText('label.folder_name')).toBeVisible();
-		const folderName = screen.getByRole('textbox', { name: /label\.folder_name/i });
+		expect(screen.getByText(/folder name/i)).toBeVisible();
+		const folderName = screen.getByRole('textbox', { name: /folder name/i });
 		expect(folderName).toBeVisible();
 		expect(folderName).toHaveValue(inputValue);
 	});

--- a/src/views/sidebar/parts/edit/tests/name-input.test.tsx
+++ b/src/views/sidebar/parts/edit/tests/name-input.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { setupTest, screen } from '../../../../../carbonio-ui-commons/test/test-setup';
+import NameInputRow from '../name-input';
+import { ZIMBRA_STANDARD_COLORS } from '../../../../../carbonio-ui-commons/constants';
+
+describe('NameInputRow', () => {
+	const inputValue = 'Test Folder';
+	const folderColor = 1;
+	const showWarning = false;
+	const inpDisable = false;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should render correctly', () => {
+		setupTest(
+			<NameInputRow
+				setInputValue={jest.fn()}
+				inpDisable={inpDisable}
+				showWarning={showWarning}
+				inputValue={inputValue}
+				folderColor={folderColor}
+				setFolderColor={jest.fn()}
+			/>
+		);
+
+		expect(screen.getByText('label.select_color')).toBeVisible();
+		expect(screen.getByText('color.blue')).toBeVisible();
+
+		expect(screen.getByText('label.folder_name')).toBeVisible();
+		const folderName = screen.getByRole('textbox', { name: /label\.folder_name/i });
+		expect(folderName).toBeVisible();
+		expect(folderName).toHaveValue(inputValue);
+	});
+	it('should call colorPicker onChange with the new color', async () => {
+		const setFolderColor = jest.fn();
+		const { user } = setupTest(
+			<NameInputRow
+				setInputValue={jest.fn()}
+				inpDisable={inpDisable}
+				showWarning={showWarning}
+				inputValue={inputValue}
+				folderColor={folderColor}
+				setFolderColor={setFolderColor}
+			/>
+		);
+
+		await user.click(screen.getByTestId('icon: ChevronDownOutline'));
+		await user.click(screen.getByText('color.red'));
+
+		expect(setFolderColor).toHaveBeenCalledWith(ZIMBRA_STANDARD_COLORS[5].zValue);
+	});
+});

--- a/src/views/sidebar/tests/edit-modal.test.tsx
+++ b/src/views/sidebar/tests/edit-modal.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { faker } from '@faker-js/faker';
-import { act, screen, waitFor, within } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
 
 import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';

--- a/src/views/sidebar/tests/edit-modal.test.tsx
+++ b/src/views/sidebar/tests/edit-modal.test.tsx
@@ -293,13 +293,11 @@ describe('edit-modal', () => {
 		const folderName = faker.lorem.word();
 		await user.type(folderInputElement, folderName);
 
-		await waitFor(() => {
-			expect(
-				screen.getByRole('button', {
-					name: /label\.edit/i
-				})
-			).toBeEnabled();
-		});
+		expect(
+			screen.getByRole('button', {
+				name: /label\.edit/i
+			})
+		).toBeEnabled();
 
 		const wipeInterceptor = createSoapAPIInterceptor<
 			{ action: SoapFolderAction },

--- a/src/views/sidebar/tests/edit-modal.test.tsx
+++ b/src/views/sidebar/tests/edit-modal.test.tsx
@@ -12,6 +12,7 @@ import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
 import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
 import { ZIMBRA_STANDARD_COLORS } from '../../../carbonio-ui-commons/constants/utils';
 import { getFolder } from '../../../carbonio-ui-commons/store/zustand/folder';
+import { generateFolder } from '../../../carbonio-ui-commons/test/mocks/folders/folders-generator';
 import { createSoapAPIInterceptor } from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/store/folders';
 import { buildSoapErrorResponseBody } from '../../../carbonio-ui-commons/test/mocks/utils/soap';
@@ -20,6 +21,10 @@ import { Folder, FolderView } from '../../../carbonio-ui-commons/types/folder';
 import { SoapFolderAction } from '../../../types';
 import { EditModal } from '../edit-modal';
 
+const aFolderWithoutSharePermission = (folder: Partial<Folder> = {}): Folder => ({
+	...generateFolder(folder),
+	acl: undefined
+});
 describe('edit-modal', () => {
 	test('edit the folder excepting the system folders', async () => {
 		const closeModal = jest.fn();
@@ -56,10 +61,10 @@ describe('edit-modal', () => {
 			{}
 		);
 
-		expect(screen.getByText(/label\.folder_name/i)).toBeInTheDocument();
-		expect(screen.getByText(/label\.folder_name/i)).toBeEnabled();
+		const folderInputElement = screen.getByRole('textbox', { name: /folder name/i });
+		expect(folderInputElement).toBeEnabled();
 
-		const selectColor = screen.getByText(/label\.select_color/i);
+		const selectColor = screen.getByText(/select color/i);
 		expect(selectColor).toBeInTheDocument();
 		await act(async () => {
 			await user.click(selectColor);
@@ -112,9 +117,9 @@ describe('edit-modal', () => {
 			{}
 		);
 
-		expect(screen.getByText(/label\.folder_name/i)).toBeInTheDocument();
+		expect(screen.getByText(/folder name/i)).toBeInTheDocument();
 
-		const selectColor = screen.getByText(/label\.select_color/i);
+		const selectColor = screen.getByText(/select color/i);
 		expect(selectColor).toBeInTheDocument();
 		await act(async () => {
 			await user.click(selectColor);
@@ -165,8 +170,8 @@ describe('edit-modal', () => {
 
 		setupTest(<EditModal onClose={(): void => closeModal()} folder={folder} />, {});
 
-		expect(screen.getByText(/label\.folder_name/i)).toBeInTheDocument();
-		expect(screen.getByText(/label\.folder_name/i)).toBeEnabled();
+		expect(screen.getByText(/folder name/i)).toBeInTheDocument();
+		expect(screen.getByText(/folder name/i)).toBeEnabled();
 		const retentionPolicy = within(screen.getByTestId('retention_policy-icon')).getByTestId(
 			'icon: ChevronDownOutline'
 		);
@@ -205,8 +210,8 @@ describe('edit-modal', () => {
 
 		setupTest(<EditModal onClose={(): void => closeModal()} folder={folder} />, {});
 
-		expect(screen.getByText(/label\.folder_name/i)).toBeInTheDocument();
-		expect(screen.getByText(/label\.folder_name/i)).toBeEnabled();
+		expect(screen.getByText(/folder name/i)).toBeInTheDocument();
+		expect(screen.getByText(/folder name/i)).toBeEnabled();
 		const retentionPolicy = within(screen.getByTestId('retention_policy-icon')).getByTestId(
 			'icon: ChevronDownOutline'
 		);
@@ -360,54 +365,77 @@ describe('edit-modal', () => {
 		expect(editButton).toBeEnabled();
 	});
 
-	test('error message display and edit button disable if syatem folder name use', async () => {
-		const closeModal = jest.fn();
+	describe('Folder name input', () => {
+		it('should disable the submit button when folder name input is empty', async () => {
+			const folder: Folder = aFolderWithoutSharePermission({ name: 'Test' });
 
-		const folder: Folder = {
-			id: '106',
-			uuid: faker.string.uuid(),
-			name: 'Confluence',
-			absFolderPath: '/Inbox/Confluence',
-			l: FOLDERS.INBOX,
-			luuid: faker.string.uuid(),
-			checked: false,
-			f: 'u',
-			u: 25,
-			view: 'message' as FolderView,
-			rev: 27896,
-			ms: 27896,
-			n: 101,
-			s: 5550022,
-			i4ms: 33607,
-			i4next: 17183,
-			activesyncdisabled: false,
-			webOfflineSyncDays: 0,
-			recursive: false,
-			deletable: true,
-			isLink: false,
-			children: [],
-			parent: undefined,
-			depth: 2
-		};
+			const { user } = setupTest(<EditModal onClose={jest.fn()} folder={folder} />, {});
 
-		const { user } = setupTest(
-			<EditModal onClose={(): void => closeModal()} folder={folder} />,
-			{}
-		);
+			const newFolder = screen.getByTestId('folder-name');
+			const folderInputElement = within(newFolder).getByRole('textbox');
+			expect(folderInputElement).toHaveValue('Test');
+			await user.clear(folderInputElement);
+			expect(folderInputElement).toHaveValue('');
 
-		expect(screen.getByTestId('folder-name')).toBeInTheDocument();
-		const newFolder = screen.getByTestId('folder-name');
-		const folderInputElement = within(newFolder).getByRole('textbox');
-		expect(folderInputElement).toBeEnabled();
-		expect(newFolder).toBeInTheDocument();
-
-		// Insert the new folder name into the text input with system folder name
-		await user.type(folderInputElement, '/folders.inbox/i');
-		expect(screen.getByTestId('rename-error-msg')).toBeVisible();
-
-		const editButton = screen.getByRole('button', {
-			name: /label\.edit/i
+			const editButton = screen.getByRole('button', {
+				name: /label\.edit/i
+			});
+			expect(editButton).toBeDisabled();
 		});
-		expect(editButton).toBeDisabled();
+
+		it('should enable the edit submit button when folder name input is not empty', async () => {
+			const folder: Folder = aFolderWithoutSharePermission({ name: 'Test' });
+
+			setupTest(<EditModal onClose={jest.fn()} folder={folder} />, {});
+
+			const newFolder = screen.getByTestId('folder-name');
+			const folderInputElement = within(newFolder).getByRole('textbox');
+			expect(folderInputElement).toHaveValue('Test');
+
+			const editButton = screen.getByRole('button', {
+				name: /label\.edit/i
+			});
+			expect(editButton).toBeEnabled();
+		});
+
+		it('should display the "Cannot use a system folder name" error when folder name input is equal to a system folder', async () => {
+			const folder: Folder = aFolderWithoutSharePermission({ name: 'Test' });
+
+			const { user } = setupTest(<EditModal onClose={jest.fn()} folder={folder} />, {});
+
+			const newFolder = screen.getByTestId('folder-name');
+			const folderInputElement = within(newFolder).getByRole('textbox');
+			expect(folderInputElement).toHaveValue('Test');
+			await user.clear(folderInputElement);
+			await user.type(folderInputElement, 'Inbox');
+
+			expect(await screen.findByText('You cannot rename a folder as a system one')).toBeVisible();
+		});
+
+		it('should display the error message "Special characters not allowed" when folder name uses special chars', async () => {
+			const folder: Folder = aFolderWithoutSharePermission({ name: 'Test' });
+
+			const { user } = setupTest(
+				<EditModal onClose={(): void => jest.fn()()} folder={folder} />,
+				{}
+			);
+
+			expect(screen.getByTestId('folder-name')).toBeInTheDocument();
+			const newFolder = screen.getByTestId('folder-name');
+			const folderInputElement = within(newFolder).getByRole('textbox');
+			expect(folderInputElement).toBeEnabled();
+			expect(newFolder).toBeInTheDocument();
+
+			// Insert the new folder name into the text input with system folder name
+			await user.type(folderInputElement, '/something.with.dots/i');
+			expect(
+				await screen.findByText('Special characters not allowed. Max lenght is 128 characters.')
+			).toBeVisible();
+
+			const editButton = screen.getByRole('button', {
+				name: /label\.edit/i
+			});
+			expect(editButton).toBeDisabled();
+		});
 	});
 });

--- a/src/views/sidebar/tests/edit-modal.test.tsx
+++ b/src/views/sidebar/tests/edit-modal.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { faker } from '@faker-js/faker';
-import { act, screen, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
 
 import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
@@ -288,28 +288,29 @@ describe('edit-modal', () => {
 		const folderInputElement = within(newFolder).getByRole('textbox');
 
 		expect(folderInputElement).toBeInTheDocument();
-		await act(async () => {
-			await user.clear(folderInputElement);
-		});
-
-		const editButton = screen.getByRole('button', {
-			name: /label\.edit/i
-		});
-		expect(editButton).toBeEnabled();
+		await user.clear(folderInputElement);
 
 		const folderName = faker.lorem.word();
-		// update the existing folder name into the text input
-		await act(async () => {
-			await user.type(folderInputElement, folderName);
+		await user.type(folderInputElement, folderName);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {
+					name: /label\.edit/i
+				})
+			).toBeEnabled();
 		});
+
 		const wipeInterceptor = createSoapAPIInterceptor<
 			{ action: SoapFolderAction },
 			ErrorSoapBodyResponse
 		>('FolderAction', buildSoapErrorResponseBody());
 
-		await act(async () => {
-			await user.click(editButton);
-		});
+		await user.click(
+			screen.getByRole('button', {
+				name: /label\.edit/i
+			})
+		);
 		const { action } = await wipeInterceptor;
 
 		expect(action.id).toBe(folder.id);

--- a/src/views/sidebar/utils.ts
+++ b/src/views/sidebar/utils.ts
@@ -5,6 +5,7 @@
  */
 import { type AccordionItemType } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
+import { useTranslation } from 'react-i18next';
 
 import { ROOT_NAME, ZIMBRA_STANDARD_COLORS } from '../../carbonio-ui-commons/constants';
 import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
@@ -57,14 +58,17 @@ export const getFolderIconName = (folder: Folder | AccordionItemType): string | 
 	return 'FolderOutline';
 };
 
-export const translatedSystemFolders = (): Array<string> => [
-	t('folders.inbox', 'Inbox'),
-	t('folders.sent', 'Sent'),
-	t('folders.drafts', 'Drafts'),
-	t('folders.trash', 'Trash'),
-	t('folders.spam', 'Spam'),
-	t('folders.junk', 'Junk')
-];
+export const useTranslatedSystemFolders = (): Array<string> => {
+	const [translate] = useTranslation();
+	return [
+		translate('folders.inbox', 'Inbox'),
+		translate('folders.sent', 'Sent'),
+		translate('folders.drafts', 'Drafts'),
+		translate('folders.trash', 'Trash'),
+		translate('folders.spam', 'Spam'),
+		translate('folders.junk', 'Junk')
+	];
+};
 
 type GetSystemFolderProps = {
 	folderId?: string;


### PR DESCRIPTION
Updated also:
- internal variable names
- added and improve existing tests on folder input name (check cannot be empty, cannot be system folder name, cannot contain special chars)
- updated usages of t -> useTranslation to allow uniform testing (check system folder not allowed)

Ref: CO-2039