### PR TITLE
[Co-2878] fix: inline img deletion

### DIFF
--- a/src/views/app/detail-panel/edit/parts/editor-paste-handler.ts
+++ b/src/views/app/detail-panel/edit/parts/editor-paste-handler.ts
@@ -103,10 +103,12 @@ const processNextUpload = async (editor: Editor, editorId: string): Promise<void
 		if (!uploadImageResult?.cidUrl) {
 			throw new Error('No CID URL found in upload response');
 		}
-
+		// get the updated image in ordeer to avoid TinyMCE caching issues
+		const blob = await fetch(uploadImageResult.downloadServiceUrl).then((r) => r.blob());
+		const objectUrl = URL.createObjectURL(blob);
 		editor.insertContent(
-			`<img alt="${uploadImageResult.fileName}" src="${uploadImageResult.downloadServiceUrl}" 
-                  data-mce-src="${uploadImageResult.cidUrl}" />`
+			`<img id="img-${uuid()}" alt="${uploadImageResult.fileName}" src="${objectUrl}"
+    data-mce-src="${uploadImageResult.cidUrl}"/>`
 		);
 	}
 

--- a/src/views/app/detail-panel/edit/parts/editor-paste-handler.ts
+++ b/src/views/app/detail-panel/edit/parts/editor-paste-handler.ts
@@ -107,8 +107,7 @@ const processNextUpload = async (editor: Editor, editorId: string): Promise<void
 		const blob = await fetch(uploadImageResult.downloadServiceUrl).then((r) => r.blob());
 		const objectUrl = URL.createObjectURL(blob);
 		editor.insertContent(
-			`<img id="img-${uuid()}" alt="${uploadImageResult.fileName}" src="${objectUrl}"
-    data-mce-src="${uploadImageResult.cidUrl}"/>`
+			`<img alt="${uploadImageResult.fileName}" src="${objectUrl}" data-mce-src="${uploadImageResult.cidUrl}"/>`
 		);
 	}
 

--- a/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
@@ -8,7 +8,7 @@ import React, { useCallback, useMemo, useRef } from 'react';
 import { Container } from '@zextras/carbonio-design-system';
 import { useUserSettings } from '@zextras/carbonio-shell-ui';
 import { Composer } from '@zextras/carbonio-ui-text-composer';
-import { debounce, noop } from 'lodash';
+import { noop } from 'lodash';
 import type { TinyMCE, Editor } from 'tinymce';
 
 import { buildArrayFromFileList } from 'helpers/files';

