### PR TITLE
feat: [CO-1983] Implement visual notification for unread emails in subfolders

### DIFF
--- a/src/styled-wrapper.tsx
+++ b/src/styled-wrapper.tsx
@@ -23,7 +23,7 @@ const createDottedIcon =
 		return (
 			<svg {...props}>
 				<BaseIcon {...iconProps} />
-				<circle cx={'19'} cy={'19'} r={'4'} fill={'#2B73D2'} stroke={'#f5f6f8'} strokeWidth={'1'} />
+				<circle cx={'19'} cy={'5'} r={'4'} fill={'#2B73D2'} stroke={'#f5f6f8'} strokeWidth={'1'} />
 			</svg>
 		);
 	};

--- a/src/styled-wrapper.tsx
+++ b/src/styled-wrapper.tsx
@@ -23,7 +23,7 @@ const createDottedIcon =
 		return (
 			<svg {...props}>
 				<BaseIcon {...iconProps} />
-				<circle cx={'19'} cy={'19'} r={'4'} fill={'#2B73D2'} stroke={'white'} strokeWidth={'1'} />
+				<circle cx={'19'} cy={'19'} r={'4'} fill={'#2B73D2'} stroke={'#f5f6f8'} strokeWidth={'1'} />
 			</svg>
 		);
 	};

--- a/src/styled-wrapper.tsx
+++ b/src/styled-wrapper.tsx
@@ -4,21 +4,45 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
+import React, { SVGProps } from 'react';
 
-import { ThemeProvider } from '@zextras/carbonio-design-system';
-import type { Theme as DSTheme } from '@zextras/carbonio-design-system';
-import { createGlobalStyle, DefaultTheme } from 'styled-components';
+import { Theme, ThemeProvider } from '@zextras/carbonio-design-system';
+import { createGlobalStyle } from 'styled-components';
 
 import { AnimatedLoader } from './assets/animated-loader';
 
