### PR TITLE
HOTFIX: escape HTML in subject in print content

### DIFF
--- a/src/commons/print-conversation/get-body-wrapper.ts
+++ b/src/commons/print-conversation/get-body-wrapper.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { escape } from 'lodash';
 
 export function getBodyWrapper({ content, subject }: { content: string; subject: string }): string {
 	return `
@@ -15,7 +16,7 @@ export function getBodyWrapper({ content, subject }: { content: string; subject:
                         padding-left: 0.25rem;
                         display: flex;
                         align-items: center;">
-							<b>${subject}</b>
+							<b>${escape(subject)}</b>
 						</div>
 						<hr />
 					</td>

--- a/src/commons/print-conversation/get-subject.ts
+++ b/src/commons/print-conversation/get-subject.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { escape } from 'lodash';
 
 export const getSubject = (content: string, subject: string): string => `<tr>
     <td style="
@@ -15,5 +16,5 @@ export const getSubject = (content: string, subject: string): string => `<tr>
        font-style: normal;
        font-weight: 400;
        font-size: 0.875rem;
-       line-height: 1.3125rem;">${content}</span></td>
+       line-height: 1.3125rem;">${escape(content)}</span></td>
     </tr>`;


### PR DESCRIPTION
Escape HTML entities in subject and content using lodash's escape function to prevent potential HTML injection in the print conversation components. Changes applied to get-body-wrapper.ts and get-subject.ts.