### PR TITLE
remove CO-2067 related todos

### DIFF
--- a/src/views/settings/components/recover-messages-modal.tsx
+++ b/src/views/settings/components/recover-messages-modal.tsx
@@ -55,10 +55,7 @@ export const RecoverMessagesModal = ({
 					disabled={isLoading}
 					onConfirm={onConfirm}
 					label={modalFooterLabel}
-					// TODO: CO-2067 fix type
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore
-					primaryButtonIcon={isLoading && AnimatedLoader}
+					primaryButtonIcon={isLoading ? AnimatedLoader : undefined}
 				/>
 			</Container>
 		</Container>

--- a/src/views/sidebar/edit-modal.tsx
+++ b/src/views/sidebar/edit-modal.tsx
@@ -34,9 +34,6 @@ export const EditModal: FC<ModalProps> = ({ folder, onClose }) => {
 
 				{activeModal === 'edit' && (
 					<EditPermissionsModal
-						// TODO: CO-2067 fix type
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore
 						folder={folder}
 						onClose={onClose}
 						goBack={goBack}
@@ -53,15 +50,7 @@ export const EditModal: FC<ModalProps> = ({ folder, onClose }) => {
 					/>
 				)}
 
-				{activeModal === 'share' && (
-					<EditPermissionsModal
-						// TODO: CO-2067 fix type
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore
-						folder={folder}
-						onClose={onClose}
-					/>
-				)}
+				{activeModal === 'share' && <EditPermissionsModal folder={folder} onClose={onClose} />}
 			</Container>
 		</Context.Provider>
 	);


### PR DESCRIPTION
Remove unnecessary TypeScript ignore comments and related TODOs in EditModal and RecoverMessagesModal components. Update the primaryButtonIcon prop to use a conditional expression instead of ignoring type checks.