### PR TITLE
fix: [CO-2234] Strip threading metadata in "Edit as new" to avoid conversation merge

### DIFF
--- a/src/store/editor/editor-generators.ts
+++ b/src/store/editor/editor-generators.ts
@@ -501,7 +501,6 @@ export const generateEditAsNewEditor = (originalMessage: MailMessage): MailsEdit
 		subject: originalMessage.subject,
 		text,
 		requestReadReceipt: isRequestReadReceipt,
-		originalId: originalMessage.id,
 		originalMessage,
 		size: originalMessage.size
 	};

--- a/src/store/editor/editor-generators.ts
+++ b/src/store/editor/editor-generators.ts
@@ -498,7 +498,9 @@ export const generateEditAsNewEditor = (originalMessage: MailMessage): MailsEdit
 			cc: retrieveCCForEditNew(originalMessage),
 			bcc: retrieveBCC(originalMessage)
 		},
-		subject: originalMessage.subject ? originalMessage.subject.replace(REPLY_REGEX, '') : '',
+		subject: originalMessage.subject
+			? originalMessage.subject.replace(REPLY_REGEX, '').replace(FORWARD_REGEX, '')
+			: '',
 		text,
 		requestReadReceipt: isRequestReadReceipt,
 		originalMessage,

--- a/src/store/editor/editor-generators.ts
+++ b/src/store/editor/editor-generators.ts
@@ -498,7 +498,7 @@ export const generateEditAsNewEditor = (originalMessage: MailMessage): MailsEdit
 			cc: retrieveCCForEditNew(originalMessage),
 			bcc: retrieveBCC(originalMessage)
 		},
-		subject: originalMessage.subject,
+		subject: originalMessage.subject ? originalMessage.subject.replace(REPLY_REGEX, '') : '',
 		text,
 		requestReadReceipt: isRequestReadReceipt,
 		originalMessage,

--- a/src/store/editor/tests/editor-generators.test.ts
+++ b/src/store/editor/tests/editor-generators.test.ts
@@ -10,7 +10,7 @@ import { EditViewActions } from 'constants/index';
 import { generateEditor } from 'store/editor/editor-generators';
 import { getEditor } from 'store/editor/hooks/editors';
 import { generateMessage } from 'tests/generators/generateMessage';
