### PR TITLE
fix: [CO-2090] Editor, fix inline image preview handling

### DIFF
--- a/src/store/editor/editor-transformation.test.ts
+++ b/src/store/editor/editor-transformation.test.ts
@@ -58,7 +58,7 @@ describe('buildSavedAttachments', () => {
 				contentId: '65766eee-4439-438c-a375-1ac111ed1a07@zimbra',
 				contentType: 'text/html',
 				filename: '',
-				isInline: false,
+				isInline: true,
 				messageId: message.id,
 				partName: 'filename.jpg',
 				requiresSmartLinkConversion: true,

--- a/src/store/editor/editor-transformation.test.ts
+++ b/src/store/editor/editor-transformation.test.ts
@@ -34,37 +34,147 @@ describe('composeAttachMpField', () => {
 });
 
 describe('buildSavedAttachments', () => {
-	it('should return an empty array when there are no SavedAttachment', () => {
-		const mailMessage = generateMessage({ folderId: '2' });
-		const result = buildSavedAttachments(mailMessage);
+	it('should return an empty array when there are no parts', () => {
+		const message = generateMessage({ folderId: '2' });
+		message.parts = [];
+		const result = buildSavedAttachments(message);
 		expect(result).toEqual([]);
 	});
-	it('should return an array of SavedAttachment when there are SavedAttachment', () => {
+
+	it('should correctly mark image/* type with contentId as inline', () => {
 		const message = generateMessage({ folderId: '2' });
 		message.parts = [
 			{
-				contentType: 'text/html',
-				content: `<html><body><div style="font-family:&#39;arial&#39; , &#39;helvetica&#39; , sans-serif;font-size:12pt;color:#000000"><div style="font-family:&#39;arial&#39; , &#39;helvetica&#39; , sans-serif;font-size:12pt;color:#000000">\r\n<div style="font-family:&#39;arial&#39; , &#39;helvetica&#39; , sans-serif;font-size:12pt;color:#000000">\r\n<div style="font-family:&#39;arial&#39; , &#39;helvetica&#39; , sans-serif;font-size:12pt;color:#000000"> <img src="cid:2dbe26b8-2c96-40a0-94c5-ad891bac1f9a&#64;zimbra" /> <img src="cid:b8c321cd-0b7b-4a18-8b86-da38b937b6eb&#64;zimbra" alt="pic1" data-testId="picture1"/> <img src="cid:65766eee-4439-438c-a375-1ac111ed1a07&#64;zimbra" /><br /><br />\r\n<div><br />Kind Regards <br /><br />something</div>\r\n</div>\r\n</div>\r\n</div></div></body></html>`,
-				size: 999,
-				name: 'filename.jpg',
-				ci: '<65766eee-4439-438c-a375-1ac111ed1a07@zimbra>',
+				contentType: 'image/png',
+				filename: 'img.png',
+				name: '2.2',
+				size: 1234,
+				ci: '<abc123@zimbra>',
+				requiresSmartLinkConversion: false
+			}
+		];
+
+		const result = buildSavedAttachments(message);
+
+		expect(result[0]).toMatchObject({
+			isInline: true,
+			contentId: 'abc123@zimbra',
+			partName: '2.2',
+			contentType: 'image/png',
+			filename: 'img.png',
+			messageId: message.id
+		});
+	});
+
+	it('should mark part with disposition "inline" as inline even if not an image', () => {
+		const message = generateMessage({ folderId: '2' });
+		message.parts = [
+			{
+				contentType: 'application/pdf',
+				disposition: 'inline',
+				filename: 'doc.pdf',
+				name: '2.3',
+				size: 2048,
+				requiresSmartLinkConversion: false
+			}
+		];
+
+		const result = buildSavedAttachments(message);
+		expect(result[0].isInline).toBe(true);
+	});
+
+	it('should not mark as inline when contentId is missing and disposition is not "inline"', () => {
+		const message = generateMessage({ folderId: '2' });
+		message.parts = [
+			{
+				contentType: 'application/pdf',
+				filename: 'doc.pdf',
+				name: '2.4',
+				size: 512,
+				requiresSmartLinkConversion: false
+			}
+		];
+
+		const result = buildSavedAttachments(message);
+		expect(result[0].isInline).toBe(false);
+	});
+
+	it('should extract inner contentId from brackets', () => {
+		const message = generateMessage({ folderId: '2' });
+		message.parts = [
+			{
+				contentType: 'image/jpeg',
+				ci: '<image123@crb>',
+				name: '2.5',
+				size: 200,
+				requiresSmartLinkConversion: false
+			}
+		];
+
+		const result = buildSavedAttachments(message);
+		expect(result[0].contentId).toBe('image123@crb');
+	});
+
+	it('should leave contentId undefined if ci is not present', () => {
+		const message = generateMessage({ folderId: '2' });
+		message.parts = [
+			{
+				contentType: 'image/jpeg',
+				name: '2.6',
+				size: 300,
+				requiresSmartLinkConversion: false
+			}
+		];
+
+		const result = buildSavedAttachments(message);
+		expect(result[0].contentId).toBeUndefined();
+	});
+
+	it('should set requiresSmartLinkConversion correctly', () => {
+		const message = generateMessage({ folderId: '2' });
+		message.parts = [
+			{
+				contentType: 'image/jpeg',
+				name: '2.7',
+				size: 300,
 				requiresSmartLinkConversion: true
 			}
 		];
-		const result = buildSavedAttachments(message);
 
-		const expectedOutput = [
+		const result = buildSavedAttachments(message);
+		expect(result[0].requiresSmartLinkConversion).toBe(true);
+	});
+
+	it('should correctly build a SavedAttachment for a part with inline CID and text/html content', () => {
+		const message = generateMessage({ folderId: '2' });
+
+		message.parts = [
 			{
-				contentId: '65766eee-4439-438c-a375-1ac111ed1a07@zimbra',
 				contentType: 'text/html',
-				filename: '',
-				isInline: true,
-				messageId: message.id,
-				partName: 'filename.jpg',
-				requiresSmartLinkConversion: true,
-				size: 999
+				content: `<html><body>
+				<img src="cid:65766eee-4439-438c-a375-1ac111ed1a07@zimbra" />
+				<p>Hello, this is a test email with inline image.</p>
+			</body></html>`,
+				size: 999,
+				name: '2.2',
+				ci: '<65766eee-4439-438c-a375-1ac111ed1a07@zimbra>',
+				requiresSmartLinkConversion: false
 			}
 		];
-		expect(result).toMatchObject(expectedOutput);
+
+		const result = buildSavedAttachments(message);
+
+		expect(result).toEqual([
+			{
+				messageId: message.id,
+				isInline: true, // because ci is present and contentType is text/html
+				contentId: '65766eee-4439-438c-a375-1ac111ed1a07@zimbra',
+				filename: '', // no filename provided
+				partName: '2.2',
+				contentType: 'text/html',
+				size: 999,
+				requiresSmartLinkConversion: false
+			}
+		]);
 	});
 });

--- a/src/store/editor/editor-transformations.ts
+++ b/src/store/editor/editor-transformations.ts
@@ -195,11 +195,6 @@ export const getMP = (editor: MailsEditorV2): SoapEmailMessagePartObj[] => {
 										_content: getHtmlWithPreAppliedStyled(contentWithCidUrl.richText, style) ?? ''
 									}
 								},
-								...unsavedInlineAttachment.map((inlineAttachment) => ({
-									ci: inlineAttachment.contentId,
-									ct: inlineAttachment.contentType,
-									attach: { aid: inlineAttachment.aid }
-								})),
 								...savedInlineAttachment.map((inlineAttachment) => ({
 									ci: inlineAttachment.contentId,
 									ct: inlineAttachment.contentType,
@@ -211,6 +206,12 @@ export const getMP = (editor: MailsEditorV2): SoapEmailMessagePartObj[] => {
 											}
 										]
 									}
+								})),
+								// keep this order saved -> unsaved
+								...unsavedInlineAttachment.map((inlineAttachment) => ({
+									ci: inlineAttachment.contentId,
+									ct: inlineAttachment.contentType,
+									attach: { aid: inlineAttachment.aid }
 								}))
 							]
 						}

--- a/src/store/editor/editor-transformations.ts
+++ b/src/store/editor/editor-transformations.ts
@@ -32,6 +32,7 @@ import {
 	MailAttachment,
 	MailAttachmentParts,
 	MailMessage,
+	MailMessagePart,
 	MailsEditorV2,
 	MsgAttach,
 	Participant,
@@ -425,10 +426,12 @@ export const createSoapSendMsgRequestFromEditor = (editor: MailsEditorV2): SoapD
 
 export const buildSavedAttachments = (message: MailMessage): Array<SavedAttachment> => {
 	const attachmentsParts = getAttachmentParts(message.parts);
+	const isProbablyInline = (part: MailMessagePart): boolean =>
+		part.disposition === 'inline' || (!!part.ci && part.contentType?.startsWith('image/'));
+
 	return attachmentsParts.map<SavedAttachment>((part) => ({
 		messageId: message.id,
-		// TODO create a function to determine if the attachment is an inline even when the disposition is not set
-		isInline: part.disposition === 'inline' && !!part.filename && !!part.ci,
+		isInline: isProbablyInline(part),
 		contentId: (part.ci && extractContentIdInnerPart(part.ci)) ?? undefined,
 		filename: part.filename ?? '',
 		partName: part.name,


### PR DESCRIPTION
#### What was changed
- Reordered the mapping of unsaved and saved inline attachments in the editor transformation `getMp` function that composes mimePart section of the `SaveDraftRequest` payload. This fixes inline attachment ordering to maintain correct `downloadServiceUrl` in editor, As a result the inline images can be correctly previewed.
- Improve inline attachment detection in `buildSavedAttachments`. Removed the filename requirement from the detection logic.

#### Technical details

The SaveDraft API assigns MIME part names (e.g., `2.2`, `2.3`, etc.) based on the order of inline attachments in the request payload. Previously, unsaved inline attachments were added before saved ones, causing the most recently added image to take the lowest part name (`2.2`). This shifted previously saved attachments to later part names (`2.3`, `2.4`, etc.).

As a result, the `downloadServiceUrl`, which is built using the MIME part name, pointed to the wrong attachment after each draft save. This broke rendering in clients that use the part-based download URL (e.g., `/service/home/~/?id=438&part=2.2`) to fetch inline images.
