### PR TITLE
fix: disable keyboard shortcuts when file preview is open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "carbonio-mails-ui",
 			"version": "1.27.0",
+			"hasInstallScript": true,
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"build": "sdk build",
 		"deploy": "sdk deploy",
+		"install": "sdk install",
 		"start": "sdk watch",
 		"type-check": "tsc --noEmit",
 		"type-check:watch": "npm run type-check -- --watch",

--- a/src/__test__/mocks/carbonio-ui-preview/carbonio-ui-preview.ts
+++ b/src/__test__/mocks/carbonio-ui-preview/carbonio-ui-preview.ts
@@ -9,7 +9,9 @@ export const previewContextMock = {
 	createPreview: jest.fn(),
 	initPreview: jest.fn(),
 	openPreview: jest.fn(),
-	emptyPreview: jest.fn()
+	emptyPreview: jest.fn(),
+	currentIndex: -1,
+	previews: []
 };
 
 export const PreviewsManagerContext = React.createContext(previewContextMock);

--- a/src/hooks/tests/use-is-file-preview-open.test.tsx
+++ b/src/hooks/tests/use-is-file-preview-open.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { previewContextMock } from '../../__test__/mocks/carbonio-ui-preview';
+import { setupHook } from '../../__test__/test-setup';
+import { useIsFilePreviewOpen } from '../use-is-file-preview-open';
+
+const mockPreviewCurrentIndex = (index: number): void => {
+	previewContextMock.currentIndex = index;
+};
+
+describe('useIsFilePreviewOpen', () => {
+	it('returns true when there is a preview open >= 0', () => {
+		mockPreviewCurrentIndex(0);
+
+		const { result } = setupHook(useIsFilePreviewOpen);
+
+		expect(result.current).toBe(true);
+	});
+
+	it('returns false when there is no preview open < 0', () => {
+		mockPreviewCurrentIndex(-1);
+
+		const { result } = setupHook(useIsFilePreviewOpen);
+
+		expect(result.current).toBe(false);
+	});
+});

--- a/src/hooks/use-is-file-preview-open.ts
+++ b/src/hooks/use-is-file-preview-open.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useContext } from 'react';
+
+import { PreviewsManagerContext } from '@zextras/carbonio-ui-preview';
+
+export const useIsFilePreviewOpen = (): boolean => {
+	const previewContext = useContext(PreviewsManagerContext);
+	return previewContext.currentIndex >= 0;
+};

--- a/src/views/app/folder-panel/conversations/conversation-shortcuts-register.tsx
+++ b/src/views/app/folder-panel/conversations/conversation-shortcuts-register.tsx
@@ -5,6 +5,7 @@
  */
 import { useCallback, useEffect } from 'react';
 
+import { useIsFilePreviewOpen } from '../../../../hooks/use-is-file-preview-open';
 import { useKeyboardShortcutsForConv } from 'hooks/use-keyboard-shortcuts-for-conv';
 import { hasModalOverlay, isInputContext } from 'hooks/utils';
 