-import { MailMessage } from 'types/index.d';
+import { EditViewActionsType, MailMessage } from 'types/index.d';
 
 jest.mock('store/editor/hooks/editors', () => ({
 	...jest.requireActual('store/editor/hooks/editors'),
@@ -35,7 +35,6 @@ jest.mock('../../../helpers/identities', () => ({
 	getAddressOwnerAccount: jest.fn(() => ({ id: 'address-owner-id' }))
 }));
 
-// Test cases
 describe('generateEditor', () => {
 	const message = {
 		...generateMessage(),
@@ -43,89 +42,111 @@ describe('generateEditor', () => {
 		replyType: 'r'
 	} as MailMessage;
 
-	it('should generate an editor with action EDIT_AS_DRAFT', () => {
-		const result = generateEditor({
-			action: EditViewActions.EDIT_AS_DRAFT,
-			id: 'test-id',
-			message
-		});
-
-		expect(result).toBeTruthy();
-		expect(result?.id).toBe('test-editor-id');
-		expect(result?.identityId).toBe('test-identity-id');
-		expect(result?.text.plainText).toContain(message.fragment);
-		expect(result?.text.richText).toContain(message.fragment);
-		expect(result?.recipients.to).toEqual([find(message.participants, { type: 't' })]);
-		expect(result?.recipients.cc).toEqual([find(message.participants, { type: 'cc' })]);
-		expect(result?.originalId).toEqual('test-orig-id'); // Use originalId from message and not id
-		expect(result?.recipients.bcc).toEqual([]);
-		expect(result?.isRichText).toBe(true);
-	});
-
-	it('should generate an editor with action EDIT_AS_NEW', () => {
-		const result = generateEditor({
-			action: EditViewActions.EDIT_AS_NEW,
-			id: 'test-id',
-			message
-		});
-
-		expect(result).toBeTruthy();
-		expect(result?.id).toBe('test-editor-id');
-		expect(result?.identityId).toBe('test-identity-id');
-		expect(result?.text.plainText).toContain(message.fragment);
-		expect(result?.text.richText).toContain(message.fragment);
-		expect(result?.recipients.to).toEqual([find(message.participants, { type: 't' })]);
-		expect(result?.recipients.cc).toEqual([find(message.participants, { type: 'cc' })]);
-		expect(result?.originalId).toEqual(message.id); // Uses id from message as originalId
-		expect(result?.recipients.bcc).toEqual([]);
-		expect(result?.isRichText).toBe(true);
-	});
-
-	test('editor generated with EDIT_AS_NEW action should not have originalId', () => {
-		const result = generateEditor({
-			action: EditViewActions.EDIT_AS_NEW,
-			id: 'test-id',
-			message
-		});
-
-		expect(result).toBeTruthy();
-		expect(result?.originalId).toBeUndefined();
-	});
-
-	it('should throw an error if id is missing for EDIT_AS_DRAFT', () => {
-		expect(() =>
-			generateEditor({
-				action: EditViewActions.EDIT_AS_DRAFT,
-				id: undefined,
+	describe('Basic functionality', () => {
+		it('should return null for unsupported actions', () => {
+			const result = generateEditor({
+				action: 'UNSUPPORTED_ACTION' as EditViewActionsType,
+				id: 'test-id',
 				message
-			})
-		).toThrow('Cannot generate a draft editor without a message id');
+			});
+			expect(result).toBeNull();
+		});
 	});
 
-	it('should return null for unsupported actions', () => {
+	describe('EDIT_AS_DRAFT action', () => {
 		const result = generateEditor({
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			action: 'UNSUPPORTED_ACTION',
+			action: EditViewActions.EDIT_AS_DRAFT,
 			id: 'test-id',
 			message
 		});
 
-		expect(result).toBeNull();
-	});
-
-	it('should return null if no message is provided for EDIT_AS_DRAFT', () => {
-		const result = generateEditor({
-			action: EditViewActions.EDIT_AS_DRAFT,
-			id: 'test-id',
-			message: null
+		it('should throw an error if id is missing', () => {
+			expect(() =>
+				generateEditor({
+					action: EditViewActions.EDIT_AS_DRAFT,
+					id: undefined,
+					message
+				})
+			).toThrow('Cannot generate a draft editor without a message id');
 		});
 
-		expect(result).toBeNull();
+		it('should return null if no message is provided', () => {
+			const editorWithNullMessage = generateEditor({
+				action: EditViewActions.EDIT_AS_DRAFT,
+				id: 'test-id',
+				message: null
+			});
+			expect(editorWithNullMessage).toBeNull();
+		});
+
+		test('should generate editor with correct properties', () => {
+			expect(result).toBeTruthy();
+			expect(result?.id).toBe('test-editor-id');
+			expect(result?.identityId).toBe('test-identity-id');
+			expect(result?.isRichText).toBe(true);
+		});
+
+		test('should include message content', () => {
+			expect(result?.text.plainText).toContain(message.fragment);
+			expect(result?.text.richText).toContain(message.fragment);
+		});
+
+		test('should set correct recipients', () => {
+			expect(result?.recipients.to).toEqual([find(message.participants, { type: 't' })]);
+			expect(result?.recipients.cc).toEqual([find(message.participants, { type: 'cc' })]);
+			expect(result?.recipients.bcc).toEqual([]);
+		});
+
+		test('should use message.originalId', () => {
+			expect(result?.originalId).toEqual('test-orig-id');
+		});
 	});
-	describe('urgent flag', () => {
-		it.each`
-			action                                   | assertion
+
+	describe('EDIT_AS_NEW action', () => {
+		const editor = generateEditor({
+			action: EditViewActions.EDIT_AS_NEW,
+			id: 'test-id',
+			message
+		});
+
+		it('should throw an error if id is missing', () => {
+			expect(() =>
+				generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: undefined,
+					message
+				})
+			).toThrow('Cannot generate an edit as new editor without a message id');
+		});
+
+		test('should generate editor with correct properties', () => {
+			expect(editor).toBeTruthy();
+			expect(editor?.id).toBe('test-editor-id');
+			expect(editor?.identityId).toBe('test-identity-id');
+			expect(editor?.isRichText).toBe(true);
+		});
+
+		test('should include message content', () => {
+			expect(editor?.text.plainText).toContain(message.fragment);
+			expect(editor?.text.richText).toContain(message.fragment);
+		});
+
+		test('should set correct recipients', () => {
+			expect(editor?.recipients.to).toEqual([find(message.participants, { type: 't' })]);
+			expect(editor?.recipients.cc).toEqual([find(message.participants, { type: 'cc' })]);
+			expect(editor?.recipients.bcc).toEqual([]);
+		});
+
+		test('should not have originalId', () => {
+			expect(editor?.originalId).toBeUndefined();
+		});
+	});
+
+	describe('Urgent flag handling', () => {
+		const urgentMessage = { ...message, urgent: true };
+
+		describe.each`
+			action                                   | expected
 			${EditViewActions.REPLY}                 | ${false}
 			${EditViewActions.NEW}                   | ${false}
 			${EditViewActions.REPLY_ALL}             | ${false}
@@ -136,33 +157,34 @@ describe('generateEditor', () => {
 			${EditViewActions.FORWARD_AS_ATTACHMENT} | ${false}
 			${EditViewActions.EDIT_AS_NEW}           | ${false}
 			${EditViewActions.MAIL_TO}               | ${false}
-		`(`should set urgent in editor to $assertion if action is $action`, ({ action, assertion }) => {
-			const urgentMessage = { ...message, urgent: true };
-			const replyEditor = generateEditor({
-				action,
-				id: 'test-id',
-				message: urgentMessage
+		`('Action: $action', ({ action, expected }) => {
+			it(`should set isUrgent to ${expected}`, () => {
+				const editor = generateEditor({
+					action,
+					id: 'test-id',
+					message: urgentMessage
+				});
+				expect(editor?.isUrgent).toBe(expected);
 			});
-
-			expect(replyEditor?.isUrgent).toBe(assertion);
 		});
 
-		it('should return true if action is RESUME and message is urgent', () => {
-			const urgentMessage = { ...message, urgent: true };
-			const replyEditor = generateEditor({
-				action: EditViewActions.EDIT_AS_DRAFT,
-				id: 'test-id',
-				message: urgentMessage
+		describe('RESUME action', () => {
+			it('should preserve urgent flag from original editor', () => {
+				const draftEditor = generateEditor({
+					action: EditViewActions.EDIT_AS_DRAFT,
+					id: 'test-id',
+					message: urgentMessage
+				});
+
+				(getEditor as jest.Mock).mockReturnValueOnce(draftEditor);
+
+				const resumedEditor = generateEditor({
+					action: EditViewActions.RESUME,
+					id: draftEditor?.id
+				});
+
+				expect(resumedEditor?.isUrgent).toBe(true);
 			});
-
-			(getEditor as jest.Mock).mockReturnValueOnce(replyEditor);
-
-			const resumedEditor = generateEditor({
-				action: EditViewActions.RESUME,
-				id: replyEditor?.id
-			});
-
-			expect(resumedEditor?.isUrgent).toBe(true);
 		});
 	});
 });

--- a/src/store/editor/tests/editor-generators.test.ts
+++ b/src/store/editor/tests/editor-generators.test.ts
@@ -57,9 +57,39 @@ describe('generateEditor', () => {
 		expect(result?.text.richText).toContain(message.fragment);
 		expect(result?.recipients.to).toEqual([find(message.participants, { type: 't' })]);
 		expect(result?.recipients.cc).toEqual([find(message.participants, { type: 'cc' })]);
-		expect(result?.originalId).toEqual('test-orig-id');
+		expect(result?.originalId).toEqual('test-orig-id'); // Use originalId from message and not id
 		expect(result?.recipients.bcc).toEqual([]);
 		expect(result?.isRichText).toBe(true);
+	});
+
+	it('should generate an editor with action EDIT_AS_NEW', () => {
+		const result = generateEditor({
+			action: EditViewActions.EDIT_AS_NEW,
+			id: 'test-id',
+			message
+		});
+
+		expect(result).toBeTruthy();
+		expect(result?.id).toBe('test-editor-id');
+		expect(result?.identityId).toBe('test-identity-id');
+		expect(result?.text.plainText).toContain(message.fragment);
+		expect(result?.text.richText).toContain(message.fragment);
+		expect(result?.recipients.to).toEqual([find(message.participants, { type: 't' })]);
+		expect(result?.recipients.cc).toEqual([find(message.participants, { type: 'cc' })]);
+		expect(result?.originalId).toEqual(message.id); // Uses id from message as originalId
+		expect(result?.recipients.bcc).toEqual([]);
+		expect(result?.isRichText).toBe(true);
+	});
+
+	test('editor generated with EDIT_AS_NEW action should not have originalId', () => {
+		const result = generateEditor({
+			action: EditViewActions.EDIT_AS_NEW,
+			id: 'test-id',
+			message
+		});
+
+		expect(result).toBeTruthy();
+		expect(result?.originalId).toBeUndefined();
 	});
 
 	it('should throw an error if id is missing for EDIT_AS_DRAFT', () => {

--- a/src/store/editor/tests/editor-generators.test.ts
+++ b/src/store/editor/tests/editor-generators.test.ts
@@ -141,7 +141,7 @@ describe('generateEditor', () => {
 			expect(editor?.originalId).toBeUndefined();
 		});
 
-		describe('subject handling', () => {
+		describe('subject sanitizing and handling', () => {
 			const baseMessage = {
 				...message,
 				subject: 'RE: Test Subject'
@@ -154,6 +154,36 @@ describe('generateEditor', () => {
 					message: baseMessage
 				});
 				expect(editor2?.subject).toBe('Test Subject');
+			});
+
+			it('should not removes RE: string literal if it is not prefix from subject', () => {
+				const message2 = { ...baseMessage, subject: 'TEST RE: Test Subject' };
+				const editor2 = generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: 'test-id',
+					message: message2
+				});
+				expect(editor2?.subject).toBe('TEST RE: Test Subject');
+			});
+
+			it('removes FWD: prefix from subject', () => {
+				const message2 = { ...baseMessage, subject: 'FWD: Test Subject' };
+				const editor2 = generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: 'test-id',
+					message: message2
+				});
+				expect(editor2?.subject).toBe('Test Subject');
+			});
+
+			it('should not removes FWD: string literal if it is not prefix from subject', () => {
+				const message2 = { ...baseMessage, subject: 'TEST FWD: Test Subject' };
+				const editor2 = generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: 'test-id',
+					message: message2
+				});
+				expect(editor2?.subject).toBe('TEST FWD: Test Subject');
 			});
 
 			it('removes multiple RE: prefixes', () => {

--- a/src/store/editor/tests/editor-generators.test.ts
+++ b/src/store/editor/tests/editor-generators.test.ts
@@ -140,6 +140,52 @@ describe('generateEditor', () => {
 		test('should not have originalId', () => {
 			expect(editor?.originalId).toBeUndefined();
 		});
+
+		describe('subject handling', () => {
+			const baseMessage = {
+				...message,
+				subject: 'RE: Test Subject'
+			};
+
+			it('removes RE: prefix from subject', () => {
+				const editor2 = generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: 'test-id',
+					message: baseMessage
+				});
+				expect(editor2?.subject).toBe('Test Subject');
+			});
+
+			it('removes multiple RE: prefixes', () => {
+				const message2 = { ...baseMessage, subject: 'RE: RE: Test Subject' };
+				const editor3 = generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: 'test-id',
+					message: message2
+				});
+				expect(editor3?.subject).toBe('Test Subject');
+			});
+
+			it('does not change subject if no RE: prefix', () => {
+				const message3 = { ...baseMessage, subject: 'Test Subject' };
+				const editor4 = generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: 'test-id',
+					message: message3
+				});
+				expect(editor4?.subject).toBe('Test Subject');
+			});
+
+			it('sets subject to empty string if originalMessage.subject is undefined', () => {
+				const message4 = { ...baseMessage, subject: undefined as unknown } as MailMessage;
+				const editor5 = generateEditor({
+					action: EditViewActions.EDIT_AS_NEW,
+					id: 'test-id',
+					message: message4
+				});
+				expect(editor5?.subject).toBe('');
+			});
+		});
 	});
 
 	describe('Urgent flag handling', () => {


### PR DESCRIPTION
## ✨ Summary

This PR improves the behavior of the "Edit as new" feature in the message editor generator logic. It ensures that messages edited as new are treated as standalone messages and not linked to existing threads or conversations.

## ✅ Changes

### Fixes
- **Remove `originalId`** from message object when using `EDIT_AS_NEW`, to prevent backend from linking to original conversation
- **Sanitize subject** by removing reply/forward prefixes (`RE:`, `FWD:`) when editing as new

### Tests
- Added coverage for `EDIT_AS_NEW` action to verify `originalId` is not present
- Enhanced tests for `EDIT_AS_DRAFT` and `EDIT_AS_NEW` to ensure correct behavior
- Added tests for subject sanitization logic in `EDIT_AS_NEW`