### PR TITLE
fix: [CO-2527]  add fallback logic for invalid sorting and filtering preferences

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -520,10 +520,6 @@ export const EDIT_VIEW_CLOSING_REASONS = {
 } as const;
 
 export const SORTING_OPTIONS = {
-	// unread: { label: 'unread', value: 'read' },
-	// important: { label: 'important', value: 'priority' },
-	// flagged: { label: 'flagged', value: 'flag' },
-	// attachment: { label: 'attachment', value: 'attach' },
 	from: { label: 'from', value: 'name' },
 	to: { label: 'to', value: 'rcpt' },
 	date: { label: 'date', value: 'date' },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -520,15 +520,22 @@ export const EDIT_VIEW_CLOSING_REASONS = {
 } as const;
 
 export const SORTING_OPTIONS = {
-	unread: { label: 'unread', value: 'read' },
-	important: { label: 'important', value: 'priority' },
-	flagged: { label: 'flagged', value: 'flag' },
-	attachment: { label: 'attachment', value: 'attach' },
+	// unread: { label: 'unread', value: 'read' },
+	// important: { label: 'important', value: 'priority' },
+	// flagged: { label: 'flagged', value: 'flag' },
+	// attachment: { label: 'attachment', value: 'attach' },
 	from: { label: 'from', value: 'name' },
 	to: { label: 'to', value: 'rcpt' },
 	date: { label: 'date', value: 'date' },
 	subject: { label: 'subject', value: 'subj' },
 	size: { label: 'size', value: 'size' }
+} as const;
+
+export const FILTER_OPTIONS = {
+	unread: { label: 'unread', value: 'read' },
+	important: { label: 'important', value: 'priority' },
+	flagged: { label: 'flagged', value: 'flag' },
+	attachment: { label: 'attachment', value: 'attach' }
 } as const;
 
 export const SORTING_DIRECTION = {

--- a/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
@@ -18,13 +18,18 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { capitalize, noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { SORT_ICONS, SORTING_DIRECTION, SORTING_OPTIONS } from '../../../../constants';
+import {
+	FILTER_OPTIONS,
+	SORT_ICONS,
+	SORTING_DIRECTION,
+	SORTING_OPTIONS
+} from '../../../../constants';
 import {
 	parseMessageSortingOptions,
 	updateSortAndFilterSettings
 } from '../../../../helpers/sorting';
 
-type SortingOption = {
+type Option = {
 	value: string;
 	label: string;
 };
@@ -47,7 +52,7 @@ const useListHeaderDropdownItems = ({ folderId }: { folderId: string }): Dropdow
 		[folderId, prefSortOrder]
 	);
 
-	const sortingOptions: SortingOption[] = useMemo(
+	const sortingOptions: Option[] = useMemo(
 		() => [
 			SORTING_OPTIONS.date,
 			SORTING_OPTIONS.subject,
@@ -56,12 +61,12 @@ const useListHeaderDropdownItems = ({ folderId }: { folderId: string }): Dropdow
 		[folderId]
 	);
 
-	const filteringOptions: SortingOption[] = useMemo(
+	const filteringOptions: Option[] = useMemo(
 		() => [
-			SORTING_OPTIONS.unread,
-			SORTING_OPTIONS.important,
-			SORTING_OPTIONS.flagged,
-			SORTING_OPTIONS.attachment
+			FILTER_OPTIONS.unread,
+			FILTER_OPTIONS.important,
+			FILTER_OPTIONS.flagged,
+			FILTER_OPTIONS.attachment
 		],
 		[]
 	);

--- a/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
@@ -47,7 +47,7 @@ export const SortAndFilterHeaderComponent = ({
 		[prefs?.zimbraPrefSortOrder]
 	);
 
-	const { sortType, filterType } = useMemo(
+	const { sortType: rawSortType, filterType: rawFilterType } = useMemo(
 		() => parseMessageSortingOptions(folderId, prefSortOrder),
 		[folderId, prefSortOrder]
 	);
@@ -58,6 +58,22 @@ export const SortAndFilterHeaderComponent = ({
 			filter: undefined
 		}),
 		[]
+	);
+
+	const sortType = useMemo(
+		() =>
+			Object.values(SORTING_OPTIONS).some((opt) => opt.value === rawSortType)
+				? rawSortType
+				: defaultState.type,
+		[rawSortType, defaultState.type]
+	);
+
+	const filterType = useMemo(
+		() =>
+			rawFilterType && Object.values(SORTING_OPTIONS).some((opt) => opt.value === rawFilterType)
+				? rawFilterType
+				: defaultState.filter,
+		[rawFilterType, defaultState.filter]
 	);
 
 	const resetToDefaultState = useCallback(() => {

--- a/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
@@ -9,6 +9,7 @@ import {
 	Button,
 	Container,
 	Divider,
+	Icon,
 	Padding,
 	Row,
 	Text,
@@ -18,7 +19,7 @@ import { useUserSettings } from '@zextras/carbonio-shell-ui';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
-import { SORTING_DIRECTION, SORTING_OPTIONS } from '../../../../constants';
+import { SORTING_DIRECTION, SORTING_OPTIONS, FILTER_OPTIONS } from '../../../../constants';
 import {
 	parseMessageSortingOptions,
 	updateSortAndFilterSettings
@@ -29,10 +30,15 @@ const getTranslatedLabelFromValue = (
 	t: TFunction<'translation', undefined, 'translation'>
 ): string => {
 	if (!value) return '';
-	const option = Object.values(SORTING_OPTIONS).find((opt) => opt.value === value);
-	if (!option) return value;
-	return t(`sorting_dropdown.${option.label}`, option.label);
+	const sortOpt = Object.values(SORTING_OPTIONS).find((opt) => opt.value === value);
+	if (sortOpt) return t(`sorting_dropdown.${sortOpt.label}`, sortOpt.label);
+	const filterOpt = Object.values(FILTER_OPTIONS).find((opt) => opt.value === value);
+	if (filterOpt) return t(`sorting_dropdown.${filterOpt.label}`, filterOpt.label);
+	return value;
 };
+
+const isValid = (val: string | undefined, options: Record<string, { value: string }>): boolean =>
+	!!val && Object.values(options).some((opt) => opt.value === val);
 
 export const SortAndFilterHeaderComponent = ({
 	folderId
@@ -51,28 +57,24 @@ export const SortAndFilterHeaderComponent = ({
 		() => parseMessageSortingOptions(folderId, prefSortOrder),
 		[folderId, prefSortOrder]
 	);
+
 	const defaultState = useMemo(
 		() => ({
 			type: SORTING_OPTIONS.date.value,
 			direction: SORTING_DIRECTION.DESCENDING,
-			filter: undefined
+			filter: undefined as string | undefined
 		}),
 		[]
 	);
 
 	const sortType = useMemo(
-		() =>
-			Object.values(SORTING_OPTIONS).some((opt) => opt.value === rawSortType)
-				? rawSortType
-				: defaultState.type,
+		() => (isValid(rawSortType, SORTING_OPTIONS) ? (rawSortType as string) : defaultState.type),
 		[rawSortType, defaultState.type]
 	);
 
 	const filterType = useMemo(
 		() =>
-			rawFilterType && Object.values(SORTING_OPTIONS).some((opt) => opt.value === rawFilterType)
-				? rawFilterType
-				: defaultState.filter,
+			isValid(rawFilterType, FILTER_OPTIONS) ? (rawFilterType as string) : defaultState.filter,
 		[rawFilterType, defaultState.filter]
 	);
 
@@ -115,7 +117,7 @@ export const SortAndFilterHeaderComponent = ({
 		>
 			<Divider />
 			<Row padding={{ all: 'small' }}>
-				<Text size="medium" color="gray1">
+				<Text size="medium" color="gray1" overflow="ellipsis">
 					{`${currentFilterLabel}${currentSortLabel}`}
 				</Text>
 				<Padding right="medium" />
@@ -128,7 +130,7 @@ export const SortAndFilterHeaderComponent = ({
 						size="medium"
 						label={t('label.reset', 'Reset')}
 						onClick={resetToDefaultState}
-					/>
+					></Button>
 				</Tooltip>
 			</Row>
 		</Container>

--- a/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
@@ -9,7 +9,6 @@ import {
 	Button,
 	Container,
 	Divider,
-	Icon,
 	Padding,
 	Row,
 	Text,
@@ -68,13 +67,12 @@ export const SortAndFilterHeaderComponent = ({
 	);
 
 	const sortType = useMemo(
-		() => (isValid(rawSortType, SORTING_OPTIONS) ? (rawSortType as string) : defaultState.type),
+		() => (isValid(rawSortType, SORTING_OPTIONS) ? rawSortType : defaultState.type),
 		[rawSortType, defaultState.type]
 	);
 
 	const filterType = useMemo(
-		() =>
-			isValid(rawFilterType, FILTER_OPTIONS) ? (rawFilterType as string) : defaultState.filter,
+		() => (isValid(rawFilterType, FILTER_OPTIONS) ? rawFilterType : defaultState.filter),
 		[rawFilterType, defaultState.filter]
 	);
 

--- a/src/views/app/folder-panel/parts/tests/sort-and-filter-header.test.tsx
+++ b/src/views/app/folder-panel/parts/tests/sort-and-filter-header.test.tsx
@@ -9,7 +9,7 @@ import { useUserSettings } from '@zextras/carbonio-shell-ui';
 
 import { SortAndFilterHeaderComponent } from '../sort-and-filter-header-component';
 import { screen, setupTest } from '@test-setup';
-import { SORTING_DIRECTION, SORTING_OPTIONS } from 'constants/index';
+import { FILTER_OPTIONS, SORTING_DIRECTION, SORTING_OPTIONS } from 'constants/index';
 import { parseMessageSortingOptions, updateSortAndFilterSettings } from 'helpers/sorting';
 
 jest.mock('@zextras/carbonio-shell-ui', () => ({
@@ -43,7 +43,7 @@ describe('Sort and Filter Header Component', () => {
 	it('should render with modified state', () => {
 		(parseMessageSortingOptions as jest.Mock).mockReturnValue({
 			sortType: SORTING_OPTIONS.subject.value,
-			filterType: SORTING_OPTIONS.unread.value
+			filterType: FILTER_OPTIONS.unread.value
 		});
 		setupTest(<SortAndFilterHeaderComponent folderId={folderId} />);
 
@@ -55,7 +55,7 @@ describe('Sort and Filter Header Component', () => {
 	it('should call updateSortAndFilterSettings when Reset is clicked', async () => {
 		(parseMessageSortingOptions as jest.Mock).mockReturnValue({
 			sortType: SORTING_OPTIONS.subject.value,
-			filterType: SORTING_OPTIONS.unread.value
+			filterType: FILTER_OPTIONS.unread.value
 		});
 		const { user } = setupTest(<SortAndFilterHeaderComponent folderId={folderId} />);
 
@@ -70,5 +70,15 @@ describe('Sort and Filter Header Component', () => {
 				sortType: SORTING_OPTIONS.date.value
 			})
 		);
+	});
+
+	it('should not render when invalid legacy values are normalized to defaults', () => {
+		(parseMessageSortingOptions as jest.Mock).mockReturnValue({
+			sortType: 'legacy_sort',
+			filterType: 'legacy_filter'
+		});
+		setupTest(<SortAndFilterHeaderComponent folderId={folderId} />);
+
+		expect(screen.queryByTestId('sorting-options-container')).not.toBeInTheDocument();
 	});
 });

--- a/src/views/app/folder-panel/parts/tests/sort-and-filter-header.test.tsx
+++ b/src/views/app/folder-panel/parts/tests/sort-and-filter-header.test.tsx
@@ -9,6 +9,7 @@ import { useUserSettings } from '@zextras/carbonio-shell-ui';
 
 import { SortAndFilterHeaderComponent } from '../sort-and-filter-header-component';
 import { screen, setupTest } from '@test-setup';
+import { SORTING_DIRECTION, SORTING_OPTIONS } from 'constants/index';
 import { parseMessageSortingOptions, updateSortAndFilterSettings } from 'helpers/sorting';
 
 jest.mock('@zextras/carbonio-shell-ui', () => ({
@@ -19,9 +20,6 @@ jest.mock('helpers/sorting', () => ({
 	updateSortAndFilterSettings: jest.fn()
 }));
 
-jest.mock('@zextras/carbonio-shell-ui', () => ({
-	useUserSettings: jest.fn()
-}));
 describe('Sort and Filter Header Component', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -34,7 +32,7 @@ describe('Sort and Filter Header Component', () => {
 
 	it('should not render if state is default', () => {
 		(parseMessageSortingOptions as jest.Mock).mockReturnValue({
-			sortType: 'date',
+			sortType: SORTING_OPTIONS.date.value,
 			filterType: undefined
 		});
 		setupTest(<SortAndFilterHeaderComponent folderId={folderId} />);
@@ -44,8 +42,8 @@ describe('Sort and Filter Header Component', () => {
 
 	it('should render with modified state', () => {
 		(parseMessageSortingOptions as jest.Mock).mockReturnValue({
-			sortType: 'subject',
-			filterType: 'unread'
+			sortType: SORTING_OPTIONS.subject.value,
+			filterType: SORTING_OPTIONS.unread.value
 		});
 		setupTest(<SortAndFilterHeaderComponent folderId={folderId} />);
 
@@ -56,8 +54,8 @@ describe('Sort and Filter Header Component', () => {
 
 	it('should call updateSortAndFilterSettings when Reset is clicked', async () => {
 		(parseMessageSortingOptions as jest.Mock).mockReturnValue({
-			sortType: 'subject',
-			filterType: 'unread'
+			sortType: SORTING_OPTIONS.subject.value,
+			filterType: SORTING_OPTIONS.unread.value
 		});
 		const { user } = setupTest(<SortAndFilterHeaderComponent folderId={folderId} />);
 
@@ -66,10 +64,10 @@ describe('Sort and Filter Header Component', () => {
 		expect(updateSortAndFilterSettings).toHaveBeenCalledWith(
 			expect.objectContaining({
 				filter: undefined,
-				folderId: 'test-folder',
+				folderId,
 				prefSortOrder: '',
-				sortDirection: 'Desc',
-				sortType: 'date'
+				sortDirection: SORTING_DIRECTION.DESCENDING,
+				sortType: SORTING_OPTIONS.date.value
 			})
 		);
 	});


### PR DESCRIPTION
This PR implements fallback logic for Zimbra preferences by ensuring that invalid sorting and filtering options are replaced with default values when no valid preference is found.

- Added validation logic to check if parsed sorting options exist in the valid options list
- Updated test files to use constants instead of hardcoded strings for better maintainability
- Introduced fallback mechanism that defaults to valid options when invalid preferences are detected