### PR TITLE
fix: avoid UI crash when a component selector is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@types/webpack-env": "^1.18.1",
 				"@zextras/carbonio-design-system": "^11.0.0-devel.1",
 				"@zextras/carbonio-shell-ui": "12.0.0-devel.1756979172527",
-				"@zextras/carbonio-ui-commons": "2.0.0-devel.1",
+				"@zextras/carbonio-ui-commons": "2.0.0-devel.2",
 				"@zextras/carbonio-ui-preview": "3.3.0-devel.1",
 				"@zextras/carbonio-ui-soap-lib": "^1.0.2",
 				"autolinker": "^4.1.5",
@@ -5588,9 +5588,10 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-commons": {
-			"version": "2.0.0-devel.1",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-2.0.0-devel.1.tgz",
-			"integrity": "sha512-99Dp0C4tuAheFWao8W5t9SESreMFN+LCXDxANMA1mtXqdeOmn0KwIWhT/aHkGGDlEbR5LOUrdzLQ+hoFizXamw==",
+			"version": "2.0.0-devel.2",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-2.0.0-devel.2.tgz",
+			"integrity": "sha512-G6yNf95TZBQRu+hujsICKEksrkTHtFMQOstuqjYJ2kkS8lJ5aP+Vh9RwtiY/Hos3Aqh/oYzNswkwFdgeh1CjTg==",
+			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@mui/icons-material": "^5.15.12",
 				"@mui/material": "^5.15.12",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"@types/webpack-env": "^1.18.1",
 		"@zextras/carbonio-design-system": "^11.0.0-devel.1",
 		"@zextras/carbonio-shell-ui": "12.0.0-devel.1756979172527",
-		"@zextras/carbonio-ui-commons": "2.0.0-devel.1",
+		"@zextras/carbonio-ui-commons": "2.0.0-devel.2",
 		"@zextras/carbonio-ui-preview": "3.3.0-devel.1",
 		"@zextras/carbonio-ui-soap-lib": "^1.0.2",
 		"autolinker": "^4.1.5",


### PR DESCRIPTION
Update `carbonio-ui-commons` dependency to avoid the crash caused by the `CustomListItem` component

Refs: CO-2537