### PR TITLE
fix: [CO-2188] FilterModule add id prop to FormSection for improved accessibility

### DIFF
--- a/src/views/settings/filters/index.tsx
+++ b/src/views/settings/filters/index.tsx
@@ -14,7 +14,7 @@ import { filtersSubSection } from 'views/settings/subsections';
 const FilterModule: FC = (): ReactElement => {
 	const sectionTitle = useMemo(() => filtersSubSection(), []);
 	return (
-		<FormSection label={sectionTitle.label}>
+		<FormSection label={sectionTitle.label} id={sectionTitle.id}>
 			<FormSubSection>
 				<Text>
 					{t('filters.filter_note', 'Note: changes to filter rules are saved immediately')}

--- a/src/views/settings/filters/tests/index.test.tsx
+++ b/src/views/settings/filters/tests/index.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { act } from 'react';
+
+import { setupTest } from '@test-setup';
+import FilterModule from 'views/settings/filters';
+
+jest.mock('@zextras/carbonio-shell-ui', () => ({
+	t: (key: string, fallback?: string): string => fallback || key
+}));
+
+describe('FilterModule', () => {
+	it('renders FormSection with id="filters" for anchor navigation', async () => {
+		const { container } = await act(async () => setupTest(<FilterModule />));
+		// eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
+		const el = container.querySelector('#filters');
+		expect(el).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
**What was changed:**

Fixes anchor navigation for the "Filters" section in Webmail Settings. The "Filters" section now renders with id="filters", ensuring the left-hand menu anchor works as expected.