### PR TITLE
fix: [CO-2516] Update the status of the conversations after 'mark all as read' action on the folder

### DIFF
--- a/src/normalizations/normalize-conversation.ts
+++ b/src/normalizations/normalize-conversation.ts
@@ -58,10 +58,11 @@ export const normalizeConversations = (
 	map(soapConversations, (conv) => mapToNormalizedConversation({ conversation: conv }));
 
 function calculateReadFlag(conversation: SoapPartialConversation): boolean | undefined {
-	if (conversation.f) return !/u/.test(conversation.f);
+	if (!isNil(conversation.f)) return !/u/.test(conversation.f);
 	if (conversation.u) return conversation.u <= 0;
 	return undefined;
 }
+
 const mapToNormalizedPartialConversation = ({
 	conversation
 }: NormalizePartialConversationProps): NormalizedPartialConversation => {
@@ -76,8 +77,8 @@ const mapToNormalizedPartialConversation = ({
 			subject: conversation.su,
 			fragment: conversation.fr,
 			read: calculateReadFlag(conversation),
-			hasAttachment: conversation.f ? /a/.test(conversation.f) : undefined,
-			flagged: conversation.f ? /f/.test(conversation.f) : undefined,
+			hasAttachment: !isNil(conversation.f) ? /a/.test(conversation.f) : undefined,
+			flagged: !isNil(conversation.f) ? /f/.test(conversation.f) : undefined,
 			urgent: !isNil(conversation.f) ? /!/.test(conversation.f) : undefined,
 			// Number of (nondeleted) messages. messages in trash or spam are in the count
 			messagesInConversation: conversation.n

--- a/src/normalizations/tests/normalize-conversation.test.ts
+++ b/src/normalizations/tests/normalize-conversation.test.ts
@@ -233,6 +233,7 @@ describe('Normalize partial conversation', () => {
 			messagesInConversation: 2
 		});
 	});
+
 	it('should omit fields when not defined', () => {
 		const partialConversation = {
 			id: '123'
@@ -241,5 +242,36 @@ describe('Normalize partial conversation', () => {
 		expect(result).toEqual({
 			id: '123'
 		});
+	});
+
+	it('returns normalized conversation with the correct flags value if the f field is empty', () => {
+		const msg1 = generateSoapConversationMessage('msg1', '123');
+		const msg2 = generateSoapConversationMessage('msg2', '456');
+		const partialConversation = {
+			id: '123',
+			n: 2,
+			u: 1,
+			f: '',
+			t: '1,2,3',
+			tn: 'tag1,tag2,tag3',
+			d: 123,
+			m: [msg1, msg2],
+			e: [
+				{ a: 'user1@example.com', t: ParticipantRole.FROM, p: '' },
+				{ a: 'user2@example.com', t: ParticipantRole.TO, p: '' }
+			],
+			su: 'Subject',
+			fr: 'fragment'
+		};
+
+		const result = normalizePartialConversations([partialConversation])[0];
+		expect(result).toEqual(
+			expect.objectContaining({
+				read: true,
+				hasAttachment: false,
+				flagged: false,
+				urgent: false
+			})
+		);
 	});
 });


### PR DESCRIPTION
## Overview
This pull request fixes a bug in conversation normalization where the f field was being checked with truthiness instead of null/undefined checks, causing issues when the field is an empty string. The fix ensures proper flag calculation for conversations after "mark all as read" actions on folders.

Updated flag checking logic to use isNil instead of truthiness checks
Added comprehensive test coverage for empty string f field scenarios

Refs: CO-2516