### PR TITLE
fix: update get-link usage in smartlinks-from-files to expect object

### DIFF
--- a/src/views/app/detail-panel/edit/parts/smartlink-modal/smartlink-from-files-modal.tsx
+++ b/src/views/app/detail-panel/edit/parts/smartlink-modal/smartlink-from-files-modal.tsx
@@ -25,9 +25,9 @@ type CreateLinkType = {
 type Link = {
 	__typename?: 'Link';
 	id: string;
-	url?: string | null | undefined;
-	description?: string | null | undefined;
-	expires_at?: number | null | undefined;
+	url?: string | null;
+	description?: string | null;
+	expires_at?: number | null;
 	created_at: number;
 	node: Pick<NodeWithMetadata, 'id' | '__typename'>;
 };

--- a/src/views/app/detail-panel/edit/parts/smartlink-modal/smartlink-from-files-modal.tsx
+++ b/src/views/app/detail-panel/edit/parts/smartlink-modal/smartlink-from-files-modal.tsx
@@ -12,7 +12,25 @@ import { SmartlinkAwaitingConfirmModal } from './smartlink-awaiting-confirm-moda
 import { FileNode } from '../../edit-utils-hooks/use-upload-from-files';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
 import { useEditorText } from 'store/editor/hooks';
+import { NodeWithMetadata } from 'types/integrations/carbonio-files-ui';
 import { generateSmartLinkHtml, insertAboveSignature } from 'ui-actions/utils';
+
+type CreateLinkType = {
+	node: Pick<NodeWithMetadata, 'id' | '__typename'>;
+	description?: string;
+	expiresAt?: number;
+	type: 'createLink';
+};
+
+type Link = {
+	__typename?: 'Link';
+	id: string;
+	url?: string | null | undefined;
+	description?: string | null | undefined;
+	expires_at?: number | null | undefined;
+	created_at: number;
+	node: Pick<NodeWithMetadata, 'id' | '__typename'>;
+};
 
 export const SmartlinkFromFilesModal = ({
 	onClose,
@@ -24,7 +42,8 @@ export const SmartlinkFromFilesModal = ({
 	editorId: string;
 }): React.JSX.Element => {
 	const [t] = useTranslation();
-	const [getLink, getLinkAvailable] = useIntegratedFunction('get-link');
+	const [getLink, getLinkAvailable] =
+		useIntegratedFunction<(props: CreateLinkType) => Promise<Link>>('get-link');
 	const { createSnackbar } = useUiUtilities();
 
 	const errorSnackbar = useCallback(() => {
@@ -46,23 +65,23 @@ export const SmartlinkFromFilesModal = ({
 
 			const smartLinksArray = await Promise.all(
 				fileNodes.map(async (fileNode) => {
-					const publicLinkUrl =
+					const response =
 						getLinkAvailable &&
 						(await getLink({
 							node: fileNode,
 							type: 'createLink',
 							description: fileNode.id
 						}));
-					if (!publicLinkUrl) {
+					if (!response || !response.url) {
 						errorSnackbar();
 						throw new Error('Public link creation failed');
 					}
 					return {
 						richTextLinks: generateSmartLinkHtml({
-							publicLinkUrl,
+							publicLinkUrl: response.url,
 							filename: fileNode.name
 						}),
-						plainTextLinks: publicLinkUrl
+						plainTextLinks: response.url
 					};
 				})
 			);

--- a/src/views/app/detail-panel/edit/parts/smartlink-modal/tests/smartlink-from-files-modal.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/smartlink-modal/tests/smartlink-from-files-modal.test.tsx
@@ -79,7 +79,7 @@ describe('SmartlinkFromFilesModal', () => {
 
 	describe('in richText mode', () => {
 		it('correctly adds the smartlink url before the signature', async () => {
-			const getLinkSpy = jest.fn().mockResolvedValue('url1');
+			const getLinkSpy = jest.fn().mockResolvedValue({ url: 'url1' });
 			useIntegratedFunction.mockImplementation((integratedFunctionId) => {
 				if (integratedFunctionId === 'get-link') {
 					return [getLinkSpy, true];
@@ -133,7 +133,10 @@ describe('SmartlinkFromFilesModal', () => {
 			expect(errorSnackbar).toBeInTheDocument();
 		});
 		it('correctly adds multiple smartlink urls before the signature', async () => {
-			const getLinkSpy = jest.fn().mockResolvedValue('url1').mockResolvedValueOnce('url2');
+			const getLinkSpy = jest
+				.fn()
+				.mockResolvedValueOnce({ url: 'url1' })
+				.mockResolvedValueOnce({ url: 'url2' });
 			useIntegratedFunction.mockImplementation((integratedFunctionId) => {
 				if (integratedFunctionId === 'get-link') {
 					return [getLinkSpy, true];
@@ -197,7 +200,10 @@ describe('SmartlinkFromFilesModal', () => {
 	});
 	describe('in plainText mode', () => {
 		it('correctly adds multiple smartlink urls at the end of the document', async () => {
-			const getLinkSpy = jest.fn().mockResolvedValueOnce('url1').mockResolvedValueOnce('url2');
+			const getLinkSpy = jest
+				.fn()
+				.mockResolvedValueOnce({ url: 'url1' })
+				.mockResolvedValueOnce({ url: 'url2' });
 			useIntegratedFunction.mockImplementation((integratedFunctionId) => {
 				if (integratedFunctionId === 'get-link') {
 					return [getLinkSpy, true];


### PR DESCRIPTION
Update get-link integrated function to return an object with url property instead of a string. Adjust related logic and tests to handle the new response shape.