### PR TITLE
fix: content loss when editing an email body larger than 250KB

### DIFF
--- a/src/tests/constants.ts
+++ b/src/tests/constants.ts
@@ -39,6 +39,14 @@ export const ASSERTIONS = {
 	NOT_CONTAINS: {
 		value: false,
 		desc: 'not contains'
+	},
+	IS: {
+		value: true,
+		desc: 'is'
+	},
+	IS_NOT: {
+		value: false,
+		desc: "isn't"
 	}
 };
 

--- a/src/views/app/detail-panel/edit/edit-view-controller.tsx
+++ b/src/views/app/detail-panel/edit/edit-view-controller.tsx
@@ -166,8 +166,8 @@ const EditViewController = (): React.JSX.Element => {
 	const message = useMessageById(id ?? '');
 
 	const isMessageLoadingRequired = useMemo<boolean>(
-		(): boolean => isMessageRequired && !message?.isComplete,
-		[isMessageRequired, message?.isComplete]
+		(): boolean => isMessageRequired && (!message?.isComplete || message?.body?.truncated === true),
+		[isMessageRequired, message?.body?.truncated, message?.isComplete]
 	);
 
 	/**

--- a/src/views/app/detail-panel/edit/tests/edit-view-controller.test.tsx
+++ b/src/views/app/detail-panel/edit/tests/edit-view-controller.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { faker } from '@faker-js/faker';
+import { act } from '@testing-library/react';
+import { Board } from '@zextras/carbonio-shell-ui';
+import { HttpResponse } from 'msw';
+
+import { useBoard } from '../../../../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
+import {
+	createAPIInterceptor,
+	createSoapAPIInterceptor
+} from '../../../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
+import { setupTest } from '../../../../../carbonio-ui-commons/test/test-setup';
+import { EditViewActions } from '../../../../../constants';
+import { generateNewMessageEditor } from '../../../../../store/editor/editor-generators';
+import { getSoapMailMessage } from '../../../../../store/emails/actions/tests/test-utils';
+import { ASSERTIONS } from '../../../../../tests/constants';
+import { setupEditorStore } from '../../../../../tests/generators/editor-store';
+import { populateMessagesInEmailStore } from '../../../../../tests/generators/generateMessage';
+import { GetMsgRequest, GetMsgResponse } from '../../../../../types';
+import { EditViewBoardContext } from '../edit-view-board';
+import EditViewController from '../edit-view-controller';
+
+const createBoardMock = (contextModel: EditViewBoardContext): Board<EditViewBoardContext> => ({
+	id: faker.string.uuid(),
+	boardViewId: faker.string.uuid(),
+	app: faker.word.noun(),
+	icon: faker.word.noun(),
+	title: faker.word.noun(),
+	context: contextModel
+});
+
+describe('EditViewController', () => {
+	beforeAll(() => {
+		createSoapAPIInterceptor('SaveDraft');
+		createSoapAPIInterceptor('GetShareInfo');
+		createAPIInterceptor(
+			'get',
+			'/service/extension/encryption/password/enabled',
+			HttpResponse.json({ enabled: false })
+		);
+	});
+
+	it('should render correctly', async () => {
+		// Mock the board
+		const boardMock = createBoardMock({
+			originAction: EditViewActions.NEW
+		});
+		useBoard.mockReturnValue(boardMock);
+
+		const { container } = await act(async () => setupTest(<EditViewController />));
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it.each`
+		action
+		${EditViewActions.NEW}
+		${EditViewActions.RESUME}
+		${EditViewActions.MAIL_TO}
+		${EditViewActions.COMPOSE}
+		${EditViewActions.PREFILL_COMPOSE}
+	`(`should not call the getMsg API if the action does is $action`, async ({ action }) => {
+		const editor = generateNewMessageEditor();
+		setupEditorStore({ editors: [editor] });
+
+		const boardMock = createBoardMock({
+			originAction: action,
+			editorId: editor.id
+		});
+		useBoard.mockReturnValue(boardMock);
+		const apiCallFlag = jest.fn();
+		createSoapAPIInterceptor('GetMsg').finally(() => apiCallFlag({} as GetMsgRequest));
+
+		await act(async () => setupTest(<EditViewController />));
+
+		expect(apiCallFlag).not.toHaveBeenCalledWith();
+	});
+
+	it.each`
+		action
+		${EditViewActions.REPLY}
+		${EditViewActions.REPLY_ALL}
+		${EditViewActions.FORWARD}
+		${EditViewActions.FORWARD_AS_ATTACHMENT}
+		${EditViewActions.EDIT_AS_NEW}
+		${EditViewActions.EDIT_AS_DRAFT}
+	`(
+		`should not call the getMsg API if the action is $action but the required  message is fully loaded`,
+		async ({ action }) => {
+			const messages = populateMessagesInEmailStore({
+				messageGeneratorParams: [{ truncated: false, isComplete: true }]
+			});
+
+			const boardMock = createBoardMock({
+				originAction: action,
+				originActionTargetId: messages[0].id
+			});
+			useBoard.mockReturnValue(boardMock);
+			const apiCallFlag = jest.fn();
+			createSoapAPIInterceptor('GetMsg').finally(() => apiCallFlag({} as GetMsgRequest));
+
+			await act(async () => setupTest(<EditViewController />));
+
+			expect(apiCallFlag).not.toHaveBeenCalledWith();
+		}
+	);
+
+	it.each`
+		action                                   | isComplete           | isTruncated
+		${EditViewActions.REPLY}                 | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS}
+		${EditViewActions.REPLY}                 | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS_NOT}
+		${EditViewActions.REPLY}                 | ${ASSERTIONS.IS}     | ${ASSERTIONS.IS}
+		${EditViewActions.REPLY_ALL}             | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS}
+		${EditViewActions.REPLY_ALL}             | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS_NOT}
+		${EditViewActions.REPLY_ALL}             | ${ASSERTIONS.IS}     | ${ASSERTIONS.IS}
+		${EditViewActions.FORWARD}               | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS}
+		${EditViewActions.FORWARD}               | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS_NOT}
+		${EditViewActions.FORWARD}               | ${ASSERTIONS.IS}     | ${ASSERTIONS.IS}
+		${EditViewActions.FORWARD_AS_ATTACHMENT} | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS}
+		${EditViewActions.FORWARD_AS_ATTACHMENT} | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS_NOT}
+		${EditViewActions.FORWARD_AS_ATTACHMENT} | ${ASSERTIONS.IS}     | ${ASSERTIONS.IS}
+		${EditViewActions.EDIT_AS_NEW}           | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS}
+		${EditViewActions.EDIT_AS_NEW}           | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS_NOT}
+		${EditViewActions.EDIT_AS_NEW}           | ${ASSERTIONS.IS}     | ${ASSERTIONS.IS}
+		${EditViewActions.EDIT_AS_DRAFT}         | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS}
+		${EditViewActions.EDIT_AS_DRAFT}         | ${ASSERTIONS.IS_NOT} | ${ASSERTIONS.IS_NOT}
+		${EditViewActions.EDIT_AS_DRAFT}         | ${ASSERTIONS.IS}     | ${ASSERTIONS.IS}
+	`(
+		`should call the getMsg API if the action is $action, the required message $isComplete.desc complete and $isTruncated.desc truncated`,
+		async ({ action, isComplete, isTruncated }) => {
+			const messages = populateMessagesInEmailStore({
+				messageGeneratorParams: [{ truncated: isTruncated.value, isComplete: isComplete.value }]
+			});
+
+			const boardMock = createBoardMock({
+				originAction: action,
+				originActionTargetId: messages[0].id
+			});
+			useBoard.mockReturnValue(boardMock);
+			const soapMessage = getSoapMailMessage(messages[0].id);
+			const getMsgInterceptor = createSoapAPIInterceptor<GetMsgRequest, GetMsgResponse>('GetMsg', {
+				m: [soapMessage]
+			});
+
+			await act(async () => setupTest(<EditViewController />));
+
+			const getMsgRequest = await getMsgInterceptor;
+
+			expect(getMsgRequest).toEqual(
+				expect.objectContaining({
+					m: expect.objectContaining({
+						id: messages[0].id
+					})
+				})
+			);
+		}
+	);
+});


### PR DESCRIPTION
Perform a message full load when opening a draft or replying/forwarding/editing-as-new a message with a body larger than 250KB 

> [!IMPORTANT]
>  Require [Commons PR#182](https://github.com/zextras/carbonio-ui-commons/pull/182)

Refs: CO-2087