### PR TITLE
fix: [CO-2724] Browser makes failed network requests to CID URLs

### DIFF
--- a/src/commons/get-quoted-text-util.ts
+++ b/src/commons/get-quoted-text-util.ts
@@ -283,10 +283,7 @@ export function getOriginalHtmlContent(text: string): string {
 		return '';
 	}
 
-	let processedText = text;
-	while (SCRIPT_REGEX.test(processedText)) {
-		processedText = processedText.replace(SCRIPT_REGEX, '');
-	}
+	const processedText = text.replace(SCRIPT_REGEX, '');
 
 	const parser = new DOMParser();
 	const htmlDoc = parser.parseFromString(processedText, 'text/html');
@@ -296,7 +293,7 @@ export function getOriginalHtmlContent(text: string): string {
 	flatten(htmlNode, nodeList);
 	const { done } = processNodeList(nodeList);
 
-	return done && htmlNode.textContent ? htmlNode.innerHTML : text;
+	return done && htmlNode.textContent ? htmlNode.innerHTML : processedText;
 }
 
 function getTextFromBlock(block: Array<string> | undefined): string | null {

--- a/src/commons/get-quoted-text-util.ts
+++ b/src/commons/get-quoted-text-util.ts
@@ -282,11 +282,16 @@ export function getOriginalHtmlContent(text: string): string {
 	if (!text) {
 		return '';
 	}
-	const htmlNode = document.createElement('div');
-	htmlNode.innerHTML = text;
-	while (SCRIPT_REGEX.test(text)) {
-		text = text.replace(SCRIPT_REGEX, '');
+
+	let processedText = text;
+	while (SCRIPT_REGEX.test(processedText)) {
+		processedText = processedText.replace(SCRIPT_REGEX, '');
 	}
+
+	const parser = new DOMParser();
+	const htmlDoc = parser.parseFromString(processedText, 'text/html');
+	const htmlNode = htmlDoc.body;
+
 	const nodeList: Array<ChildNode> = [];
 	flatten(htmlNode, nodeList);
 	const { done } = processNodeList(nodeList);

--- a/src/commons/tests/get-quoted-text-utils.test.tsx
+++ b/src/commons/tests/get-quoted-text-utils.test.tsx
@@ -67,6 +67,72 @@ describe('Get Quoted Test Utils', () => {
 			expect(getOriginalHtmlContent(originalHTML)).toBe('<div>Test</div>');
 		});
 
+		it('should remove single script tag', () => {
+			const originalHTML = '<div>Test</div><script>alert("xss")</script><p>Content</p>';
+			const result = getOriginalHtmlContent(originalHTML);
+			expect(result).not.toContain('<script>');
+			expect(result).not.toContain('alert');
+			expect(result).toContain('Test');
+			expect(result).toContain('Content');
+		});
+
+		it('should remove multiple script tags', () => {
+			const originalHTML =
+				'<div>Test</div><script>alert("xss1")</script><p>Content</p><script>alert("xss2")</script>';
+			const result = getOriginalHtmlContent(originalHTML);
+			expect(result).not.toContain('<script>');
+			expect(result).not.toContain('alert');
+			expect(result).toContain('Test');
+			expect(result).toContain('Content');
+		});
+
+		it('should remove script tags with attributes', () => {
+			const originalHTML =
+				'<div>Test</div><script type="text/javascript" src="evil.js">alert("xss")</script>';
+			const result = getOriginalHtmlContent(originalHTML);
+			expect(result).not.toContain('<script');
+			expect(result).not.toContain('alert');
+			expect(result).toContain('Test');
+		});
+
+		it('should remove script tags with multiline content', () => {
+			const originalHTML = `<div>Test</div><script>
+				function malicious() {
+					alert("xss");
+				}
+			</script><p>Content</p>`;
+			const result = getOriginalHtmlContent(originalHTML);
+			expect(result).not.toContain('<script>');
+			expect(result).not.toContain('malicious');
+			expect(result).toContain('Test');
+			expect(result).toContain('Content');
+		});
+
+		it('should remove nested script-like content', () => {
+			const originalHTML = '<div>Test</div><script>var x = "<div>fake</div>";</script><p>Real</p>';
+			const result = getOriginalHtmlContent(originalHTML);
+			expect(result).not.toContain('<script>');
+			expect(result).not.toContain('var x');
+			expect(result).toContain('Test');
+			expect(result).toContain('Real');
+		});
+
+		it('should handle case-insensitive script tags', () => {
+			const originalHTML = '<div>Test</div><SCRIPT>alert("xss")</SCRIPT><p>Content</p>';
+			const result = getOriginalHtmlContent(originalHTML);
+			expect(result).not.toContain('SCRIPT');
+			expect(result).not.toContain('alert');
+			expect(result).toContain('Test');
+		});
+
+		it('should handle empty script tags', () => {
+			const originalHTML = '<div>Test</div><script></script><p>Content</p>';
+			const result = getOriginalHtmlContent(originalHTML);
+			expect(result).not.toContain('<script>');
+			expect(result).toContain('Test');
+			expect(result).toContain('Content');
+		});
+
 		it.each([
 			'Forwarded Message',
 			'Weitergeleitete Nachricht',


### PR DESCRIPTION
This PR fixes an issue where the browser was making failed network requests to CID URLs by preventing automatic resource loading during HTML parsing. The key change is switching from `document.createElement` to `DOMParser.parseFromString`, which creates an inert document that doesn't trigger image or resource loading.

### Key Changes
- Replaced `document.createElement('div')` with `DOMParser.parseFromString()` to prevent automatic resource loading
- Improved script removal logic by using a separate `processedText` variable instead of modifying `text` in-place

### Impact
- User Experience: Eliminates console errors and failed network requests
- Performance: Reduces unnecessary network overhead and real Browser DOM based processing of content
