### PR TITLE
fix: [CO-2475] display inline attachments with no content-id in editor

### DIFF
--- a/src/store/editor/hooks/attachments.ts
+++ b/src/store/editor/hooks/attachments.ts
@@ -92,7 +92,7 @@ export const useEditorAttachments = (editorId: MailsEditorV2['id']): EditorAttac
 	);
 	const savedStandardAttachments = reject(
 		useEditorsStore((state) => state.editors[editorId].savedAttachments),
-		'isInline'
+		(x) => x.isInline && x.contentId !== undefined
 	);
 	const removeStandardAttachmentsInvoker = useEditorsStore(
 		(state) => state.clearStandardAttachments

--- a/src/views/app/detail-panel/edit/edit-attachments-block.tsx
+++ b/src/views/app/detail-panel/edit/edit-attachments-block.tsx
@@ -44,7 +44,12 @@ export const EditAttachmentsBlock: FC<{
 		<StyledComp.RowContainer background="gray6">
 			<StyledComp.ColContainer $occupyFull>
 				<Container crossAlignment="flex-start">
-					<Container orientation="horizontal" mainAlignment="space-between" wrap="wrap">
+					<Container
+						orientation="horizontal"
+						mainAlignment="space-between"
+						wrap="wrap"
+						data-testid={'edit-attachments-block'}
+					>
 						{map(expanded ? allAttachments : allAttachments.slice(0, 2), (attachment, index) =>
 							// FIXME: This ternary is a temporary fix. Remove once the backend is exposing the correct data
 							// REF IRIS-4205

--- a/src/views/app/detail-panel/edit/tests/edit-attachments-block.test.tsx
+++ b/src/views/app/detail-panel/edit/tests/edit-attachments-block.test.tsx
@@ -6,8 +6,12 @@
 
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
+import { EditViewActions } from '../../../../../constants';
+import { generateEditor } from '../../../../../store/editor/editor-generators';
+import { generateMessage } from '../../../../../tests/generators/generateMessage';
+import type { MailsEditorV2 } from '../../../../../types';
 import { setupTest } from '@test-setup';
 import { addEditor } from 'store/editor/index';
 import { setupEditorStore } from 'tests/generators/editor-store';
@@ -55,5 +59,38 @@ describe('Attachments visualization', () => {
 				throw new Error(`The attachment block for the file ${filename} is not present`);
 			}
 		});
+	});
+	it('should display inline attachments with no Content-ID', async () => {
+		setupEditorStore({ editors: [] });
+		const message = generateMessage({
+			parts: [
+				{
+					name: 'inlinePart1',
+					filename: 'part1',
+					disposition: 'inline' as const,
+					ci: '123',
+					contentType: 'image/png',
+					size: 200
+				},
+				{
+					name: 'part2',
+					filename: 'file-with-no-content-id',
+					disposition: 'inline' as const,
+					contentType: 'image/png',
+					size: 200
+				}
+			]
+		});
+		const editor = generateEditor({
+			action: EditViewActions.EDIT_AS_DRAFT,
+			id: 'test-id',
+			message
+		}) as MailsEditorV2;
+		addEditor({ id: editor.id, editor });
+
+		setupTest(<EditAttachmentsBlock editorId={editor.id} />);
+
+		const editAttachmentsBlock = await screen.findByTestId('edit-attachments-block');
+		expect(await within(editAttachmentsBlock).findByText('file-with-no-content-id')).toBeVisible();
 	});
 });

--- a/src/views/app/detail-panel/edit/tests/edit-attachments-block.test.tsx
+++ b/src/views/app/detail-panel/edit/tests/edit-attachments-block.test.tsx
@@ -65,14 +65,6 @@ describe('Attachments visualization', () => {
 		const message = generateMessage({
 			parts: [
 				{
-					name: 'inlinePart1',
-					filename: 'part1',
-					disposition: 'inline' as const,
-					ci: '123',
-					contentType: 'image/png',
-					size: 200
-				},
-				{
 					name: 'part2',
 					filename: 'file-with-no-content-id',
 					disposition: 'inline' as const,
@@ -92,5 +84,40 @@ describe('Attachments visualization', () => {
 
 		const editAttachmentsBlock = await screen.findByTestId('edit-attachments-block');
 		expect(await within(editAttachmentsBlock).findByText('file-with-no-content-id')).toBeVisible();
+	});
+	it('should NOT display inline attachments with Content-ID', async () => {
+		setupEditorStore({ editors: [] });
+		const message = generateMessage({
+			parts: [
+				{
+					name: 'part2',
+					filename: 'other',
+					disposition: 'inline' as const,
+					contentType: 'image/png',
+					size: 200
+				},
+				{
+					name: 'inlinePart1',
+					filename: 'file-with-content-id',
+					disposition: 'inline' as const,
+					ci: '123',
+					contentType: 'image/png',
+					size: 200
+				}
+			]
+		});
+		const editor = generateEditor({
+			action: EditViewActions.EDIT_AS_DRAFT,
+			id: 'test-id',
+			message
+		}) as MailsEditorV2;
+		addEditor({ id: editor.id, editor });
+
+		setupTest(<EditAttachmentsBlock editorId={editor.id} />);
+
+		const editAttachmentsBlock = await screen.findByTestId('edit-attachments-block');
+		expect(
+			within(editAttachmentsBlock).queryByText('file-with-content-id')
+		).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
**Related PR:** https://github.com/zextras/carbonio-mailbox/pull/792