### PR TITLE
fix: [CO-2312] use full name in sent mails instead of first name

### DIFF
--- a/src/views/app/detail-panel/edit/parts/recipients-row.tsx
+++ b/src/views/app/detail-panel/edit/parts/recipients-row.tsx
@@ -13,8 +13,29 @@ import {
 } from '@zextras/carbonio-ui-commons';
 import { map, some } from 'lodash';
 
-import { Participant } from '../../../../../types';
+import { Participant } from 'types';
 import { isValidEmail } from 'views/search/parts/utils';
+
+/**
+ * Get the name for a contact based on available fields
+ * @param contact - The contact input item
+ * @returns The contact name or undefined
+ */
+const getContactName = (contact: ContactInputItem): string | undefined => {
+	if (contact.value.type !== CONTACT_TYPES.CONTACT) {
+		return undefined;
+	}
+
+	if (contact.value.fullName) {
+		return contact.value.fullName;
+	}
+
+	if (contact.value.firstName && contact.value.lastName) {
+		return `${contact.value.firstName} ${contact.value.lastName}`;
+	}
+
+	return contact.value.firstName;
+};
 
 export type RecipientsRowProps = {
 	type: ParticipantRoleType;
@@ -58,13 +79,7 @@ export const RecipientsRow: FC<RecipientsRowProps> = ({
 					(recipient) => recipient.address === contact.value.email
 				);
 				const isGroup = contact.value.type === CONTACT_TYPES.DISTRIBUTION_LIST;
-				const contactName =
-					contact.value.type === CONTACT_TYPES.CONTACT
-						? contact.value.fullName ||
-							(contact.value.firstName && contact.value.lastName
-								? `${contact.value.firstName} ${contact.value.lastName}`
-								: contact.value.firstName)
-						: undefined;
+				const contactName = getContactName(contact);
 				return (
 					alreadyExists || {
 						id: contact.id,

--- a/src/views/app/detail-panel/edit/parts/recipients-row.tsx
+++ b/src/views/app/detail-panel/edit/parts/recipients-row.tsx
@@ -58,13 +58,20 @@ export const RecipientsRow: FC<RecipientsRowProps> = ({
 					(recipient) => recipient.address === contact.value.email
 				);
 				const isGroup = contact.value.type === CONTACT_TYPES.DISTRIBUTION_LIST;
+				const contactName =
+					contact.value.type === CONTACT_TYPES.CONTACT
+						? contact.value.fullName ||
+							(contact.value.firstName && contact.value.lastName
+								? `${contact.value.firstName} ${contact.value.lastName}`
+								: contact.value.firstName)
+						: undefined;
 				return (
 					alreadyExists || {
 						id: contact.id,
 						type,
 						address: contact.value.email,
 						isGroup,
-						name: contact.value.type === CONTACT_TYPES.CONTACT ? contact.value.firstName : undefined
+						name: contactName
 					}
 				);
 			});

--- a/src/views/app/detail-panel/edit/parts/recipients-row.tsx
+++ b/src/views/app/detail-panel/edit/parts/recipients-row.tsx
@@ -79,14 +79,13 @@ export const RecipientsRow: FC<RecipientsRowProps> = ({
 					(recipient) => recipient.address === contact.value.email
 				);
 				const isGroup = contact.value.type === CONTACT_TYPES.DISTRIBUTION_LIST;
-				const contactName = getContactName(contact);
 				return (
 					alreadyExists || {
 						id: contact.id,
 						type,
 						address: contact.value.email,
 						isGroup,
-						name: contactName
+						name: getContactName(contact)
 					}
 				);
 			});

--- a/src/views/app/detail-panel/edit/parts/tests/recipients-row.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/recipients-row.test.tsx
@@ -152,6 +152,178 @@ describe('recipients-row', () => {
 				)
 			).toBeInTheDocument();
 		});
