### PR TITLE
fix: [CO-1964] Clicking edit draft action opens multiple duplicate editors

### DIFF
--- a/src/views/app/detail-panel/edit/edit-view-board.tsx
+++ b/src/views/app/detail-panel/edit/edit-view-board.tsx
@@ -41,25 +41,21 @@ export const createEditBoard = ({
 	onConfirm,
 	title = ''
 }: CreateEditBoardParams): Board => {
-	if (action === EditViewActions.EDIT_AS_DRAFT && actionTargetId) {
-		const boardId = generateBoardId(action, actionTargetId);
-		const existingBoard = getBoardById(boardId);
+	const isDraftEdit = action === EditViewActions.EDIT_AS_DRAFT && actionTargetId;
+	const boardId = isDraftEdit ? generateBoardId(action, actionTargetId) : undefined;
 
+	if (isDraftEdit) {
+		const existingBoard = boardId ? getBoardById(boardId) : undefined;
 		if (existingBoard) {
 			setCurrentBoard(existingBoard.id);
 			return existingBoard;
 		}
 	}
 
-	const idForCreation =
-		action === EditViewActions.EDIT_AS_DRAFT && actionTargetId
-			? generateBoardId(action, actionTargetId)
-			: undefined;
-
 	return addBoard<EditViewBoardContext>({
 		boardViewId: MAILS_BOARD_VIEW_ID,
 		title,
-		id: idForCreation,
+		id: boardId,
 		context: {
 			originAction: action,
 			originActionTargetId: actionTargetId,

--- a/src/views/app/detail-panel/edit/edit-view-board.tsx
+++ b/src/views/app/detail-panel/edit/edit-view-board.tsx
@@ -25,13 +25,19 @@ type CreateEditBoardParams = {
 };
 
 /**
- * Generate a consistent board ID for draft editing
+ * Get draft board ID based on action and target ID
+ *
+ * @param action
+ * @param actionTargetId
  */
-const generateBoardId = (action: EditViewActionsType, actionTargetId?: string): string => {
+const getDraftBoardId = (
+	action: EditViewActionsType,
+	actionTargetId?: string
+): string | undefined => {
 	if (action === EditViewActions.EDIT_AS_DRAFT && actionTargetId) {
 		return `${MAILS_BOARD_VIEW_ID}-edit-draft-${actionTargetId}`;
 	}
-	return `${MAILS_BOARD_VIEW_ID}-${action}-${actionTargetId ?? Date.now()}`;
+	return undefined;
 };
 
 export const createEditBoard = ({
@@ -41,11 +47,10 @@ export const createEditBoard = ({
 	onConfirm,
 	title = ''
 }: CreateEditBoardParams): Board => {
-	const isDraftEdit = action === EditViewActions.EDIT_AS_DRAFT && actionTargetId;
-	const boardId = isDraftEdit ? generateBoardId(action, actionTargetId) : undefined;
+	const draftBoardId = getDraftBoardId(action, actionTargetId);
 
-	if (isDraftEdit) {
-		const existingBoard = boardId ? getBoardById(boardId) : undefined;
+	if (draftBoardId) {
+		const existingBoard = getBoardById(draftBoardId);
 		if (existingBoard) {
 			setCurrentBoard(existingBoard.id);
 			return existingBoard;
@@ -55,7 +60,7 @@ export const createEditBoard = ({
 	return addBoard<EditViewBoardContext>({
 		boardViewId: MAILS_BOARD_VIEW_ID,
 		title,
-		id: boardId,
+		id: draftBoardId,
 		context: {
 			originAction: action,
 			originActionTargetId: actionTargetId,

--- a/src/views/app/detail-panel/edit/edit-view-board.tsx
+++ b/src/views/app/detail-panel/edit/edit-view-board.tsx
@@ -31,7 +31,7 @@ const generateBoardId = (action: EditViewActionsType, actionTargetId?: string): 
 	if (action === EditViewActions.EDIT_AS_DRAFT && actionTargetId) {
 		return `${MAILS_BOARD_VIEW_ID}-edit-draft-${actionTargetId}`;
 	}
-	return `${MAILS_BOARD_VIEW_ID}-${action}-${actionTargetId || Date.now()}`;
+	return `${MAILS_BOARD_VIEW_ID}-${action}-${actionTargetId ?? Date.now()}`;
 };
 
 export const createEditBoard = ({

--- a/src/views/app/detail-panel/edit/edit-view-board.tsx
+++ b/src/views/app/detail-panel/edit/edit-view-board.tsx
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { addBoard, Board } from '@zextras/carbonio-shell-ui';
+import { addBoard, Board, getBoardById, setCurrentBoard } from '@zextras/carbonio-shell-ui';
 
-import { MAILS_BOARD_VIEW_ID } from 'constants/index';
+import { MAILS_BOARD_VIEW_ID, EditViewActions } from 'constants/index';
 import { EditorPrefillData, EditViewActionsType } from 'types/index.d';
 
 export type EditViewBoardContext = {
@@ -16,11 +16,6 @@ export type EditViewBoardContext = {
 	onConfirm?: (param: { editor: { text: [string, string] }; onBoardClose: () => void }) => void;
 };
 
-export type BoardContext = {
-	action: EditViewActionsType;
-	id?: string;
-};
-
 type CreateEditBoardParams = {
 	action: EditViewActionsType;
 	actionTargetId?: string;
@@ -29,16 +24,42 @@ type CreateEditBoardParams = {
 	onConfirm?: () => void;
 };
 
+/**
+ * Generate a consistent board ID for draft editing
+ */
+const generateBoardId = (action: EditViewActionsType, actionTargetId?: string): string => {
+	if (action === EditViewActions.EDIT_AS_DRAFT && actionTargetId) {
+		return `${MAILS_BOARD_VIEW_ID}-edit-draft-${actionTargetId}`;
+	}
+	return `${MAILS_BOARD_VIEW_ID}-${action}-${actionTargetId || Date.now()}`;
+};
+
 export const createEditBoard = ({
 	action,
 	actionTargetId,
 	compositionData,
 	onConfirm,
 	title = ''
-}: CreateEditBoardParams): Board =>
-	addBoard<EditViewBoardContext>({
+}: CreateEditBoardParams): Board => {
+	if (action === EditViewActions.EDIT_AS_DRAFT && actionTargetId) {
+		const boardId = generateBoardId(action, actionTargetId);
+		const existingBoard = getBoardById(boardId);
+
+		if (existingBoard) {
+			setCurrentBoard(existingBoard.id);
+			return existingBoard;
+		}
+	}
+
+	const idForCreation =
+		action === EditViewActions.EDIT_AS_DRAFT && actionTargetId
+			? generateBoardId(action, actionTargetId)
+			: undefined;
+
+	return addBoard<EditViewBoardContext>({
 		boardViewId: MAILS_BOARD_VIEW_ID,
 		title,
+		id: idForCreation,
 		context: {
 			originAction: action,
 			originActionTargetId: actionTargetId,
@@ -46,3 +67,4 @@ export const createEditBoard = ({
 			compositionData
 		}
 	});
+};

--- a/src/views/app/detail-panel/edit/tests/edit-view-board.test.ts
+++ b/src/views/app/detail-panel/edit/tests/edit-view-board.test.ts
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { addBoard, Board, getBoardById, setCurrentBoard } from '@zextras/carbonio-shell-ui';
+
+import { EditViewActions } from '../../../../../constants';
+import { createEditBoard } from '../edit-view-board';
+
+jest.mock('@zextras/carbonio-shell-ui', () => ({
+	addBoard: jest.fn(),
+	getBoardById: jest.fn(),
+	setCurrentBoard: jest.fn()
+}));
+
+const mockAddBoard = addBoard as jest.MockedFunction<typeof addBoard>;
+const mockGetBoardById = getBoardById as jest.MockedFunction<typeof getBoardById>;
+const mockSetCurrentBoard = setCurrentBoard as jest.MockedFunction<typeof setCurrentBoard>;
+
+describe('createEditBoard', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should create a new board when no existing board exists for draft editing', () => {
+		const mockBoard: Board = {
+			app: '',
+			boardViewId: '',
+			context: undefined,
+			icon: '',
+			title: '',
+			id: 'new-board'
+		};
+		mockGetBoardById.mockReturnValue(undefined);
+		mockAddBoard.mockReturnValue(mockBoard);
+
+		const result = createEditBoard({
+			action: EditViewActions.EDIT_AS_DRAFT,
+			actionTargetId: 'draft-123'
+		});
+
+		expect(mockGetBoardById).toHaveBeenCalledWith('mails_editor_board_view-edit-draft-draft-123');
+		expect(mockAddBoard).toHaveBeenCalledWith({
+			boardViewId: 'mails_editor_board_view',
+			id: 'mails_editor_board_view-edit-draft-draft-123',
+			title: '',
+			context: {
+				originAction: EditViewActions.EDIT_AS_DRAFT,
+				originActionTargetId: 'draft-123',
+				onConfirm: undefined,
+				compositionData: undefined
+			}
+		});
+		expect(mockSetCurrentBoard).not.toHaveBeenCalled();
+		expect(result).toBe(mockBoard);
+	});
+
+	it('should focus existing board instead of creating new one when draft editing board already exists', () => {
+		const existingBoard: Board = {
+			app: '',
+			boardViewId: '',
+			context: undefined,
+			icon: '',
+			title: '',
+			id: 'existing-board'
+		};
+		mockGetBoardById.mockReturnValue(existingBoard);
+
+		const result = createEditBoard({
+			action: EditViewActions.EDIT_AS_DRAFT,
+			actionTargetId: 'draft-123'
+		});
+
+		expect(mockGetBoardById).toHaveBeenCalledWith('mails_editor_board_view-edit-draft-draft-123');
+		expect(mockSetCurrentBoard).toHaveBeenCalledWith('existing-board');
+		expect(mockAddBoard).not.toHaveBeenCalled();
+		expect(result).toBe(existingBoard);
+	});
+
+	it('should create a new board for non-draft actions without checking for existing boards', () => {
+		const mockBoard: Board = {
+			app: '',
+			boardViewId: '',
+			context: undefined,
+			icon: '',
+			title: '',
+			id: 'new-board'
+		};
+		mockAddBoard.mockReturnValue(mockBoard);
+
+		const result = createEditBoard({
+			action: EditViewActions.REPLY,
+			actionTargetId: 'message-123'
+		});
+
+		expect(mockGetBoardById).not.toHaveBeenCalled();
+		expect(mockSetCurrentBoard).not.toHaveBeenCalled();
+		expect(mockAddBoard).toHaveBeenCalledWith({
+			boardViewId: 'mails_editor_board_view',
+			title: '',
+			id: undefined,
+			context: {
+				originAction: EditViewActions.REPLY,
+				originActionTargetId: 'message-123',
+				onConfirm: undefined,
+				compositionData: undefined
+			}
+		});
+		expect(result).toBe(mockBoard);
+	});
+
+	it('should create a new board when draft editing without actionTargetId', () => {
+		const mockBoard: Board = {
+			app: '',
+			boardViewId: '',
+			context: undefined,
+			icon: '',
+			title: '',
+			id: 'new-board'
+		};
+		mockAddBoard.mockReturnValue(mockBoard);
+
+		const result = createEditBoard({
+			action: EditViewActions.EDIT_AS_DRAFT
+		});
+
+		expect(mockGetBoardById).not.toHaveBeenCalled();
+		expect(mockSetCurrentBoard).not.toHaveBeenCalled();
+		expect(mockAddBoard).toHaveBeenCalledWith({
+			boardViewId: 'mails_editor_board_view',
+			title: '',
+			id: undefined,
+			context: {
+				originAction: EditViewActions.EDIT_AS_DRAFT,
+				originActionTargetId: undefined,
+				onConfirm: undefined,
+				compositionData: undefined
+			}
+		});
+		expect(result).toBe(mockBoard);
+	});
+});


### PR DESCRIPTION
This PR fixes a bug where clicking the "edit draft" action could open multiple duplicate editors. The solution implements a check to prevent creating duplicate boards for draft editing by reusing existing boards when they already exist.

Adds logic to check for existing draft editing boards before creating new ones
Implements a consistent board ID generation strategy for draft editing
Focuses existing boards instead of creating duplicates when they already exist