### PR TITLE
chore: vitest configure JUnit reporter to not output in console + other cleanups

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,11 @@ import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { configDefaults, defineConfig } from 'vitest/config';
 
+const junitReporter: ['junit', { outputFile: string; logConsoleError: boolean }] = [
+	'junit',
+	{ outputFile: 'junit.xml', logConsoleError: false }
+];
+
 export default defineConfig({
 	plugins: [
 		react({
@@ -37,9 +42,9 @@ export default defineConfig({
 		mockReset: false,
 		testTimeout: 20000,
 		hookTimeout: 20000,
-		reporters: ['default', 'junit'],
+		reporters: ['default', junitReporter],
 		coverage: {
-			enabled: true,
+			enabled: false,
 			provider: 'v8',
 			reporter: ['text', 'cobertura', 'lcov'],
 			reportsDirectory: 'coverage',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,9 +8,9 @@ import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { configDefaults, defineConfig } from 'vitest/config';
 
-const junitReporter: ['junit', { outputFile: string; logConsoleError: boolean }] = [
+const junitReporter: ['junit', { outputFile: string; console: boolean }] = [
 	'junit',
-	{ outputFile: 'junit.xml', logConsoleError: false }
+	{ outputFile: 'junit.xml', console: false }
 ];
 
 export default defineConfig({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,9 +44,9 @@ export default defineConfig({
 		hookTimeout: 20000,
 		reporters: ['default', junitReporter],
 		coverage: {
-			enabled: false,
+			enabled: true,
 			provider: 'v8',
-			reporter: ['text', 'cobertura', 'lcov'],
+			reporter: ['lcov'],
 			reportsDirectory: 'coverage',
 			include: ['src/**/*.{ts,tsx}'],
 			exclude: ['**/__test__/**', '**/tests/**', '**/mocks/**', '**/*.test.{js,jsx,ts,tsx}']

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
 		coverage: {
 			enabled: true,
 			provider: 'v8',
-			reporter: ['lcov'],
+			reporter: ['cobertura', 'lcov'],
 			reportsDirectory: 'coverage',
 			include: ['src/**/*.{ts,tsx}'],
 			exclude: ['**/__test__/**', '**/tests/**', '**/mocks/**', '**/*.test.{js,jsx,ts,tsx}']


### PR DESCRIPTION
This PR configures Vitest to suppress console output for JUnit and coverage reports while maintaining file-based reporting. The changes reduce console noise during test execution by configuring the JUnit reporter to disable console error logging and removing text-based coverage reporting.

Configured JUnit reporter with `console: false` to suppress console output
Removed `text` coverage reporter (we don't want coverage report in console), keeping only `lcov` and `cobertura` (this one seems to be used by jenkins to collect coverage)