### PR TITLE
fix: regression message view sent subfolder email list doesn't show recipient

### DIFF
--- a/src/__test__/mocks/store/folders.ts
+++ b/src/__test__/mocks/store/folders.ts
@@ -37,11 +37,10 @@ export const populateFoldersStore = ({
 		}
 		return { ...result, [key]: link.id };
 	}, {});
-	const initialStoreState: FolderState = {
+	const initialStoreState: Partial<FolderState> = {
 		linksIdMap,
 		folders,
-		searches: {},
-		updateFolder: jest.fn()
+		searches: {}
 	};
-	useFolderStore.setState(initialStoreState, true);
+	useFolderStore.setState((state) => ({ ...state, ...initialStoreState }), true);
 };

--- a/src/helpers/folders.ts
+++ b/src/helpers/folders.ts
@@ -217,14 +217,14 @@ export const isInboxSubfolder = ({
 		return false;
 	}
 
-	return path.toLowerCase().startsWith('/inbox/') || path.toLowerCase() === '/inbox';
+	return path.toLowerCase().startsWith('/inbox') || path.toLowerCase() === '/inbox';
 };
 
 /**
  * Tells if a folder is a subfolder of the sent folder
  * @param folderId
  */
-export const isSentSubfolder = (folder: Folder | undefined): boolean => {
+export const isSentOrItsSubfolder = (folder: Folder | undefined): boolean => {
 	if (!folder) {
 		return false;
 	}

--- a/src/helpers/folders.ts
+++ b/src/helpers/folders.ts
@@ -212,11 +212,30 @@ export const isInboxSubfolder = ({
 
 	const folderIdAbsPath = useFolderStore.getState()?.folders?.[folderId ?? '']?.absFolderPath;
 	const path = folder ? folder.absFolderPath : folderIdAbsPath;
+
 	if (!path) {
 		return false;
 	}
 
-	return path.toLowerCase().startsWith('/inbox');
+	return path.toLowerCase().startsWith('/inbox/') || path.toLowerCase() === '/inbox';
+};
+
+/**
+ * Tells if a folder is a subfolder of the sent folder
+ * @param folderId
+ */
+export const isSentSubfolder = (folder: Folder | undefined): boolean => {
+	if (!folder) {
+		return false;
+	}
+
+	const path = folder.absFolderPath;
+
+	if (!path) {
+		return false;
+	}
+
+	return path.toLowerCase().startsWith('/sent/') || path.toLowerCase() === '/sent';
 };
 
 /**

--- a/src/helpers/folders.ts
+++ b/src/helpers/folders.ts
@@ -217,7 +217,7 @@ export const isInboxSubfolder = ({
 		return false;
 	}
 
-	return path.toLowerCase().startsWith('/inbox') || path.toLowerCase() === '/inbox';
+	return path.toLowerCase().startsWith('/inbox');
 };
 
 /**

--- a/src/views/app/folder-panel/parts/participants-name.tsx
+++ b/src/views/app/folder-panel/parts/participants-name.tsx
@@ -11,7 +11,7 @@ import { FOLDERS, getFolder, ParticipantRole } from '@zextras/carbonio-ui-common
 import { findIndex, reduce, trimStart, uniqBy } from 'lodash';
 
 import { participantToString } from 'commons/utils';
-import { getFolderIdParts, isSentSubfolder } from 'helpers/folders';
+import { getFolderIdParts, isSentOrItsSubfolder } from 'helpers/folders';
 import { isConversation } from 'helpers/messages';
 import { getConversationMessages } from 'store/emails/store';
 import {
@@ -54,10 +54,10 @@ export const ParticipantsName = ({
 				folderId !== FOLDERS.SENT &&
 				folderId !== FOLDERS.DRAFTS &&
 				!isSearchModule &&
-				!isSentSubfolder(folder)
+				!isSentOrItsSubfolder(folder)
 			)
 				return p.type === ParticipantRole.FROM; // Not sent or drafts
-			if (!isSearchModule && (isSentSubfolder(folder) || folderId === FOLDERS.SENT))
+			if (!isSearchModule && (isSentOrItsSubfolder(folder) || folderId === FOLDERS.SENT))
 				return p.type === ParticipantRole.TO; // sent
 			if (isSearchModule) return p.type === ParticipantRole.FROM; // search module
 			return true; // keep all

--- a/src/views/app/folder-panel/parts/participants-name.tsx
+++ b/src/views/app/folder-panel/parts/participants-name.tsx
@@ -7,11 +7,11 @@ import React, { useMemo } from 'react';
 
 import { Padding, Row, Text, Tooltip } from '@zextras/carbonio-design-system';
 import { t, useUserAccount } from '@zextras/carbonio-shell-ui';
-import { FOLDERS, ParticipantRole } from '@zextras/carbonio-ui-commons';
+import { FOLDERS, getFolder, ParticipantRole } from '@zextras/carbonio-ui-commons';
 import { findIndex, reduce, trimStart, uniqBy } from 'lodash';
 
 import { participantToString } from 'commons/utils';
-import { getFolderIdParts } from 'helpers/folders';
+import { getFolderIdParts, isSentSubfolder } from 'helpers/folders';
 import { isConversation } from 'helpers/messages';
 import { getConversationMessages } from 'store/emails/store';
 import {
@@ -43,15 +43,22 @@ export const ParticipantsName = ({
 
 	const parent = isConversation(item) ? getConversationMessages(item.id)[0].parent : item.parent;
 
+	const folder = getFolder(parent);
 	const folderId = getFolderIdParts(parent).id;
 	const participantsWithoutReplyTo = removeReplyToParticipants(item.participants);
 
 	const participantsString = useMemo(() => {
 		const participants = participantsWithoutReplyTo.filter((p) => {
 			if (isConversation(item)) return true;
-			if (folderId !== FOLDERS.SENT && folderId !== FOLDERS.DRAFTS && !isSearchModule)
+			if (
+				folderId !== FOLDERS.SENT &&
+				folderId !== FOLDERS.DRAFTS &&
+				!isSearchModule &&
+				!isSentSubfolder(folder)
+			)
 				return p.type === ParticipantRole.FROM; // Not sent or drafts
-			if (folderId === FOLDERS.SENT && !isSearchModule) return p.type === ParticipantRole.TO; // sent
+			if (!isSearchModule && (isSentSubfolder(folder) || folderId === FOLDERS.SENT))
+				return p.type === ParticipantRole.TO; // sent
 			if (isSearchModule) return p.type === ParticipantRole.FROM; // search module
 			return true; // keep all
 		});
@@ -68,7 +75,7 @@ export const ParticipantsName = ({
 			(acc, part) => trimStart(`${acc}, ${participantToString(part, [account])}`, ', '),
 			''
 		);
-	}, [account, folderId, isSearchModule, item, participantsWithoutReplyTo]);
+	}, [account, folder, folderId, isSearchModule, item, participantsWithoutReplyTo]);
 
 	return (
 		<Row wrap="nowrap" takeAvailableSpace mainAlignment="flex-start">

--- a/src/views/app/folder-panel/parts/tests/participants-name.test.tsx
+++ b/src/views/app/folder-panel/parts/tests/participants-name.test.tsx
@@ -8,9 +8,10 @@ import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
 import { useUserAccount } from '@zextras/carbonio-shell-ui';
-import { FOLDERS, ParticipantRole } from '@zextras/carbonio-ui-commons';
+import { FOLDERS, ParticipantRole, useFolderStore } from '@zextras/carbonio-ui-commons';
 
 import { setupTest } from '@test-setup';
+import { generateFolder } from '@test-utils/folders/folders-generator';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { populateConversationInEmailStore } from 'tests/generators/generateConversation';
 import { generateMessage, populateMessagesInEmailStore } from 'tests/generators/generateMessage';
@@ -41,7 +42,8 @@ describe('ParticipantsName component', () => {
 				messageGeneratorParams: [
 					{
 						id: '1',
-						from: { address: 'recipient@example.com', type: ParticipantRole.TO },
+						from: { address: 'me@example.com', type: ParticipantRole.FROM },
+						to: [{ address: 'recipient@example.com', type: ParticipantRole.TO }],
 						folderId: FOLDERS.SENT
 					}
 				]
@@ -54,15 +56,20 @@ describe('ParticipantsName component', () => {
 		);
 	});
 
-	it('renders participants string for sent folder', async () => {
+	it('renders participants string for subfolder of sent folder', async () => {
+		const subFolderId = '500';
 		populateFoldersStore();
+		const subFolder = generateFolder({ id: subFolderId, name: 'Sent Subfolder' });
+		useFolderStore.getState().updateFolder(FOLDERS.SENT, { children: [subFolder] });
+
 		const message = await waitFor(() =>
 			populateMessagesInEmailStore({
 				messageGeneratorParams: [
 					{
 						id: '1',
-						from: { address: 'recipient@example.com', type: ParticipantRole.TO },
-						folderId: FOLDERS.SENT
+						from: { address: 'me@example.com', type: ParticipantRole.FROM },
+						to: [{ address: 'recipient@example.com', type: ParticipantRole.TO }],
+						folderId: subFolderId // subfolder of sent
 					}
 				]
 			})

--- a/src/views/app/folder-panel/parts/tests/participants-name.test.tsx
+++ b/src/views/app/folder-panel/parts/tests/participants-name.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
 import { useUserAccount } from '@zextras/carbonio-shell-ui';
-import { FOLDERS, ParticipantRole, useFolderStore } from '@zextras/carbonio-ui-commons';
+import { Folder, FOLDERS, ParticipantRole, useFolderStore } from '@zextras/carbonio-ui-commons';
 
 import { setupTest } from '@test-setup';
 import { generateFolder } from '@test-utils/folders/folders-generator';
@@ -58,9 +58,20 @@ describe('ParticipantsName component', () => {
 
 	it('renders participants string for subfolder of sent folder', async () => {
 		const subFolderId = '500';
+		const subFolder = generateFolder({
+			id: subFolderId,
+			name: 'Sent Subfolder',
+			l: FOLDERS.SENT,
+			parent: FOLDERS.SENT,
+			absFolderPath: '/Sent/Sent Subfolder'
+		} satisfies Partial<Folder>);
 		populateFoldersStore();
-		const subFolder = generateFolder({ id: subFolderId, name: 'Sent Subfolder' });
+
 		useFolderStore.getState().updateFolder(FOLDERS.SENT, { children: [subFolder] });
+		useFolderStore.setState((state) => ({
+			...state,
+			folders: { ...state.folders, [subFolderId]: subFolder }
+		}));
 
 		const message = await waitFor(() =>
 			populateMessagesInEmailStore({


### PR DESCRIPTION
This PR fixes a regression where emails in subfolders of the _Sent_ folder were not displaying recipient information in the message view. The fix ensures that subfolders of Sent behave the same as the _Sent_ folder itself by showing TO participants instead of FROM participants.

Added a new helper function `isSentSubfolder()` to identify _Sent_ subfolders
Modified the participants filtering logic to handle _Sent_ subfolders
Updated tests to verify the fix and improve test data accuracy

Refs: CO-2520