-const themeOverride = (theme: DSTheme): DSTheme => ({
-	...theme,
-	icons: {
-		...theme.icons,
-		AnimatedLoader
-	} as DefaultTheme['icons'] // FIXME check how to remove this cast
-});
+declare type IconComponent = (props: SVGProps<SVGSVGElement>) => React.JSX.Element;
+
+const createDottedIcon =
+	(BaseIcon: IconComponent): IconComponent =>
+	// eslint-disable-next-line react/display-name
+	(props) => (
+		<svg {...props}>
+			<BaseIcon {...props} />
+			<circle cx={'20'} cy={'19'} r={'4'} fill={'#2B73D2'} stroke={'white'} strokeWidth={'1'} />
+		</svg>
+	);
+
+const themeOverride = (theme: Theme): Theme => {
+	const outlineIconsWithNotificationDot = Object.entries(theme.icons).reduce(
+		(acc, [name, Icon]) => {
+			if (name.endsWith('Outline')) {
+				return { ...acc, [`${name}WithDot`]: createDottedIcon(Icon) };
+			}
+			return acc;
+		},
+		{} as Record<string, IconComponent>
+	);
+
+	return {
+		...theme,
+		icons: {
+			...theme.icons,
+			...outlineIconsWithNotificationDot,
+			AnimatedLoader
+		}
+	};
+};
 
 const GlobalStyle = createGlobalStyle`
   .disable-hover, .disable-hover * {

--- a/src/styled-wrapper.tsx
+++ b/src/styled-wrapper.tsx
@@ -11,17 +11,22 @@ import { createGlobalStyle } from 'styled-components';
 
 import { AnimatedLoader } from './assets/animated-loader';
 
-declare type IconComponent = (props: SVGProps<SVGSVGElement>) => React.JSX.Element;
+type IconComponent = (props: SVGProps<SVGSVGElement>) => React.JSX.Element;
 
 const createDottedIcon =
 	(BaseIcon: IconComponent): IconComponent =>
 	// eslint-disable-next-line react/display-name
-	(props) => (
-		<svg {...props}>
-			<BaseIcon {...props} />
-			<circle cx={'20'} cy={'19'} r={'4'} fill={'#2B73D2'} stroke={'white'} strokeWidth={'1'} />
-		</svg>
-	);
+	(props) => {
+		const iconProps = { ...props };
+		// @ts-expect-error remove data-testid from props for better testing
+		delete iconProps['data-testid'];
+		return (
+			<svg {...props}>
+				<BaseIcon {...iconProps} />
+				<circle cx={'19'} cy={'19'} r={'4'} fill={'#2B73D2'} stroke={'white'} strokeWidth={'1'} />
+			</svg>
+		);
+	};
 
 const themeOverride = (theme: Theme): Theme => {
 	const outlineIconsWithNotificationDot = Object.entries(theme.icons).reduce(

--- a/src/views/sidebar/accordion-custom-component.tsx
+++ b/src/views/sidebar/accordion-custom-component.tsx
@@ -222,11 +222,13 @@ const AccordionCustomComponent: FC<{ item: Folder }> = ({ item: folder }) => {
 		const hasSubfolderUnread = subfolderUnread > 0;
 
 		if (hasSubfolderUnread) {
-			return t(
+			return `${folderLabel} (${t(
 				'tooltip.subfolder_unread_status',
-				'{{folderLabel}} ({{subfolder}} unread mails in subfolders)',
-				{ folderLabel, subfolder: subfolderUnread }
-			);
+				'{{count}} unread mails in subfolders',
+				{
+					count: subfolderUnread
+				}
+			)})`;
 		}
 
 		return folderLabel;

--- a/src/views/sidebar/accordion-custom-component.tsx
+++ b/src/views/sidebar/accordion-custom-component.tsx
@@ -224,7 +224,7 @@ const AccordionCustomComponent: FC<{ item: Folder }> = ({ item: folder }) => {
 		if (hasSubfolderUnread) {
 			return t(
 				'tooltip.subfolder_unread_status',
-				'{{folderLabel}} ({{subfolder}} unread in subfolders)',
+				'{{folderLabel}} ({{subfolder}} unread mails in subfolders)',
 				{ folderLabel, subfolder: subfolderUnread }
 			);
 		}

--- a/src/views/sidebar/accordion-custom-component.tsx
+++ b/src/views/sidebar/accordion-custom-component.tsx
@@ -23,9 +23,11 @@ import styled from 'styled-components';
 
 import { FolderActionWrapper } from './folder-action-wrapper';
 import {
+	folderHasChildren,
 	getFolderIconColor,
 	getFolderIconName,
 	getFolderTranslatedName,
+	getTotalUnreadCountInSubfolders,
 	handleDragEnter
 } from './utils';
 import { folderActionSoapApi } from '../../api/folder-action-soap-api';
@@ -38,6 +40,7 @@ import { useOnMouseHover } from '../../hooks/use-on-mouse-hover';
 import { useUiUtilities } from '../../hooks/use-ui-utilities';
 import { convActionEmailStoreAction } from '../../store/emails/actions/conv-action-action';
 import { msgActionEmailStoreAction } from '../../store/emails/actions/msg-action-action';
+import StyledWrapper from '../../styled-wrapper';
 
 const FittedRow = styled(Row)`
 	max-width: calc(100% - (2 * ${({ theme }): string => theme.sizes.padding.small}));
@@ -190,22 +193,44 @@ const AccordionCustomComponent: FC<{ item: Folder }> = ({ item: folder }) => {
 		}),
 		[]
 	);