@@ -21,6 +22,7 @@ export const ConversationShortcutsRegister = ({
 	conversationIds,
 	folderId
 }: ConversationShortcutsRegisterProps): null => {
+	const isFilePreviewOpen = useIsFilePreviewOpen();
 	const keyboardActions = useKeyboardShortcutsForConv({
 		conversationIds,
 		folderId
@@ -30,15 +32,18 @@ export const ConversationShortcutsRegister = ({
 		(event: KeyboardEvent): void => {
 			const isInputField = isInputContext(event.target);
 
-			// Ignore shortcuts when typing in form fields
-			// or when a modal overlay is present
-			if (isInputField || hasModalOverlay()) {
+			/*
+			 * Ignore shortcuts when typing in form fields
+			 * or when a modal overlay is present
+			 * or when file preview is open
+			 */
+			if (isInputField || hasModalOverlay() || isFilePreviewOpen) {
 				return;
 			}
 
 			keyboardActions(event);
 		},
-		[keyboardActions]
+		[isFilePreviewOpen, keyboardActions]
 	);
 
 	useEffect(() => {

--- a/src/views/app/folder-panel/messages/message-shortcuts-register.tsx
+++ b/src/views/app/folder-panel/messages/message-shortcuts-register.tsx
@@ -26,7 +26,6 @@ export const MessageShortcutsRegister = ({
 
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent): void => {
-			console.count('MessageShortcutsRegister handleKeyDown');
 			const isInputField = isInputContext(event.target);
 
 			/*

--- a/src/views/app/folder-panel/messages/message-shortcuts-register.tsx
+++ b/src/views/app/folder-panel/messages/message-shortcuts-register.tsx
@@ -5,6 +5,7 @@
  */
 import { useCallback, useEffect } from 'react';
 
+import { useIsFilePreviewOpen } from '../../../../hooks/use-is-file-preview-open';
 import { useKeyboardShortcutsForMsg } from 'hooks/use-keyboard-shortcuts-for-msg';
 import { hasModalOverlay, isInputContext } from 'hooks/utils';
 
@@ -17,23 +18,29 @@ export const MessageShortcutsRegister = ({
 	messageIds,
 	folderId
 }: MessageShortcutsRegisterProps): null => {
+	const isFilePreviewOpen = useIsFilePreviewOpen();
 	const keyboardActions = useKeyboardShortcutsForMsg({
 		messageIds,
 		folderId
 	});
+
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent): void => {
+			console.count('MessageShortcutsRegister handleKeyDown');
 			const isInputField = isInputContext(event.target);
 
-			// Ignore shortcuts when typing in form fields
-			// or when a modal overlay is present
-			if (isInputField || hasModalOverlay()) {
+			/*
+			 * Ignore shortcuts when typing in form fields
+			 * or when a modal overlay is present
+			 * or when file preview is open
+			 */
+			if (isInputField || hasModalOverlay() || isFilePreviewOpen) {
 				return;
 			}
 
 			keyboardActions(event);
 		},
-		[keyboardActions]
+		[isFilePreviewOpen, keyboardActions]
 	);
 	useEffect(() => {
 		document.addEventListener('keydown', handleKeyDown);

--- a/src/views/search/parts/search-panel-header.tsx
+++ b/src/views/search/parts/search-panel-header.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { FC, useCallback, useEffect, useMemo } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 
 import {
 	Button,
@@ -31,18 +31,6 @@ export const SearchPanelHeader: FC<{
 		() => item?.subject ?? t('label.no_subject_with_tags', '<No Subject>'),
 		[item?.subject]
 	);
-
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent): void => {
-			if (e.key === 'Escape') {
-				e.preventDefault();
-				e.stopPropagation();
-				closePanelCallback();
-			}
-		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, [closePanelCallback]);
 
 	return (
 		<>

--- a/src/views/search/test/search-view.test.tsx
+++ b/src/views/search/test/search-view.test.tsx
@@ -431,62 +431,6 @@ describe('SearchView', () => {
 			const conversation2 = getSoapConversation('2', { t: '' });
 			const conversation3 = getSoapConversation('3', { t: '' });
 
-			it('closes the conversation panel on Escape (window keydown)', async () => {
-				const addSpy = jest.spyOn(window, 'addEventListener');
-
-				const { queryChip } = setupSearchViewTest({ viewBy: 'conversation', query: 'hello' });
-				const mockUseQuery = jest.fn();
-				mockUseQuery.mockReturnValue([[queryChip], noop]);
-
-				const defaultConversation = getSoapConversation('123');
-				const message1 = generateSoapConversationMessage('100', '123');
-				const message2 = generateSoapConversationMessage('200', '123');
-				const conversation = { ...defaultConversation, n: 2, m: [message1, message2] };
-
-				createSoapAPIInterceptor<SearchRequest, SearchResponse>('Search', {
-					c: [conversation],
-					more: false
-				});
-				createSoapAPIInterceptor<SearchConvRequest, SearchConvResponse>('SearchConv', {
-					m: [message1, message2],
-					more: false,
-					offset: '0',
-					orderBy: 'dateDesc'
-				});
-
-				const resultsHeader = (props: { label: string }): ReactElement => <>{props.label}</>;
-				const searchViewProps: SearchViewProps = {
-					useQuery: mockUseQuery,
-					ResultsHeader: resultsHeader,
-					useDisableSearch: () => [false, noop]
-				};
-
-				setupTest(<SearchView {...searchViewProps} />, { initialEntries: ['/conversation/123'] });
-
-				expect(await screen.findByTestId('SearchConversationPanel-123')).toBeInTheDocument();
-
-				// retrieve the last keydown event handler
-				const keydownCalls = addSpy.mock.calls.filter(([type]) => type === 'keydown');
-				expect(keydownCalls.length).toBeGreaterThan(0);
-				const handler = keydownCalls[keydownCalls.length - 1][1] as (e: KeyboardEvent) => void;
-
-				// mock the event
-				const preventDefault = jest.fn();
-				const stopPropagation = jest.fn();
-				const fakeEvent = {
-					key: 'Escape',
-					preventDefault,
-					stopPropagation
-				} as unknown as KeyboardEvent;
-
-				act(() => {
-					handler(fakeEvent);
-				});
-
-				expect(preventDefault).toHaveBeenCalled();
-				expect(stopPropagation).toHaveBeenCalled();
-			});
-
 			it('items should still be selected after a multiple selection action', async () => {
 				const { queryChip } = setupSearchViewTest({ viewBy: 'conversation', query: 'hello' });
 


### PR DESCRIPTION
This pull request introduces a new hook to detect if the file preview is open and integrates it into the keyboard shortcut handling logic for both the conversation and message panels. This ensures that keyboard shortcuts are disabled when the file preview is active, improving user experience and preventing unintended actions. Additionally, there is a minor cleanup in the search panel header component and a new script added to `package.json`.

**Keyboard shortcut handling improvements:**

* Added the `useIsFilePreviewOpen` hook in `src/hooks/use-is-file-preview-open.ts` to determine if the file preview is currently open.
* Updated `ConversationShortcutsRegister` and `MessageShortcutsRegister` components to use the new hook and prevent shortcuts when the file preview is open. [[1]](diffhunk://#diff-b4834d179f3f58335b5570d9505145674228469b83de7fa0badcb5331312d694R8) [[2]](diffhunk://#diff-b4834d179f3f58335b5570d9505145674228469b83de7fa0badcb5331312d694R25) [[3]](diffhunk://#diff-b4834d179f3f58335b5570d9505145674228469b83de7fa0badcb5331312d694L33-R46) [[4]](diffhunk://#diff-d0f8bcd6746cc9c795b712a93cdc48dd9080a68174ef44870e821f19d470d03aR8) [[5]](diffhunk://#diff-d0f8bcd6746cc9c795b712a93cdc48dd9080a68174ef44870e821f19d470d03aR21-R43)
* Improved the dependency array for the shortcut handlers to include the new state, ensuring correct reactivity. [[1]](diffhunk://#diff-b4834d179f3f58335b5570d9505145674228469b83de7fa0badcb5331312d694L33-R46) [[2]](diffhunk://#diff-d0f8bcd6746cc9c795b712a93cdc48dd9080a68174ef44870e821f19d470d03aR21-R43)

**Codebase cleanup:**

* Removed unused `useEffect` for handling Escape key in `SearchPanelHeader`, streamlining the component. [[1]](diffhunk://#diff-0ca282016f63b43910d68c43a89cc058ab06634e10a190a5622f5bb2ad4a0506L6-R6) [[2]](diffhunk://#diff-0ca282016f63b43910d68c43a89cc058ab06634e10a190a5622f5bb2ad4a0506L35-L46)

**Build system update:**

* Added a new `install` script to `package.json` for easier SDK installation.
Refs: CO-2828