--- a/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
@@ -125,12 +125,25 @@ export const RichTextEditorContainer = ({
 		({ editor: tinymce, files: fileList }: FileSelectProps): void => {
 			if (!fileList) return;
 			const files = buildArrayFromFileList(fileList);
+
 			addInlineAttachments(files, {
 				onSaveComplete: (inlineAttachments) => {
-					inlineAttachments.forEach((inlineAttachment) => {
-						const img = `&nbsp;<img alt="Inline attachment" data-pnsrc="${inlineAttachment.cidUrl}" data-mce-src="${inlineAttachment.cidUrl}" src="${inlineAttachment.downloadServiceUrl}" /><br/>`;
+					const insertPromises = inlineAttachments.map(async (inlineAttachment) => {
+						const url = inlineAttachment.downloadServiceUrl;
+						if (!url) return;
+						// get the updated image in ordeer to avoid TinyMCE caching issues
+						const blob = await fetch(url).then((r) => r.blob());
+						const objectUrl = URL.createObjectURL(blob);
+
+						const img = `&nbsp;<img alt="Inline attachment"
+                            data-pnsrc="${inlineAttachment.cidUrl}"
+                            data-mce-src="${inlineAttachment.cidUrl}"
+                            src="${objectUrl}" /><br/>`;
+
 						tinymce?.activeEditor?.insertContent(img);
 					});
+
+					Promise.all(insertPromises).catch(console.error);
 				}
 			});
 		},

--- a/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
@@ -24,6 +24,12 @@ type FileSelectProps = {
 	files: FileList | null | undefined;
 };
 
+type InlineAttachment = {
+	contentId: string | undefined;
+	cidUrl: string | undefined;
+	downloadServiceUrl: string | undefined;
+};
+
 export const SAVE_EDITOR_DELAY = 2000;
 
 export const RichTextEditorContainer = ({
@@ -126,25 +132,35 @@ export const RichTextEditorContainer = ({
 			if (!fileList) return;
 			const files = buildArrayFromFileList(fileList);
 
+			const insertSingleInlineAttachment = async (
+				editor: TinyMCE,
+				inlineAttachment: InlineAttachment
+			): Promise<void> => {
+				const url = inlineAttachment.downloadServiceUrl;
+				if (!url) return;
+				// get the updated image in order to avoid TinyMCE caching issues
+				const blob = await fetch(url).then((r) => r.blob());
+				const objectUrl = URL.createObjectURL(blob);
+
+				const img = `&nbsp;<img alt="Inline attachment"
+                data-pnsrc="${inlineAttachment.cidUrl}"
+                data-mce-src="${inlineAttachment.cidUrl}"
+                src="${objectUrl}" /><br/>`;
+
+				editor?.activeEditor?.insertContent(img);
+			};
+
+			const handleSaveComplete = (inlineAttachments: InlineAttachment[]): void => {
+				const editor = tinymce;
+				const insertPromises = inlineAttachments.map((inlineAttachment) =>
+					insertSingleInlineAttachment(editor, inlineAttachment)
+				);
+
+				Promise.all(insertPromises).catch(console.error);
+			};
+
 			addInlineAttachments(files, {
-				onSaveComplete: (inlineAttachments) => {
-					const insertPromises = inlineAttachments.map(async (inlineAttachment) => {
-						const url = inlineAttachment.downloadServiceUrl;
-						if (!url) return;
-						// get the updated image in ordeer to avoid TinyMCE caching issues
-						const blob = await fetch(url).then((r) => r.blob());
-						const objectUrl = URL.createObjectURL(blob);
-
-						const img = `&nbsp;<img alt="Inline attachment"
-                            data-pnsrc="${inlineAttachment.cidUrl}"
-                            data-mce-src="${inlineAttachment.cidUrl}"
-                            src="${objectUrl}" /><br/>`;
-
-						tinymce?.activeEditor?.insertContent(img);
-					});
-
-					Promise.all(insertPromises).catch(console.error);
-				}
+				onSaveComplete: handleSaveComplete
 			});
 		},
 		[addInlineAttachments]

--- a/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
@@ -71,14 +71,33 @@ export const RichTextEditorContainer = ({
 		[getCurrentText, onExternalTextChanges, setTextProvider]
 	);
 
+	const cleanupUnusedAttachments = useCallback(
+		(html: string) => {
+			if (!composerRef.current) return;
+
+			const doc = new DOMParser().parseFromString(html, 'text/html');
+
+			// collect all used attachment IDs
+			const usedCids = Array.from(doc.querySelectorAll('img[data-pnsrc], img[src^="cid:"]'))
+				.map((img) => img.getAttribute('data-pnsrc') || img.getAttribute('src'))
+				.filter((cid): cid is string => Boolean(cid));
+
+			removeInlineAttachments(usedCids);
+		},
+		[removeInlineAttachments]
+	);
+
 	const saveEditor = useCallback(() => {
 		if (!composerRef.current) {
 			return;
 		}
+
 		const plainText = composerRef.current.getContent({ format: 'text' });
 		const richText = composerRef.current.getContent({ format: 'html' });
+
+		cleanupUnusedAttachments(richText);
 		setText({ plainText, richText }, { syncTextProvider: false });
-	}, [setText]);
+	}, [cleanupUnusedAttachments, setText]);
 
 	const onTextChange = useCallback(() => {
 		if (timeoutId.current) {
@@ -131,22 +150,6 @@ export const RichTextEditorContainer = ({
 			if (editViewWrapper) {
 				editViewWrapper.scrollTop = editViewWrapperPrevScrollTop ?? 0;
 			}
-		};
-	}
-
-	function createAttachmentCleanupHandler(editor: Editor, removeFn: (usedCids: string[]) => void) {
-		return (): void => {
-			const content = editor.getContent({ format: 'html' });
-			const parser = new DOMParser();
-			const doc = parser.parseFromString(content, 'text/html');
-			const usedCids = [
-				...Array.from(doc.querySelectorAll('img[pnsrc]')).map((img) => img.getAttribute('pnsrc')),
-				...Array.from(doc.querySelectorAll('img[src^="cid:"]')).map((img) =>
-					img.getAttribute('src')
-				)
-			].filter((cid): cid is string => Boolean(cid));
-
-			removeFn(usedCids);
 		};
 	}
 
@@ -236,16 +239,9 @@ export const RichTextEditorContainer = ({
 				onComposerInit({} as Event, editor);
 
 				const handlePaste = createPasteHandler(editor, editorId);
-				const handleAttachmentCleanup = createAttachmentCleanupHandler(
-					editor,
-					removeInlineAttachments
-				);
-
 				editor.on('paste', handlePaste);
 				editor.on('input', onTextChange);
 				editor.on('remove', onComposerClose);
-				editor.on('Paste Cut Drop Undo Redo', handleAttachmentCleanup);
-				editor.on('Change', debounce(handleAttachmentCleanup, 300));
 
 				// Handle drag over events
 				if (onDragOver) {
@@ -268,8 +264,7 @@ export const RichTextEditorContainer = ({
 		onTextChange,
 		prefs?.zimbraPrefHtmlEditorDefaultFontColor,
 		prefs?.zimbraPrefHtmlEditorDefaultFontFamily,
-		prefs?.zimbraPrefHtmlEditorDefaultFontSize,
-		removeInlineAttachments
+		prefs?.zimbraPrefHtmlEditorDefaultFontSize
 	]);
 
 	return (

--- a/src/views/app/detail-panel/edit/parts/tests/editor-paste-handler.test.ts
+++ b/src/views/app/detail-panel/edit/parts/tests/editor-paste-handler.test.ts
@@ -190,27 +190,23 @@ describe('handleEditorPaste', () => {
 			expect(result.cidUrl).toBeDefined();
 		});
 
-		it('should fetch the uploaded image, create object URL, and insert it into the editor', async () => {
-			const setDid = jest.fn();
-			const setSize = jest.fn();
-			const removeUnsavedAttachments = jest.fn();
-			const setSavedAttachments = jest.fn();
+		it('should fetch uploaded image and insert updated <img> tag into editor', async () => {
 			(useEditorsStore.getState as jest.Mock).mockReturnValue({
-				setDid,
-				setSize,
-				removeUnsavedAttachments,
-				setSavedAttachments
+				setDid: jest.fn(),
+				setSize: jest.fn(),
+				removeUnsavedAttachments: jest.fn(),
+				setSavedAttachments: jest.fn()
 			});
 
 			(saveDraftEmailStoreAction as jest.Mock).mockResolvedValue({
 				m: [
 					{
-						id: 'msg456',
-						s: 2048,
+						id: 'msg789',
+						s: 1234,
 						mp: [
 							{
 								part: '2.2',
-								ct: 'image/jpeg',
+								ct: 'image/png',
 								s: 1000,
 								cd: 'inline',
 								filename: mockFile.name,
@@ -221,15 +217,16 @@ describe('handleEditorPaste', () => {
 				]
 			});
 
+			// Mock getEditor to return savedAttachments
 			(getEditor as jest.Mock).mockReturnValueOnce({ unsavedAttachments: [] }).mockReturnValueOnce({
 				savedAttachments: [
 					{
-						messageId: 'msg456',
+						messageId: 'msg789',
 						isInline: true,
 						contentId: mockContentId,
 						filename: mockFile.name,
 						partName: '2.2',
-						contentType: 'image/jpeg',
+						contentType: 'image/png',
 						size: 1000
 					}
 				]
@@ -237,27 +234,20 @@ describe('handleEditorPaste', () => {
 
 			(uploadFileApi as jest.Mock).mockResolvedValue({ aid: mockAid });
 
-			const fakeBlob = new Blob(['xxx'], { type: 'image/jpeg' });
+			const fakeBlob = new Blob(['xxx'], { type: 'image/png' });
 			global.fetch = jest.fn(() =>
-				Promise.resolve({
-					blob: () => Promise.resolve(fakeBlob)
-				})
+				Promise.resolve({ blob: () => Promise.resolve(fakeBlob) })
 			) as jest.Mock;
-
-			const fakeObjectUrl = 'blob://test-url-2';
+			const fakeObjectUrl = 'blob://fake-object-url';
 			global.URL.createObjectURL = jest.fn(() => fakeObjectUrl);
 
-			const editor = {
-				insertContent: jest.fn(),
-				setProgressState: jest.fn()
-			};
+			const editor = { insertContent: jest.fn(), setProgressState: jest.fn() };
 
-			// call uploadImage first
 			const uploadResult = await testingPurposeOnly.uploadImage(mockFile, mockEditorId);
 
-			// then simulate processNextUpload inserting the image
 			const blob = await fetch(uploadResult.downloadServiceUrl).then((r) => r.blob());
 			const objectUrl = URL.createObjectURL(blob);
+
 			editor.insertContent(
 				`<img alt="${uploadResult.fileName}" src="${objectUrl}" data-mce-src="${uploadResult.cidUrl}"/>`
 			);
@@ -265,6 +255,8 @@ describe('handleEditorPaste', () => {
 			expect(editor.insertContent).toHaveBeenCalledWith(
 				`<img alt="${mockFile.name}" src="${fakeObjectUrl}" data-mce-src="cid:${mockContentId}"/>`
 			);
+			expect(fetch).toHaveBeenCalledWith(uploadResult.downloadServiceUrl);
+			expect(URL.createObjectURL).toHaveBeenCalledWith(fakeBlob);
 		});
 	});
 });

--- a/src/views/app/detail-panel/edit/parts/tests/editor-paste-handler.test.ts
+++ b/src/views/app/detail-panel/edit/parts/tests/editor-paste-handler.test.ts
@@ -245,6 +245,7 @@ describe('handleEditorPaste', () => {
 
 			const uploadResult = await testingPurposeOnly.uploadImage(mockFile, mockEditorId);
 
+			// **This is the part you actually want to test: fetch → blob → object URL → insert**
 			const blob = await fetch(uploadResult.downloadServiceUrl).then((r) => r.blob());
 			const objectUrl = URL.createObjectURL(blob);
 

--- a/src/views/app/detail-panel/edit/parts/tests/editor-paste-handler.test.ts
+++ b/src/views/app/detail-panel/edit/parts/tests/editor-paste-handler.test.ts
@@ -129,12 +129,11 @@ describe('handleEditorPaste', () => {
 	});
 
 	describe('uploadImage', () => {
+		const mockFile = new File(['content'], '1.jpg', { type: 'image/jpeg' });
+		const mockAid = '12345';
+		const mockContentId = `${mockAid}@carbonio`;
+		const mockEditorId = 'test-editor';
 		it('should upload an image and return the correct result', async () => {
-			const mockFile = new File(['content'], '1.jpg', { type: 'image/jpeg' });
-			const mockAid = '12345';
-			const mockContentId = `${mockAid}@carbonio`;
-			const mockEditorId = 'test-editor';
-
 			(useEditorsStore.getState as jest.Mock).mockReturnValue({
 				setDid: jest.fn(),
 				setSize: jest.fn(),
@@ -189,6 +188,83 @@ describe('handleEditorPaste', () => {
 			expect(result.fileName).toBe(mockFile.name);
 			expect(result.downloadServiceUrl).toBeDefined();
 			expect(result.cidUrl).toBeDefined();
+		});
+
+		it('should fetch the uploaded image, create object URL, and insert it into the editor', async () => {
+			const setDid = jest.fn();
+			const setSize = jest.fn();
+			const removeUnsavedAttachments = jest.fn();
+			const setSavedAttachments = jest.fn();
+			(useEditorsStore.getState as jest.Mock).mockReturnValue({
+				setDid,
+				setSize,
+				removeUnsavedAttachments,
+				setSavedAttachments
+			});
+
+			(saveDraftEmailStoreAction as jest.Mock).mockResolvedValue({
+				m: [
+					{
+						id: 'msg456',
+						s: 2048,
+						mp: [
+							{
+								part: '2.2',
+								ct: 'image/jpeg',
+								s: 1000,
+								cd: 'inline',
+								filename: mockFile.name,
+								ci: mockContentId
+							}
+						]
+					}
+				]
+			});
+
+			(getEditor as jest.Mock).mockReturnValueOnce({ unsavedAttachments: [] }).mockReturnValueOnce({
+				savedAttachments: [
+					{
+						messageId: 'msg456',
+						isInline: true,
+						contentId: mockContentId,
+						filename: mockFile.name,
+						partName: '2.2',
+						contentType: 'image/jpeg',
+						size: 1000
+					}
+				]
+			});
+
+			(uploadFileApi as jest.Mock).mockResolvedValue({ aid: mockAid });
+
+			const fakeBlob = new Blob(['xxx'], { type: 'image/jpeg' });
+			global.fetch = jest.fn(() =>
+				Promise.resolve({
+					blob: () => Promise.resolve(fakeBlob)
+				})
+			) as jest.Mock;
+
+			const fakeObjectUrl = 'blob://test-url-2';
+			global.URL.createObjectURL = jest.fn(() => fakeObjectUrl);
+
+			const editor = {
+				insertContent: jest.fn(),
+				setProgressState: jest.fn()
+			};
+
+			// call uploadImage first
+			const uploadResult = await testingPurposeOnly.uploadImage(mockFile, mockEditorId);
+
+			// then simulate processNextUpload inserting the image
+			const blob = await fetch(uploadResult.downloadServiceUrl).then((r) => r.blob());
+			const objectUrl = URL.createObjectURL(blob);
+			editor.insertContent(
+				`<img alt="${uploadResult.fileName}" src="${objectUrl}" data-mce-src="${uploadResult.cidUrl}"/>`
+			);
+
+			expect(editor.insertContent).toHaveBeenCalledWith(
+				`<img alt="${mockFile.name}" src="${fakeObjectUrl}" data-mce-src="cid:${mockContentId}"/>`
+			);
 		});
 	});
 });

--- a/src/views/app/detail-panel/edit/parts/tests/rich-text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/rich-text-editor-container.test.tsx
@@ -89,6 +89,7 @@ describe('RichTextEditorContainer', () => {
 	});
 
 	test('cleans up inline attachments that are no longer in content', async () => {
+		jest.useFakeTimers();
 		setupTest(<RichTextEditorContainer editorId="editor-1" onDragOver={jest.fn()} />);
 		await screen.findByTestId('mock-composer');
 
@@ -98,13 +99,11 @@ describe('RichTextEditorContainer', () => {
 				'<img src="https://test.test/image.png" /></p>'
 		);
 
-		editorInstance?.dispatch('Change');
+		editorInstance?.dispatch('input');
+		// fast-forward debounce timer
+		jest.runAllTimers();
 
-		expect(mockRemoveInlineAttachments).toHaveBeenCalledWith([
-			'cid:first',
-			'cid:first',
-			'cid:second'
-		]);
+		expect(mockRemoveInlineAttachments).toHaveBeenCalledWith(['cid:first', 'cid:second']);
 	});
 
 	test('handles paste event and restores scroll position', async () => {

--- a/src/views/app/detail-panel/edit/parts/tests/rich-text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/rich-text-editor-container.test.tsx
@@ -124,4 +124,30 @@ describe('RichTextEditorContainer', () => {
 		expect(handleEditorPaste).toHaveBeenCalledWith(editorInstance, 'editor-1', event);
 		expect(parent.scrollTop).toBe(42);
 	});
+
+	test('cleanupUnusedAttachments removes only used inline attachments in real component', async () => {
+		jest.useFakeTimers();
+
+		// Render component
+		setupTest(<RichTextEditorContainer editorId="editor-1" onDragOver={jest.fn()} />);
+		await screen.findByTestId('mock-composer');
+
+		// Set editor content with some inline attachments and some normal images
+		editorInstance?.setContent(
+			'<p>' +
+				'<img data-pnsrc="cid:first" src="cid:first" />' +
+				'<img src="cid:second" />' +
+				'<img src="https://test.test/image.png" />' +
+				'</p>'
+		);
+
+		// Trigger the input event to call onTextChange -> saveEditor -> cleanupUnusedAttachments
+		editorInstance?.dispatch('input');
+
+		// Fast-forward debounce timer
+		jest.runAllTimers();
+
+		// Assert that removeInlineAttachments was called with only the cids
+		expect(mockRemoveInlineAttachments).toHaveBeenCalledWith(['cid:first', 'cid:second']);
+	});
 });

--- a/src/views/app/detail-panel/edit/parts/tests/rich-text-editor-container.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/rich-text-editor-container.test.tsx
@@ -128,11 +128,9 @@ describe('RichTextEditorContainer', () => {
 	test('cleanupUnusedAttachments removes only used inline attachments in real component', async () => {
 		jest.useFakeTimers();
 
-		// Render component
 		setupTest(<RichTextEditorContainer editorId="editor-1" onDragOver={jest.fn()} />);
 		await screen.findByTestId('mock-composer');
 
-		// Set editor content with some inline attachments and some normal images
 		editorInstance?.setContent(
 			'<p>' +
 				'<img data-pnsrc="cid:first" src="cid:first" />' +
@@ -141,13 +139,10 @@ describe('RichTextEditorContainer', () => {
 				'</p>'
 		);
 
-		// Trigger the input event to call onTextChange -> saveEditor -> cleanupUnusedAttachments
 		editorInstance?.dispatch('input');
 
-		// Fast-forward debounce timer
 		jest.runAllTimers();
 
-		// Assert that removeInlineAttachments was called with only the cids
 		expect(mockRemoveInlineAttachments).toHaveBeenCalledWith(['cid:first', 'cid:second']);
 	});
 });


### PR DESCRIPTION
- improved usage of cleanup attachments fn
- blob to override internal img caching by tinymce