### PR TITLE
chore(todo.md): remove obsolete todo list

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,9 +1,0 @@
-# TODO
-
-- [ ] drag and drop of messages
-- [ ] drag and drop of conversations
-- [ ] send of message breaks ui
-- [ ] sync data handler
-  - [ ] ordering of conversations messages in conversations
-
-END


### PR DESCRIPTION
Deleted the todo.md file as it is no longer needed. The tasks listed have been either completed, moved elsewhere, or are no longer relevant.