### PR TITLE
remove debounceSaveEditor in rich-text-editor-container

### DIFF
--- a/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
@@ -7,16 +7,11 @@ import React, { useCallback, useMemo, useRef } from 'react';
 
 import { Container } from '@zextras/carbonio-design-system';
 import { useIntegratedComponent, useUserSettings } from '@zextras/carbonio-shell-ui';
-import { debounce, noop } from 'lodash';
+import { noop } from 'lodash';
 import type { TinyMCE, Editor } from 'tinymce';
 
 import { buildArrayFromFileList } from 'helpers/files';
-import {
-	useEditorAttachments,
-	useEditorsStore,
-	useEditorText,
-	useEditorTextProvider
-} from 'store/editor/index';
+import { useEditorAttachments, useEditorText, useEditorTextProvider } from 'store/editor/index';
 import { MailsEditorV2 } from 'types/index.d';
 import * as StyledComp from 'views/app/detail-panel/edit/parts/edit-view-styled-components';
 import { handleEditorPaste } from 'views/app/detail-panel/edit/parts/editor-paste-handler';
@@ -81,22 +76,14 @@ export const RichTextEditorContainer = ({
 		if (!composerRef.current) {
 			return;
 		}
-
-		const { plainText, richText } = useEditorsStore.getState().editors[editorId].text;
+		const plainText = composerRef.current.getContent({ format: 'text' });
+		const richText = composerRef.current.getContent({ format: 'html' });
 		setText({ plainText, richText }, { syncTextProvider: false });
-	}, [editorId, setText]);
-	const debouncedSetText = useMemo(
-		() =>
-			debounce(() => {
-				useEditorsStore.getState().setText(editorId, getCurrentText() as MailsEditorV2['text']);
-			}, 150),
-		[editorId, getCurrentText]
-	);
+	}, [setText]);
 	const onTextChange = useCallback(() => {
 		if (timeoutId.current) {
 			clearTimeout(timeoutId.current);
 		}
-		debouncedSetText();
 		timeoutId.current = setTimeout(() => {
 			if (!composerRef.current) {
 				return;
@@ -107,7 +94,7 @@ export const RichTextEditorContainer = ({
 			composerRef.current?.setDirty(false);
 			alreadyFocused && composerRef.current?.focus();
 		}, SAVE_EDITOR_DELAY);
-	}, [debouncedSetText, saveEditor]);
+	}, [saveEditor]);
 
 	const onComposerClose = useCallback(() => {
 		saveEditor();


### PR DESCRIPTION
Removed debounce logic and related imports from text synchronization.
ref: CO-2213