+
+		describe('contact name handling', () => {
+			it('should use fullName when available for contact', async () => {
+				const valueToAdd = {
+					...generateMockContactInputItem(),
+					value: {
+						id: '1',
+						email: 'test@test.com',
+						type: CONTACT_TYPES.CONTACT,
+						firstName: 'John',
+						lastName: 'Doe',
+						fullName: 'John Doe'
+					}
+				};
+				mockContactInput({ valueToAdd });
+				const mockOnChange = jest.fn();
+
+				const { user } = setupTest(
+					<RecipientsRow
+						dataTestid={'mockedContactInput'}
+						type="f"
+						label="label"
+						recipients={[]}
+						onRecipientsChange={mockOnChange}
+					></RecipientsRow>
+				);
+				await triggerOnAdd(user);
+
+				expect(mockOnChange).toHaveBeenCalledWith([expect.objectContaining({ name: 'John Doe' })]);
+			});
+
+			it('should fallback to firstName + lastName when fullName is not available', async () => {
+				const valueToAdd = {
+					...generateMockContactInputItem(),
+					value: {
+						id: '1',
+						email: 'test@test.com',
+						type: CONTACT_TYPES.CONTACT,
+						firstName: 'John',
+						lastName: 'Doe'
+					}
+				};
+				mockContactInput({ valueToAdd });
+				const mockOnChange = jest.fn();
+
+				const { user } = setupTest(
+					<RecipientsRow
+						dataTestid={'mockedContactInput'}
+						type="f"
+						label="label"
+						recipients={[]}
+						onRecipientsChange={mockOnChange}
+					></RecipientsRow>
+				);
+				await triggerOnAdd(user);
+
+				expect(mockOnChange).toHaveBeenCalledWith([expect.objectContaining({ name: 'John Doe' })]);
+			});
+
+			it('should fallback to firstName when only firstName is available', async () => {
+				const valueToAdd = {
+					...generateMockContactInputItem(),
+					value: {
+						id: '1',
+						email: 'test@test.com',
+						type: CONTACT_TYPES.CONTACT,
+						firstName: 'John'
+					}
+				};
+				mockContactInput({ valueToAdd });
+				const mockOnChange = jest.fn();
+
+				const { user } = setupTest(
+					<RecipientsRow
+						dataTestid={'mockedContactInput'}
+						type="f"
+						label="label"
+						recipients={[]}
+						onRecipientsChange={mockOnChange}
+					></RecipientsRow>
+				);
+				await triggerOnAdd(user);
+
+				expect(mockOnChange).toHaveBeenCalledWith([expect.objectContaining({ name: 'John' })]);
+			});
+
+			it('should use fullName even when firstName and lastName are also present', async () => {
+				const valueToAdd = {
+					...generateMockContactInputItem(),
+					value: {
+						id: '1',
+						email: 'dummy.user@gmail.com',
+						type: CONTACT_TYPES.CONTACT,
+						firstName: 'dummy',
+						lastName: 'user',
+						fullName: 'dummy user'
+					}
+				};
+				mockContactInput({ valueToAdd });
+				const mockOnChange = jest.fn();
+
+				const { user } = setupTest(
+					<RecipientsRow
+						dataTestid={'mockedContactInput'}
+						type="f"
+						label="label"
+						recipients={[]}
+						onRecipientsChange={mockOnChange}
+					></RecipientsRow>
+				);
+				await triggerOnAdd(user);
+
+				expect(mockOnChange).toHaveBeenCalledWith([
+					expect.objectContaining({ name: 'dummy user' })
+				]);
+			});
+
+			it('should set name to undefined for distribution lists', async () => {
+				const valueToAdd = {
+					...generateMockContactInputItem(),
+					value: {
+						id: '1',
+						email: 'list@test.com',
+						type: CONTACT_TYPES.DISTRIBUTION_LIST,
+						firstName: 'List',
+						lastName: 'Name',
+						fullName: 'List Name'
+					}
+				};
+				mockContactInput({ valueToAdd });
+				const mockOnChange = jest.fn();
+
+				const { user } = setupTest(
+					<RecipientsRow
+						dataTestid={'mockedContactInput'}
+						type="f"
+						label="label"
+						recipients={[]}
+						onRecipientsChange={mockOnChange}
+					></RecipientsRow>
+				);
+				await triggerOnAdd(user);
+
+				expect(mockOnChange).toHaveBeenCalledWith([expect.objectContaining({ name: undefined })]);
+			});
+
+			it('should set name to undefined when no name fields are available', async () => {
+				const valueToAdd = {
+					...generateMockContactInputItem(),
+					value: {
+						id: '1',
+						email: 'test@test.com',
+						type: CONTACT_TYPES.CONTACT
+					}
+				};
+				mockContactInput({ valueToAdd });
+				const mockOnChange = jest.fn();
+
+				const { user } = setupTest(
+					<RecipientsRow
+						dataTestid={'mockedContactInput'}
+						type="f"
+						label="label"
+						recipients={[]}
+						onRecipientsChange={mockOnChange}
+					></RecipientsRow>
+				);
+				await triggerOnAdd(user);
+
+				expect(mockOnChange).toHaveBeenCalledWith([expect.objectContaining({ name: undefined })]);
+			});
+		});
 	});
 
 	describe('when ContactInput is available', () => {

--- a/src/views/settings/tests/signature-settings.test.tsx
+++ b/src/views/settings/tests/signature-settings.test.tsx
@@ -98,7 +98,6 @@ describe('Signature settings', () => {
 		it.todo('should display an error if the request for the list of signatures fails');
 
 		it('should render the list of signatures', async () => {
-			// const signatures: Array<SignItemType> = times(12, () => buildSignature({}));
 			const signatures: Array<SignItemType> = times(12, (i) =>
 				buildSignature({ label: `Signature ${i}` })
 			);

--- a/src/views/settings/tests/signature-settings.test.tsx
+++ b/src/views/settings/tests/signature-settings.test.tsx
@@ -98,7 +98,10 @@ describe('Signature settings', () => {
 		it.todo('should display an error if the request for the list of signatures fails');
 
 		it('should render the list of signatures', async () => {
-			const signatures: Array<SignItemType> = times(12, () => buildSignature({}));
+			// const signatures: Array<SignItemType> = times(12, () => buildSignature({}));
+			const signatures: Array<SignItemType> = times(12, (i) =>
+				buildSignature({ label: `Signature ${i}` })
+			);
 			handleGetSignaturesRequest(signatures);
 			setupTest(<SettingsViewMock preloadedSignatures={signatures} />);
 			await screen.findByText(signatures[0].label, undefined, { timeout: FIND_TIMEOUT });


### PR DESCRIPTION
This PR addresses a bug where viewing sent items, only the first name of contacts was being displayed in the recipients field. This was caused by the `RecipientsRow` component only using `contact.value.firstName` when setting the participant name. Which in turn causes the composer send wrong data to `SavedraftRequest`. That in turn make the APIs return participant infomation with just their firstname as `fullName`. 

**Solution**

- Updated the name assignment logic in recipients-row.tsx to use a proper fallback chain:
    - First priority: Use fullName if available
    - Second priority: Combine firstName + lastName if both exist
    - Final fallback: Use only firstName if nothing else is available

This ensures that the full name is displayed when available, providing better user experience and more complete contact information.