-	const accordionItem = useMemo(
-		() => ({
+
+	const accordionItem = useMemo(() => {
+		const hasSubfolderUnreads =
+			folderHasChildren(folder) && getTotalUnreadCountInSubfolders(folder) > 0;
+		return {
 			...folder,
 			label:
 				folder.id === FOLDERS.USER_ROOT
 					? accountName
 					: (getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }) ?? ''),
-			icon: getFolderIconName(folder) ?? undefined,
+			icon: getFolderIconName(folder, hasSubfolderUnreads) ?? undefined,
 			iconColor: getFolderIconColor(folder) ?? '',
 			badgeCounter: badgeCount(folder.id === FOLDERS.DRAFTS ? folder.n : folder?.u),
 			badgeType,
 			to: `/folder/${folder.id}`,
 			textProps
-		}),
-		[folder, accountName, badgeType, textProps]
-	);
+		};
+	}, [folder, accountName, badgeType, textProps]);
+
+	const accordionItemToolTip = useMemo(() => {
+		const folderLabel =
+			folder.id === FOLDERS.USER_ROOT
+				? accountName
+				: (getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }) ?? '');
+
+		const subfolderUnread = folderHasChildren(folder) ? getTotalUnreadCountInSubfolders(folder) : 0;
+		const hasSubfolderUnread = subfolderUnread > 0;
+
+		if (hasSubfolderUnread) {
+			return t(
+				'tooltip.subfolder_unread_status',
+				'{{folderLabel}} ({{subfolder}} unread in subfolders)',
+				{ folderLabel, subfolder: subfolderUnread }
+			);
+		}
+
+		return folderLabel;
+	}, [folder, accountName]);
 
 	const statusIcon = useMemo(() => {
 		const RowWithIcon = (icon: string, color: string, tooltipText: string): React.JSX.Element => (
@@ -251,66 +276,68 @@ const AccordionCustomComponent: FC<{ item: Folder }> = ({ item: folder }) => {
 		);
 
 	return (
-		<Row width="fill" minWidth={0} ref={ref}>
-			<Drop
-				acceptType={['message', 'conversation', 'folder']}
-				onDrop={(data: DragObj): void => {
-					onDropAction({
-						type: data.type ?? '',
-						data: data.data,
-						event: data.event
-					} as OnDropActionProps);
-				}}
-				onDragEnter={(data: DragObj): { success: boolean } | undefined =>
-					handleDragEnter(
-						{
+		<StyledWrapper>
+			<Row width="fill" minWidth={0} ref={ref}>
+				<Drop
+					acceptType={['message', 'conversation', 'folder']}
+					onDrop={(data: DragObj): void => {
+						onDropAction({
 							type: data.type ?? '',
 							data: data.data,
 							event: data.event
-						} as OnDropActionProps,
-						folder
-					)
-				}
-				overlayAcceptComponent={<DropOverlayContainer $folder={folder} />}
-				overlayDenyComponent={<DropDenyOverlayContainer $folder={folder} />}
-			>
-				<Drag
-					type="folder"
-					data={folder}
-					dragDisabled={dragFolderDisable}
-					style={{ display: 'block' }}
+						} as OnDropActionProps);
+					}}
+					onDragEnter={(data: DragObj): { success: boolean } | undefined =>
+						handleDragEnter(
+							{
+								type: data.type ?? '',
+								data: data.data,
+								event: data.event
+							} as OnDropActionProps,
+							folder
+						)
+					}
+					overlayAcceptComponent={<DropOverlayContainer $folder={folder} />}
+					overlayDenyComponent={<DropDenyOverlayContainer $folder={folder} />}
 				>
-					<Link
-						to={`../folder/${folder.id}`}
-						style={{ width: '100%', height: '100%', textDecoration: 'none' }}
+					<Drag
+						type="folder"
+						data={folder}
+						dragDisabled={dragFolderDisable}
+						style={{ display: 'block' }}
 					>
-						{hasBeenHovered ? (
-							<FolderActionWrapper folder={folder}>
-								<Tooltip label={accordionItem.label} placement="right" maxWidth="100%">
-									<AccordionItem
-										data-testid={`accordion-folder-item-${folder.id}`}
-										item={accordionItem}
-									>
-										{statusIcon}
-									</AccordionItem>
-								</Tooltip>
-							</FolderActionWrapper>
-						) : (
-							<Container padding={{ left: 'small' }}>
-								<Tooltip label={accordionItem.label} placement="right" maxWidth="100%">
-									<AccordionItem
-										data-testid={`accordion-folder-item-${folder.id}`}
-										item={accordionItem}
-									>
-										{statusIcon}
-									</AccordionItem>
-								</Tooltip>
-							</Container>
-						)}
-					</Link>
-				</Drag>
-			</Drop>
-		</Row>
+						<Link
+							to={`../folder/${folder.id}`}
+							style={{ width: '100%', height: '100%', textDecoration: 'none' }}
+						>
+							{hasBeenHovered ? (
+								<FolderActionWrapper folder={folder}>
+									<Tooltip label={accordionItemToolTip} placement="right" maxWidth="100%">
+										<AccordionItem
+											data-testid={`accordion-folder-item-${folder.id}`}
+											item={accordionItem}
+										>
+											{statusIcon}
+										</AccordionItem>
+									</Tooltip>
+								</FolderActionWrapper>
+							) : (
+								<Container padding={{ left: 'small' }}>
+									<Tooltip label={accordionItemToolTip} placement="right" maxWidth="100%">
+										<AccordionItem
+											data-testid={`accordion-folder-item-${folder.id}`}
+											item={accordionItem}
+										>
+											{statusIcon}
+										</AccordionItem>
+									</Tooltip>
+								</Container>
+							)}
+						</Link>
+					</Drag>
+				</Drop>
+			</Row>
+		</StyledWrapper>
 	);
 };
 

--- a/src/views/sidebar/accordion-custom-component.tsx
+++ b/src/views/sidebar/accordion-custom-component.tsx
@@ -34,7 +34,7 @@ import { folderActionSoapApi } from '../../api/folder-action-soap-api';
 import { ROOT_NAME } from '../../carbonio-ui-commons/constants';
 import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
 import { isSystemFolder } from '../../carbonio-ui-commons/helpers/folders';
-import type { Folder } from '../../carbonio-ui-commons/types/folder';
+import type { Folder } from '../../carbonio-ui-commons/types';
 import type { OnDropActionProps } from '../../carbonio-ui-commons/types/sidebar';
 import { useOnMouseHover } from '../../hooks/use-on-mouse-hover';
 import { useUiUtilities } from '../../hooks/use-ui-utilities';
@@ -202,9 +202,9 @@ const AccordionCustomComponent: FC<{ item: Folder }> = ({ item: folder }) => {
 			label:
 				folder.id === FOLDERS.USER_ROOT
 					? accountName
-					: (getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }) ?? ''),
+					: getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }),
 			icon: getFolderIconName(folder, hasSubfolderUnreads) ?? undefined,
