### PR TITLE
fix: [CO-2842] Composer editing area does not auto-expand in rich & plain text edit modes

### DIFF
--- a/src/views/app/detail-panel/edit/edit-view.tsx
+++ b/src/views/app/detail-panel/edit/edit-view.tsx
@@ -528,7 +528,6 @@ export const EditView = React.forwardRef<EditViewHandle, EditViewProp>(function 
 		<Container
 			data-testid={'edit-view-editor'}
 			mainAlignment={flexStart}
-			height={'fit'}
 			crossAlignment={flexStart}
 			padding={{ all: 'large' }}
 			background={'gray5'}

--- a/src/views/app/detail-panel/edit/edit-view.tsx
+++ b/src/views/app/detail-panel/edit/edit-view.tsx
@@ -528,6 +528,7 @@ export const EditView = React.forwardRef<EditViewHandle, EditViewProp>(function 
 		<Container
 			data-testid={'edit-view-editor'}
 			mainAlignment={flexStart}
+			height={'100%'}
 			crossAlignment={flexStart}
 			padding={{ all: 'large' }}
 			background={'gray5'}

--- a/src/views/app/detail-panel/edit/parts/plain-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/plain-text-editor-container.tsx
@@ -85,7 +85,7 @@ export const PlainTextEditorContainer = ({
 	}, [setText, setTextProvider, textProviderValue]);
 
 	return (
-		<Container background={'gray6'} height="fit">
+		<Container background={'gray6'}>
 			<StyledComp.TextArea
 				data-testid="MailPlainTextEditor"
 				ref={textAreaRef}

--- a/src/views/app/detail-panel/edit/parts/plain-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/plain-text-editor-container.tsx
@@ -90,7 +90,7 @@ export const PlainTextEditorContainer = ({
 				data-testid="MailPlainTextEditor"
 				ref={textAreaRef}
 				defaultValue={initialValueRef.current}
-				style={{ fontFamily: defaultFontFamily }}
+				style={{ fontFamily: defaultFontFamily, outline: 'none' }}
 				onFocus={(ev): void => {
 					ev.currentTarget.setSelectionRange(0, null);
 				}}

--- a/src/views/app/detail-panel/edit/parts/plain-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/plain-text-editor-container.tsx
@@ -85,7 +85,7 @@ export const PlainTextEditorContainer = ({
 	}, [setText, setTextProvider, textProviderValue]);
 
 	return (
-		<Container background={'gray6'}>
+		<Container data-testid={'PlainTextEditorContainer'} background={'gray6'} height="100%">
 			<StyledComp.TextArea
 				data-testid="MailPlainTextEditor"
 				ref={textAreaRef}

--- a/src/views/app/detail-panel/edit/parts/tests/plain-text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/plain-text-editor-container.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { PlainTextEditorContainer } from '../plain-text-editor-container';
+import { setupTest } from '@test-setup';
+import { useUserSettings } from '@test-utils/carbonio-shell-ui/carbonio-shell-ui';
+import { setupEditorStore } from '__test__/generators/editor-store';
+import { generateNewMessageEditor } from 'store/editor/editor-generators';
+
+describe('PlainTextEditorContainer', () => {
+	const setUpMocks = (): void => {
+		useUserSettings.mockReturnValue({
+			prefs: { zimbraPrefHtmlEditorDefaultFontFamily: 'Arial' },
+			attrs: {},
+			props: []
+		});
+	};
+
+	it('should render plain text editor with textarea', () => {
+		const editor = generateNewMessageEditor();
+		const editors = [
+			{ ...editor, isRichText: false, text: { plainText: 'Test content', richText: '<p>Test</p>' } }
+		];
+		setupEditorStore({ editors });
+		setUpMocks();
+
+		setupTest(<PlainTextEditorContainer editorId={editor.id} />);
+
+		const textArea = screen.getByTestId('MailPlainTextEditor');
+		expect(textArea).toBeInTheDocument();
+		expect(textArea).toHaveValue('Test content');
+	});
+
+	it('should render container without height constraints to allow dynamic growth', async () => {
+		const editor = generateNewMessageEditor();
+		const editors = [
+			{
+				...editor,
+				isRichText: false,
+				text: { plainText: 'Long text content', richText: '<p>Long text</p>' }
+			}
+		];
+		setupEditorStore({ editors });
+		setUpMocks();
+
+		setupTest(<PlainTextEditorContainer editorId={editor.id} />);
+
+		const containerElement = await screen.findByTestId('PlainTextEditorContainer');
+		const computedStyle = getComputedStyle(containerElement);
+
+		expect(computedStyle.height).toBe('100%');
+
+		const textArea = screen.getByTestId('MailPlainTextEditor');
+		expect(textArea).toBeInTheDocument();
+	});
+
+	it('should apply custom font family from user settings', () => {
+		const editor = generateNewMessageEditor();
+		const editors = [
+			{ ...editor, isRichText: false, text: { plainText: 'Test', richText: '<p>Test</p>' } }
+		];
+		setupEditorStore({ editors });
+		useUserSettings.mockReturnValue({
+			prefs: { zimbraPrefHtmlEditorDefaultFontFamily: 'Courier New' },
+			attrs: {},
+			props: []
+		});
+
+		setupTest(<PlainTextEditorContainer editorId={editor.id} />);
+
+		const textArea = screen.getByTestId('MailPlainTextEditor') as HTMLTextAreaElement;
+		expect(textArea).toBeInTheDocument();
+		expect(textArea).toHaveStyle({ fontFamily: 'Courier New' });
+	});
+});

--- a/src/views/app/detail-panel/edit/parts/tests/plain-text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/plain-text-editor-container.test.tsx
@@ -78,4 +78,21 @@ describe('PlainTextEditorContainer', () => {
 		expect(textArea).toBeInTheDocument();
 		expect(textArea).toHaveStyle({ fontFamily: 'Courier New' });
 	});
+
+	it('should have no outline on focus for better UX', () => {
+		const editor = generateNewMessageEditor();
+		const editors = [
+			{ ...editor, isRichText: false, text: { plainText: 'Test', richText: '<p>Test</p>' } }
+		];
+		setupEditorStore({ editors });
+		setUpMocks();
+
+		setupTest(<PlainTextEditorContainer editorId={editor.id} />);
+
+		const textArea = screen.getByTestId('MailPlainTextEditor') as HTMLTextAreaElement;
+		expect(textArea).toBeInTheDocument();
+
+		textArea.focus();
+		expect(textArea).toHaveStyle({ outline: 'none' });
+	});
 });

--- a/src/views/app/detail-panel/edit/parts/tests/text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/text-editor-container.test.tsx
@@ -56,22 +56,6 @@ describe('TextEditorContainer', () => {
 		expect(screen.getByTestId('MailEditorWrapper')).toBeInTheDocument();
 		expect(screen.getByText(`Composer with RichText for ${editor.id}`)).toBeInTheDocument();
 	});
-
-	it('should render container with height 100% to allow dynamic growth', () => {
-		const editor = generateNewMessageEditor();
-		const editors = [{ ...editor, text: { plainText: 'PlainText', richText: '<p>RichText</p>' } }];
-		setupEditorStore({ editors });
-		setUpMocks();
-
-		setupTest(
-			<TextEditorContainer {...createMockTextEditorContainerProps({ editorId: editor.id })} />
-		);
-
-		const containerElement = screen.getByTestId('TextEditorContainer');
-		expect(containerElement).toBeVisible();
-		const computedStyle = getComputedStyle(containerElement);
-		expect(computedStyle.height).toBe('100%');
-	});
 });
 
 const createMockTextEditorContainerProps = (

--- a/src/views/app/detail-panel/edit/parts/tests/text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/text-editor-container.test.tsx
@@ -10,8 +10,8 @@ import { screen } from '@testing-library/react';
 
 import { setupTest } from '@test-setup';
 import { useUserSettings } from '@test-utils/carbonio-shell-ui/carbonio-shell-ui';
-import { generateNewMessageEditor } from 'store/editor/editor-generators';
 import { setupEditorStore } from '__test__/generators/editor-store';
+import { generateNewMessageEditor } from 'store/editor/editor-generators';
 import { MailsEditorV2 } from 'types/index.d';
 import {
 	TextEditorContainer,
@@ -55,6 +55,22 @@ describe('TextEditorContainer', () => {
 
 		expect(screen.getByTestId('MailEditorWrapper')).toBeInTheDocument();
 		expect(screen.getByText(`Composer with RichText for ${editor.id}`)).toBeInTheDocument();
+	});
+
+	it('should render container with height 100% to allow dynamic growth', () => {
+		const editor = generateNewMessageEditor();
+		const editors = [{ ...editor, text: { plainText: 'PlainText', richText: '<p>RichText</p>' } }];
+		setupEditorStore({ editors });
+		setUpMocks();
+
+		setupTest(
+			<TextEditorContainer {...createMockTextEditorContainerProps({ editorId: editor.id })} />
+		);
+
+		const containerElement = screen.getByTestId('TextEditorContainer');
+		expect(containerElement).toBeVisible();
+		const computedStyle = getComputedStyle(containerElement);
+		expect(computedStyle.height).toBe('100%');
 	});
 });
 

--- a/src/views/app/detail-panel/edit/parts/tests/text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/text-editor-container.test.tsx
@@ -56,6 +56,45 @@ describe('TextEditorContainer', () => {
 		expect(screen.getByTestId('MailEditorWrapper')).toBeInTheDocument();
 		expect(screen.getByText(`Composer with RichText for ${editor.id}`)).toBeInTheDocument();
 	});
+
+	it('should set container height to "fit" when in rich text mode', () => {
+		const editor = generateNewMessageEditor();
+		const editors: Array<MailsEditorV2> = [
+			{ ...editor, isRichText: true, text: { plainText: 'PlainText', richText: '<p>RichText</p>' } }
+		];
+		setupEditorStore({ editors });
+		setUpMocks();
+
+		setupTest(
+			<TextEditorContainer {...createMockTextEditorContainerProps({ editorId: editor.id })} />
+		);
+
+		const containerElement = screen.getByTestId('TextEditorContainer');
+		expect(containerElement).toBeInTheDocument();
+
+		expect(containerElement).toHaveStyle({ height: 'fit' });
+	});
+
+	it('should set container height to "100%" when in plain text mode', () => {
+		const editor = generateNewMessageEditor();
+		const editors = [
+			{
+				...editor,
+				isRichText: false,
+				text: { plainText: 'PlainText', richText: '<p>RichText</p>' }
+			}
+		];
+		setupEditorStore({ editors });
+		setUpMocks();
+
+		setupTest(
+			<TextEditorContainer {...createMockTextEditorContainerProps({ editorId: editor.id })} />
+		);
+
+		const containerElement = screen.getByTestId('TextEditorContainer');
+		expect(containerElement).toBeInTheDocument();
+		expect(containerElement).toHaveStyle({ height: '100%' });
+	});
 });
 
 const createMockTextEditorContainerProps = (

--- a/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
@@ -21,10 +21,12 @@ export type TextEditorContainerProps = {
 export const TextEditorContainer: FC<TextEditorContainerProps> = ({ editorId, onDragOver }) => {
 	const { isRichText } = useEditorIsRichText(editorId);
 
+	const containerHeight = isRichText ? 'fit' : '100%';
+
 	return (
 		<Container
 			data-testid={'TextEditorContainer'}
-			height={'fit'}
+			height={containerHeight}
 			padding={{ all: 'small' }}
 			background={'gray6'}
 			crossAlignment="flex-end"

--- a/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
@@ -22,7 +22,13 @@ export const TextEditorContainer: FC<TextEditorContainerProps> = ({ editorId, on
 	const { isRichText } = useEditorIsRichText(editorId);
 
 	return (
-		<Container padding={{ all: 'small' }} background={'gray6'} crossAlignment="flex-end">
+		<Container
+			data-testid={'TextEditorContainer'}
+			height="100%"
+			padding={{ all: 'small' }}
+			background={'gray6'}
+			crossAlignment="flex-end"
+		>
 			{isRichText ? (
 				<RichTextEditorContainer editorId={editorId} onDragOver={onDragOver} />
 			) : (

--- a/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
@@ -24,7 +24,7 @@ export const TextEditorContainer: FC<TextEditorContainerProps> = ({ editorId, on
 	return (
 		<Container
 			data-testid={'TextEditorContainer'}
-			height="100%"
+			height={'fit'}
 			padding={{ all: 'small' }}
 			background={'gray6'}
 			crossAlignment="flex-end"

--- a/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/text-editor-container.tsx
@@ -22,12 +22,7 @@ export const TextEditorContainer: FC<TextEditorContainerProps> = ({ editorId, on
 	const { isRichText } = useEditorIsRichText(editorId);
 
 	return (
-		<Container
-			height="fit"
-			padding={{ all: 'small' }}
-			background={'gray6'}
-			crossAlignment="flex-end"
-		>
+		<Container padding={{ all: 'small' }} background={'gray6'} crossAlignment="flex-end">
 			{isRichText ? (
 				<RichTextEditorContainer editorId={editorId} onDragOver={onDragOver} />
 			) : (

--- a/src/views/app/detail-panel/edit/tests/edit-view.test.tsx
+++ b/src/views/app/detail-panel/edit/tests/edit-view.test.tsx
@@ -1730,7 +1730,7 @@ describe('Edit view', () => {
 			const mainContainer = screen.getByTestId('edit-view-editor');
 
 			const computedStyle = getComputedStyle(mainContainer);
-			expect(computedStyle.height).not.toBe('fit-content');
+			expect(computedStyle.height).toBe('100%');
 		});
 	});
 });

--- a/src/views/app/detail-panel/edit/tests/edit-view.test.tsx
+++ b/src/views/app/detail-panel/edit/tests/edit-view.test.tsx
@@ -1714,4 +1714,25 @@ describe('Edit view', () => {
 			});
 		});
 	});
+
+	describe('Container layout', () => {
+		beforeAll(() => {
+			createCheckSmimeEnabledAPIInterceptor();
+			createSoapAPIInterceptor('GetShareInfo');
+		});
+
+		test('main container should render without height constraints to allow dynamic growth', async () => {
+			const editor: MailsEditorV2 = generateNewEditor();
+			setupEditorStore({ editors: [editor] });
+
+			setupTest(<EditView editorId={editor.id} closeController={noop} />);
+
+			const mainContainer = screen.getByTestId('edit-view-editor');
+
+			expect(mainContainer).toBeVisible();
+			await waitFor(() => {
+				expect(mainContainer).not.toHaveStyle({ height: 'fit' });
+			});
+		});
+	});
 });

--- a/src/views/app/detail-panel/edit/tests/edit-view.test.tsx
+++ b/src/views/app/detail-panel/edit/tests/edit-view.test.tsx
@@ -1729,10 +1729,8 @@ describe('Edit view', () => {
 
 			const mainContainer = screen.getByTestId('edit-view-editor');
 
-			expect(mainContainer).toBeVisible();
-			await waitFor(() => {
-				expect(mainContainer).not.toHaveStyle({ height: 'fit' });
-			});
+			const computedStyle = getComputedStyle(mainContainer);
+			expect(computedStyle.height).not.toBe('fit-content');
 		});
 	});
 });


### PR DESCRIPTION
This PR resolves an issue where the composer editing area was not expanding properly to accommodate content. The root cause was the use of `height={'fit'}` (equivalent to CSS `height: fit-content`) on multiple container components, which constrained the editor's ability to grow dynamically with parent component.

### Changes Made

**Container Height Updates:**
- **EditView** (`edit-view.tsx`): Changed main container from `height={'fit'}` to `height={'100%'}` to allow the editing area to utilize available vertical space
- **PlainTextEditorContainer** (`plain-text-editor-container.tsx`): Replaced `height={'fit'}` with `height={'100%'}` to ensure the plain text editor expands with content
- Removes outline on focus for `PlainTextEditorContainer` to enhance user experience (UI alignment with rich text editor container)

**Test Coverage:**
- Added tests in `edit-view.test.tsx` to verify the main container renders with `height: 100%`
- Created `plain-text-editor-container.test.tsx` with tests to ensure the plain text editor container renders with `height: 100%` and respects user font settings