-			iconColor: getFolderIconColor(folder) ?? '',
+			iconColor: getFolderIconColor(folder),
 			badgeCounter: badgeCount(folder.id === FOLDERS.DRAFTS ? folder.n : folder?.u),
 			badgeType,
 			to: `/folder/${folder.id}`,

--- a/src/views/sidebar/accordion-custom-component.tsx
+++ b/src/views/sidebar/accordion-custom-component.tsx
@@ -216,7 +216,7 @@ const AccordionCustomComponent: FC<{ item: Folder }> = ({ item: folder }) => {
 		const folderLabel =
 			folder.id === FOLDERS.USER_ROOT
 				? accountName
-				: (getFolderTranslatedName({ folderId: folder.id, folderName: folder.name }) ?? '');
+				: getFolderTranslatedName({ folderId: folder.id, folderName: folder.name });
 
 		const subfolderUnread = folderHasChildren(folder) ? getTotalUnreadCountInSubfolders(folder) : 0;
 		const hasSubfolderUnread = subfolderUnread > 0;

--- a/src/views/sidebar/tests/accordion-custom-component.test.tsx
+++ b/src/views/sidebar/tests/accordion-custom-component.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import React from 'react';
+
+import { screen, within } from '@testing-library/react';
+import assert from 'node:assert';
+
+import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
+import { createFakeIdentity } from '../../../carbonio-ui-commons/test/mocks/accounts/fakeAccounts';
+import {
+	generateFolder,
+	generateFolderLink
+} from '../../../carbonio-ui-commons/test/mocks/folders/folders-generator';
+import { getMocksContext } from '../../../carbonio-ui-commons/test/mocks/utils/mocks-context';
+import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
+import AccordionCustomComponent from '../accordion-custom-component';
+
+describe('accordion-custom-component', () => {
+	it('should render without crashing', () => {
+		const inboxFolder = generateFolder({ id: FOLDERS.INBOX, isLink: false });
+		assert(inboxFolder, 'Inbox folder should be defined');
+
+		setupTest(<AccordionCustomComponent item={inboxFolder} />);
+		const inboxItem = screen.getByTestId(`accordion-folder-item-${FOLDERS.INBOX}`);
+		expect(inboxItem).toBeInTheDocument();
+	});
+
+	it('should show the InboxOutline icon for the inbox folder when there are no subfolders', () => {
+		const inboxFolder = generateFolder({ id: FOLDERS.INBOX, isLink: false, children: [] });
+		assert(inboxFolder, 'Inbox folder should be defined');
+
+		setupTest(<AccordionCustomComponent item={inboxFolder} />);
+		const inboxItem = screen.getByTestId(`accordion-folder-item-${FOLDERS.INBOX}`);
+		expect(inboxItem).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access
+		expect(inboxItem.querySelector('svg')).toHaveAttribute('data-testid', 'icon: InboxOutline');
+	});
+
+	it('should show unread message count when there are unread messages in folder', () => {
+		const inboxFolder = generateFolder({
+			id: FOLDERS.INBOX,
+			isLink: false,
+			view: 'message',
+			name: 'Inbox',
+			u: 998,
+			absFolderPath: '/inbox',
+			n: 999
+		});
+
+		setupTest(<AccordionCustomComponent item={inboxFolder} />);
+		const inboxItem = screen.getByTestId(`accordion-folder-item-${FOLDERS.INBOX}`);
+		expect(inboxItem).toBeInTheDocument();
+		expect(within(inboxItem).getByText(String(inboxFolder?.u ?? ''))).toBeInTheDocument();
+	});
+
+	it('should show max unread message count (999+) when there are unread messages in folder', () => {
+		const inboxFolder = generateFolder({
+			id: FOLDERS.INBOX,
+			isLink: false,
+			view: 'message',
+			name: 'Inbox',
+			u: 1000, // max counter trigger at 999
+			absFolderPath: '/inbox',
+			n: 999
+		});
+
+		setupTest(<AccordionCustomComponent item={inboxFolder} />);
+		const inboxItem = screen.getByTestId(`accordion-folder-item-${FOLDERS.INBOX}`);
+		expect(inboxItem).toBeInTheDocument();
+		expect(within(inboxItem).getByText('999+')).toBeInTheDocument();
+	});
+
+	it('should show the icon with dot when subfolder has unread message ', () => {
+		const inboxFolder = generateFolder({
+			id: FOLDERS.INBOX,
+			isLink: false,
+			view: 'message',
+			name: 'Inbox',
+			u: 0,
+			absFolderPath: '/inbox',
+			n: 0,
+			children: [
+				generateFolder({
+					id: '20',
+					isLink: false,
+					view: 'message',
+					name: 'test',
+					u: 1,
+					absFolderPath: '/inbox/test'
+				})
+			]
+		});
+
+		setupTest(<AccordionCustomComponent item={inboxFolder} />);
+		const inboxItem = screen.getByTestId(`accordion-folder-item-${FOLDERS.INBOX}`);
+		expect(inboxItem).toBeInTheDocument();
+		expect(within(inboxItem).getByTestId('icon: InboxOutlineWithDot')).toBeInTheDocument();
+	});
+
+	it('should not render broken shared folder', () => {
+		const identity = createFakeIdentity();
+		const folderLink = generateFolderLink('100', '101', identity);
+		const brokenLinkFolder = { ...folderLink, isLink: true, broken: true };
+
+		setupTest(<AccordionCustomComponent item={brokenLinkFolder} />);
+		const folderAccordionItem = screen.queryByTestId(`accordion-folder-item-${folderLink.id}`);
+		expect(folderAccordionItem).not.toBeInTheDocument();
+	});
+
+	it('should render accordion item with identity fullName when folder is ROOT', () => {
+		const userRootFolder = generateFolder({
+			id: FOLDERS.USER_ROOT,
+			isLink: false,
+			view: 'message',
+			name: 'USER_ROOT',
+			absFolderPath: '/'
+		});
+
+		const { identities } = getMocksContext();
+		const { fullName } = identities.primary.identity;
+		setupTest(<AccordionCustomComponent item={userRootFolder} />);
+		const userRootItem = screen.getByTestId(`accordion-folder-item-${FOLDERS.USER_ROOT}`);
+		expect(userRootItem).toBeInTheDocument();
+		expect(within(userRootItem).getByText(fullName)).toBeInTheDocument();
+	});
+});

--- a/src/views/sidebar/tests/accordion-custom-component.test.tsx
+++ b/src/views/sidebar/tests/accordion-custom-component.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { screen, within } from '@testing-library/react';
 import assert from 'node:assert';
 
+import { ROOT_NAME } from '../../../carbonio-ui-commons/constants';
 import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
 import { createFakeIdentity } from '../../../carbonio-ui-commons/test/mocks/accounts/fakeAccounts';
 import {
@@ -116,7 +117,7 @@ describe('accordion-custom-component', () => {
 			id: FOLDERS.USER_ROOT,
 			isLink: false,
 			view: 'message',
-			name: 'USER_ROOT',
+			name: ROOT_NAME,
 			absFolderPath: '/'
 		});
 

--- a/src/views/sidebar/tests/utils.test.ts
+++ b/src/views/sidebar/tests/utils.test.ts
@@ -4,61 +4,115 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { ROOT_NAME } from '../../../carbonio-ui-commons/constants';
 import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
 import { generateFolder } from '../../../carbonio-ui-commons/test/mocks/folders/folders-generator';
+import { Folder } from '../../../carbonio-ui-commons/types';
 import { OnDropActionProps } from '../../../carbonio-ui-commons/types/sidebar';
-import { handleDragEnter } from '../utils';
+import { getFolderIconName, handleDragEnter } from '../utils';
 
-describe('handleDragEnter', () => {
-	const folder = generateFolder({
-		id: 'folder1',
-		isLink: false,
-		perm: 'rw',
-		oname: 'folder1'
+describe('utils', () => {
+	describe('handleDragEnter', () => {
+		const folder = generateFolder({
+			id: 'folder1',
+			isLink: false,
+			perm: 'rw',
+			oname: 'folder1'
+		});
+
+		it('should return success false for same folder', () => {
+			const data = {
+				type: 'conversation',
+				data: { parentFolderId: 'folder1' }
+			} as OnDropActionProps;
+			const result = handleDragEnter(data, folder);
+			expect(result).toEqual({ success: false });
+		});
+
+		it('should return success false for restricted inbox targets', () => {
+			const data = {
+				type: 'conversation',
+				data: { parentFolderId: FOLDERS.INBOX }
+			} as OnDropActionProps;
+			const result = handleDragEnter(data, { ...folder, id: FOLDERS.SENT });
+			expect(result).toEqual({ success: false });
+		});
+
+		it('should return success false for restricted draft targets', () => {
+			const data = {
+				type: 'conversation',
+				data: { parentFolderId: FOLDERS.DRAFTS }
+			} as OnDropActionProps;
+			const result = handleDragEnter(data, { ...folder, id: FOLDERS.INBOX });
+			expect(result).toEqual({ success: false });
+		});
+
+		it('should return success false for restricted destinations', () => {
+			const data = {
+				type: 'conversation',
+				data: { parentFolderId: 'folder2' }
+			} as OnDropActionProps;
+			const result = handleDragEnter(data, { ...folder, id: FOLDERS.USER_ROOT });
+			expect(result).toEqual({ success: false });
+		});
+
+		it('should return success false for folder type with same id', () => {
+			const data = { type: 'folder', data: { id: 'folder1' } } as OnDropActionProps;
+			const result = handleDragEnter(data, folder);
+			expect(result).toEqual({ success: false });
+		});
+
+		it('should return undefined for valid drag enter', () => {
+			const data = {
+				type: 'conversation',
+				data: { parentFolderId: 'folder2' }
+			} as OnDropActionProps;
+			const result = handleDragEnter(data, folder);
+			expect(result).toBeUndefined();
+		});
 	});
+	describe('getFolderIconName', () => {
+		const baseFolder = (id: string, extra?: Partial<Folder>): Folder =>
+			generateFolder({ id, ...extra });
+		it('returns correct icon for Inbox', () => {
+			expect(getFolderIconName(baseFolder(FOLDERS.INBOX))).toBe('InboxOutline');
+		});
 
-	it('should return success false for same folder', () => {
-		const data = {
-			type: 'conversation',
-			data: { parentFolderId: 'folder1' }
-		} as OnDropActionProps;
-		const result = handleDragEnter(data, folder);
-		expect(result).toEqual({ success: false });
-	});
+		it('returns correct icon for Drafts', () => {
+			expect(getFolderIconName(baseFolder(FOLDERS.DRAFTS))).toBe('FileOutline');
+		});
 
-	it('should return success false for restricted inbox targets', () => {
-		const data = {
-			type: 'conversation',
-			data: { parentFolderId: FOLDERS.INBOX }
-		} as OnDropActionProps;
-		const result = handleDragEnter(data, { ...folder, id: FOLDERS.SENT });
-		expect(result).toEqual({ success: false });
-	});
+		it('returns correct icon for Sent', () => {
+			expect(getFolderIconName(baseFolder(FOLDERS.SENT))).toBe('PaperPlaneOutline');
+		});
 
-	it('should return success false for restricted draft targets', () => {
-		const data = {
-			type: 'conversation',
-			data: { parentFolderId: FOLDERS.DRAFTS }
-		} as OnDropActionProps;
-		const result = handleDragEnter(data, { ...folder, id: FOLDERS.INBOX });
-		expect(result).toEqual({ success: false });
-	});
+		it('returns correct icon for Spam', () => {
+			expect(getFolderIconName(baseFolder(FOLDERS.SPAM))).toBe('SlashOutline');
+		});
 
-	it('should return success false for restricted destinations', () => {
-		const data = { type: 'conversation', data: { parentFolderId: 'folder2' } } as OnDropActionProps;
-		const result = handleDragEnter(data, { ...folder, id: FOLDERS.USER_ROOT });
-		expect(result).toEqual({ success: false });
-	});
+		it('returns correct icon for Trash', () => {
+			expect(getFolderIconName(baseFolder(FOLDERS.TRASH))).toBe('Trash2Outline');
+		});
 
-	it('should return success false for folder type with same id', () => {
-		const data = { type: 'folder', data: { id: 'folder1' } } as OnDropActionProps;
-		const result = handleDragEnter(data, folder);
-		expect(result).toEqual({ success: false });
-	});
+		it('returns FolderOutline for unknown system folder', () => {
+			expect(getFolderIconName(baseFolder('unknown'))).toBe('FolderOutline');
+		});
 
-	it('should return undefined for valid drag enter', () => {
-		const data = { type: 'conversation', data: { parentFolderId: 'folder2' } } as OnDropActionProps;
-		const result = handleDragEnter(data, folder);
-		expect(result).toBeUndefined();
+		it('returns FolderOutline for custom folder', () => {
+			expect(getFolderIconName(baseFolder('custom123'))).toBe('FolderOutline');
+		});
+
+		it('returns icon with dot when withNotificationDot is true', () => {
+			expect(getFolderIconName(baseFolder(FOLDERS.INBOX), true)).toBe('InboxOutlineWithDot');
+			expect(getFolderIconName(baseFolder('custom123'), true)).toBe('FolderOutlineWithDot');
+		});
+
+		it('returns null for USER_ROOT', () => {
+			expect(getFolderIconName(baseFolder(FOLDERS.USER_ROOT))).toBeNull();
+		});
+
+		it('returns null for shared root link', () => {
+			expect(getFolderIconName({ id: 'someid', isLink: true, oname: ROOT_NAME })).toBeNull();
+		});
 	});
 });

--- a/src/views/sidebar/tests/utils.test.ts
+++ b/src/views/sidebar/tests/utils.test.ts
@@ -9,7 +9,7 @@ import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
 import { generateFolder } from '../../../carbonio-ui-commons/test/mocks/folders/folders-generator';
 import { Folder } from '../../../carbonio-ui-commons/types';
 import { OnDropActionProps } from '../../../carbonio-ui-commons/types/sidebar';
-import { getFolderIconName, handleDragEnter } from '../utils';
+import { getFolderIconName, getTotalUnreadCountInSubfolders, handleDragEnter } from '../utils';
 
 describe('utils', () => {
 	describe('handleDragEnter', () => {
@@ -114,5 +114,49 @@ describe('utils', () => {
 		it('returns null for shared root link', () => {
 			expect(getFolderIconName({ id: 'someid', isLink: true, oname: ROOT_NAME })).toBeNull();
 		});
+	});
+
+	describe('getTotalUnreadCountInSubfolders', () => {
+		it('should return 0 when no subfolders', () => {
+			const folder = generateFolder({
+				id: 'folder1',
+				isLink: false,
+				perm: 'rw',
+				oname: 'folder1',
+				u: 0,
+				n: 0
+			});
+			expect(getTotalUnreadCountInSubfolders(folder)).toBe(0);
+		});
+		it('should return 0 when all subfolders have 0 unread messages', () => {
+			const folder = generateFolder({
+				id: 'folder1',
+				isLink: false,
+				perm: 'rw',
+				oname: 'folder1',
+				u: 0,
+				n: 0,
+				children: [
+					generateFolder({ id: 'subfolder1', u: 0, n: 0 }),
+					generateFolder({ id: 'subfolder2', u: 0, n: 0 })
+				]
+			});
+			expect(getTotalUnreadCountInSubfolders(folder)).toBe(0);
+		});
+	});
+	it('should return the sum of unread messages in subfolders', () => {
+		const folder = generateFolder({
+			id: 'folder1',
+			isLink: false,
+			perm: 'rw',
+			oname: 'folder1',
+			u: 0,
+			n: 0,
+			children: [
+				generateFolder({ id: 'subfolder1', u: 5, n: 0 }),
+				generateFolder({ id: 'subfolder2', u: 3, n: 0 })
+			]
+		});
+		expect(getTotalUnreadCountInSubfolders(folder)).toBe(8);
 	});
 });

--- a/src/views/sidebar/utils.ts
+++ b/src/views/sidebar/utils.ts
@@ -30,8 +30,20 @@ export const getFolderIconColor = (f: Folder | AccordionItemType): string => {
 	return ZIMBRA_STANDARD_COLORS[0].hex;
 };
 
-export const getFolderIconName = (folder: Folder | AccordionItemType): string | null => {
+/**
+ * Get the icon name for a folder
+ * @param folder - The folder object
+ * @param withNotificationDot - Whether to add a notification dot to the icon name
+ *
+ * NOTE: Icons with dots are not available in the design system, they are provided by the
+ * {@link StyledWrapper} component.
+ */
+export const getFolderIconName = (
+	folder: Folder | AccordionItemType,
+	withNotificationDot = false
+): string | null => {
 	const { id } = getFolderIdParts(folder.id);
+
 	if (
 		id === FOLDERS.USER_ROOT ||
 		('isLink' in folder && folder.isLink && folder.oname === ROOT_NAME)
@@ -39,23 +51,33 @@ export const getFolderIconName = (folder: Folder | AccordionItemType): string | 
 		return null;
 	}
 
+	let iconName: string;
+
 	if (id && isSystemFolder(id)) {
 		switch (id) {
 			case FOLDERS.INBOX:
-				return 'InboxOutline';
+				iconName = 'InboxOutline';
+				break;
 			case FOLDERS.DRAFTS:
-				return 'FileOutline';
+				iconName = 'FileOutline';
+				break;
 			case FOLDERS.SENT:
-				return 'PaperPlaneOutline';
+				iconName = 'PaperPlaneOutline';
+				break;
 			case FOLDERS.SPAM:
-				return 'SlashOutline';
+				iconName = 'SlashOutline';
+				break;
 			case FOLDERS.TRASH:
-				return 'Trash2Outline';
+				iconName = 'Trash2Outline';
+				break;
 			default:
-				return 'FolderOutline';
+				iconName = 'FolderOutline';
 		}
+	} else {
+		iconName = 'FolderOutline';
 	}
-	return 'FolderOutline';
+
+	return withNotificationDot ? `${iconName}WithDot` : iconName;
 };
 
 export const useTranslatedSystemFolders = (): Array<string> => {
@@ -144,4 +166,28 @@ export function handleDragEnter(data: OnDropActionProps, folder: Folder): DragEn
 	}
 
 	return undefined;
+}
+
+export function getTotalUnreadCount(folder: Folder): number {
+	let count = folder.u ?? 0;
+
+	folder.children?.forEach((subfolder) => {
+		count += getTotalUnreadCount(subfolder);
+	});
+
+	return count;
+}
+
+export function getTotalUnreadCountInSubfolders(folder: Folder): number {
+	let count = 0;
+	if (folder.children?.length) {
+		folder.children.forEach((subfolder) => {
+			count += getTotalUnreadCount(subfolder);
+		});
+	}
+	return count;
+}
+
+export function folderHasChildren(folder: Folder): boolean {
+	return folder.children?.length > 0;
 }


### PR DESCRIPTION
This PR implements a visual notification icon on folders to indicate if subfolders contain unread emails, addressing user confusion about hidden unread messages in case there are nested folders.

**Key Changes**:
1. **Dot Indicator**
   - Added blue dot to parent folder icons
   - Positioned at top-right

2. **Tooltip Updates**
   - New format: "Folder Name (X unread mails in subfolders)"
   - Only shows the unread info when unread mails count in subfolders > 0
   - Maintains existing translation support

**Require:** https://github.com/zextras/carbonio-ui-commons/pull/188
