### PR TITLE
feat: [CO-3053] use panel control hook in Conversation actions

### DIFF
--- a/src/__test__/conversation/ui-interactions.ts
+++ b/src/__test__/conversation/ui-interactions.ts
@@ -50,6 +50,7 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 			if (status === 'open') {
 				await screen.findByText(spamMessage);
 			} else {
+				vi.advanceTimersByTime(3000); // snackbar lasts 3 seconds
 				await waitFor(() => {
 					expect(screen.queryByText(spamMessage)).not.toBeInTheDocument();
 				});
@@ -64,6 +65,7 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 			if (status === 'open') {
 				await screen.findByText(notSpamMessage);
 			} else {
+				vi.advanceTimersByTime(3000); // snackbar lasts 3 seconds
 				await waitFor(() => {
 					expect(screen.queryByText(notSpamMessage)).not.toBeInTheDocument();
 				});

--- a/src/__test__/conversation/ui-interactions.ts
+++ b/src/__test__/conversation/ui-interactions.ts
@@ -3,16 +3,20 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { UserEvent } from '@test-setup';
 
+type ConversationContextMenuActions = {
+	markAsSpam: () => Promise<HTMLElement>;
+	notSpam: () => Promise<HTMLElement>;
+};
 type ConversationTestUtilities = {
 	checkPanelClosed: () => Promise<void>;
 	checkPanelOpen: () => Promise<HTMLElement>;
 	findConversationInList: () => Promise<HTMLElement>;
 	hoverConversationInList: (user: UserEvent) => Promise<{ hoverActionsContainer: HTMLElement }>;
-	openConversationContextMenu: (user: UserEvent) => Promise<HTMLElement>;
+	openConversationContextMenu: (user: UserEvent) => Promise<ConversationContextMenuActions>;
 	snackbars: {
 		seeConversationMovedToSpam: ({ status }: { status: 'open' | 'closed' }) => Promise<void>;
 		seeConversationNotSpamAnymore: ({ status }: { status: 'open' | 'closed' }) => Promise<void>;
@@ -35,14 +39,6 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 		await waitFor(() => {
 			expect(screen.queryByTestId(`conversation-preview-panel-${id}`)).not.toBeInTheDocument();
 		});
-	},
-	openConversationContextMenu: async (user: UserEvent): Promise<HTMLElement> => {
-		const hoverActionsSection = await screen.findByTestId(`ConversationListItem-${id}`);
-		await user.hover(hoverActionsSection);
-		const hoverContainer = screen.getByTestId(`hover-container-${id}`);
-
-		await user.rightClick(hoverContainer);
-		return screen.getByTestId('dropdown-popper-list');
 	},
 	snackbars: {
 		seeConversationMovedToSpam: async ({
@@ -73,5 +69,21 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 				});
 			}
 		}
+	},
+	openConversationContextMenu: async (user: UserEvent): Promise<ConversationContextMenuActions> => {
+		const hoverActionsSection = await screen.findByTestId(`ConversationListItem-${id}`);
+		await user.hover(hoverActionsSection);
+		const hoverContainer = screen.getByTestId(`hover-container-${id}`);
+
+		await user.rightClick(hoverContainer);
+		const contextMenu = screen.getByTestId('dropdown-popper-list');
+		return {
+			async markAsSpam(): Promise<HTMLElement> {
+				return within(contextMenu).findByText('Mark as spam');
+			},
+			async notSpam(): Promise<HTMLElement> {
+				return within(contextMenu).findByText('Not spam');
+			}
+		};
 	}
 });

--- a/src/__test__/conversation/ui-interactions.ts
+++ b/src/__test__/conversation/ui-interactions.ts
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { screen, waitFor } from '@testing-library/react';
-import { UserEvent } from '@testing-library/user-event';
+
+import { UserEvent } from '@test-setup';
 
 type ConversationTestUtilities = {
 	checkPanelClosed: () => Promise<void>;
 	checkPanelOpen: () => Promise<HTMLElement>;
 	findConversationInList: () => Promise<HTMLElement>;
 	hoverConversationInList: (user: UserEvent) => Promise<{ hoverActionsContainer: HTMLElement }>;
+	openConversationContextMenu: (user: UserEvent) => Promise<HTMLElement>;
 };
 export const conversationTestUtilities = (id: string): ConversationTestUtilities => ({
 	findConversationInList: (): Promise<HTMLElement> =>
@@ -22,12 +24,20 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 	): Promise<{ hoverActionsContainer: HTMLElement }> => {
 		const hoverActionsSection = await screen.findByTestId(`ConversationListItem-${id}`);
 		await user.hover(hoverActionsSection);
-		const hoverContainer = screen.getByTestId(/hover-container-/);
+		const hoverContainer = screen.getByTestId(`hover-container-${id}`);
 		return { hoverActionsContainer: hoverContainer };
 	},
 	checkPanelClosed: async (): Promise<void> => {
 		await waitFor(() => {
 			expect(screen.queryByTestId(`conversation-preview-panel-${id}`)).not.toBeInTheDocument();
 		});
+	},
+	openConversationContextMenu: async (user: UserEvent): Promise<HTMLElement> => {
+		const hoverActionsSection = await screen.findByTestId(`ConversationListItem-${id}`);
+		await user.hover(hoverActionsSection);
+		const hoverContainer = screen.getByTestId(`hover-container-${id}`);
+
+		await user.rightClick(hoverContainer);
+		return screen.getByTestId('dropdown-popper-list');
 	}
 });

--- a/src/__test__/conversation/ui-interactions.ts
+++ b/src/__test__/conversation/ui-interactions.ts
@@ -13,6 +13,10 @@ type ConversationTestUtilities = {
 	findConversationInList: () => Promise<HTMLElement>;
 	hoverConversationInList: (user: UserEvent) => Promise<{ hoverActionsContainer: HTMLElement }>;
 	openConversationContextMenu: (user: UserEvent) => Promise<HTMLElement>;
+	snackbars: {
+		seeConversationMovedToSpam: ({ status }: { status: 'open' | 'closed' }) => Promise<void>;
+		seeConversationNotSpamAnymore: ({ status }: { status: 'open' | 'closed' }) => Promise<void>;
+	};
 };
 export const conversationTestUtilities = (id: string): ConversationTestUtilities => ({
 	findConversationInList: (): Promise<HTMLElement> =>
@@ -39,5 +43,35 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 
 		await user.rightClick(hoverContainer);
 		return screen.getByTestId('dropdown-popper-list');
+	},
+	snackbars: {
+		seeConversationMovedToSpam: async ({
+			status
+		}: {
+			status: 'open' | 'closed';
+		}): Promise<void> => {
+			const spamMessage = 'You’ve marked this e-mail as Spam';
+			if (status === 'open') {
+				await screen.findByText(spamMessage);
+			} else {
+				await waitFor(() => {
+					expect(screen.queryByText(spamMessage)).not.toBeInTheDocument();
+				});
+			}
+		},
+		seeConversationNotSpamAnymore: async ({
+			status
+		}: {
+			status: 'open' | 'closed';
+		}): Promise<void> => {
+			const notSpamMessage = 'You’ve marked this e-mail as Not Spam';
+			if (status === 'open') {
+				await screen.findByText(notSpamMessage);
+			} else {
+				await waitFor(() => {
+					expect(screen.queryByText(notSpamMessage)).not.toBeInTheDocument();
+				});
+			}
+		}
 	}
 });

--- a/src/hooks/actions/tests/use-conv-set-not-spam.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-not-spam.test.ts
@@ -26,7 +26,7 @@ describe('useConvSetNotSpam', () => {
 			const {
 				result: { current: descriptor }
 			} = setupHook(useConvSetNotSpamDescriptor, {
-				initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.SPAM }]
+				initialProps: [{ ids, folderId: FOLDERS.SPAM }]
 			});
 
 			expect(descriptor).toEqual({
@@ -48,7 +48,7 @@ describe('useConvSetNotSpam', () => {
 			const {
 				result: { current: functions }
 			} = setupHook(useConvSetNotSpamFn, {
-				initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.SPAM }]
+				initialProps: [{ ids, folderId: FOLDERS.SPAM }]
 			});
 
 			expect(functions).toEqual({
@@ -70,7 +70,7 @@ describe('useConvSetNotSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetNotSpamFn, {
-					initialProps: [{ ids, shouldReplaceHistory: false, folderId: folder.id }]
+					initialProps: [{ ids, folderId: folder.id }]
 				});
 
 				expect(functions.canExecute()).toEqual(assertion);
@@ -85,7 +85,7 @@ describe('useConvSetNotSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetNotSpamFn, {
-					initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.INBOX }]
+					initialProps: [{ ids, folderId: FOLDERS.INBOX }]
 				});
 
 				await act(async () => {
@@ -109,7 +109,7 @@ describe('useConvSetNotSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetNotSpamFn, {
-					initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.SPAM }]
+					initialProps: [{ ids, folderId: FOLDERS.SPAM }]
 				});
 
 				act(() => {
@@ -131,9 +131,7 @@ describe('useConvSetNotSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetNotSpamFn, {
-					initialProps: [
-						{ ids, shouldReplaceHistory: false, folderId: FOLDERS.SPAM, onActionComplete }
-					]
+					initialProps: [{ ids, folderId: FOLDERS.SPAM, onActionComplete }]
 				});
 				await act(async () => {
 					functions.execute();

--- a/src/hooks/actions/tests/use-conv-set-spam.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-spam.test.ts
@@ -24,7 +24,7 @@ describe('useConvSetSpam', () => {
 			const {
 				result: { current: descriptor }
 			} = setupHook(useConvSetSpamDescriptor, {
-				initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.SPAM }]
+				initialProps: [{ ids, folderId: FOLDERS.SPAM }]
 			});
 
 			expect(descriptor).toEqual({
@@ -45,7 +45,7 @@ describe('useConvSetSpam', () => {
 			const {
 				result: { current: functions }
 			} = setupHook(useConvSetSpamFn, {
-				initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.SPAM }]
+				initialProps: [{ ids, folderId: FOLDERS.SPAM }]
 			});
 
 			expect(functions).toEqual({
@@ -67,7 +67,7 @@ describe('useConvSetSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetSpamFn, {
-					initialProps: [{ ids, shouldReplaceHistory: false, folderId: folder.id }]
+					initialProps: [{ ids, folderId: folder.id }]
 				});
 
 				expect(functions.canExecute()).toEqual(assertion);
@@ -82,7 +82,7 @@ describe('useConvSetSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetSpamFn, {
-					initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.SPAM }]
+					initialProps: [{ ids, folderId: FOLDERS.SPAM }]
 				});
 
 				await act(async () => {
@@ -106,7 +106,7 @@ describe('useConvSetSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetSpamFn, {
-					initialProps: [{ ids, shouldReplaceHistory: false, folderId: FOLDERS.INBOX }]
+					initialProps: [{ ids, folderId: FOLDERS.INBOX }]
 				});
 
 				act(() => {
@@ -128,9 +128,7 @@ describe('useConvSetSpam', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvSetSpamFn, {
-					initialProps: [
-						{ ids, shouldReplaceHistory: false, folderId: FOLDERS.INBOX, onActionComplete }
-					]
+					initialProps: [{ ids, folderId: FOLDERS.INBOX, onActionComplete }]
 				});
 				await act(async () => {
 					functions.execute();

--- a/src/hooks/actions/use-conv-actions.ts
+++ b/src/hooks/actions/use-conv-actions.ts
@@ -112,7 +112,6 @@ export const useConvActions = ({
 	const unflagDescriptor = useConvSetUnflagDescriptor([conversation.id], conversation.flagged);
 	const markAsSpamDescriptor = useConvSetSpamDescriptor({
 		ids: [conversation.id],
-		shouldReplaceHistory,
 		folderId
 	});
 	const markAsNotSpamDescriptor = useConvSetNotSpamDescriptor({

--- a/src/hooks/actions/use-conv-actions.ts
+++ b/src/hooks/actions/use-conv-actions.ts
@@ -32,7 +32,6 @@ import { NormalizedConversation, UIActionAggregator, UIActionDescriptor } from '
 
 export type ConversationActionsArgumentType = {
 	conversation: NormalizedConversation;
-	shouldReplaceHistory?: boolean;
 };
 
 type ConversationActionsReturnType = {
@@ -57,8 +56,7 @@ type ConversationActionsReturnType = {
 };
 
 export const useConvActions = ({
-	conversation,
-	shouldReplaceHistory = false
+	conversation
 }: ConversationActionsArgumentType): ConversationActionsReturnType => {
 	const messages = useConversationMessages(conversation.id);
 	const firstConversationMessage =

--- a/src/hooks/actions/use-conv-actions.ts
+++ b/src/hooks/actions/use-conv-actions.ts
@@ -116,7 +116,6 @@ export const useConvActions = ({
 	});
 	const markAsNotSpamDescriptor = useConvSetNotSpamDescriptor({
 		ids: [conversation.id],
-		shouldReplaceHistory,
 		folderId
 	});
 

--- a/src/hooks/actions/use-conv-set-not-spam.tsx
+++ b/src/hooks/actions/use-conv-set-not-spam.tsx
@@ -16,14 +16,12 @@ import { ActionFn, UIActionDescriptor } from 'types/index.d';
 
 type ConvSetNotSpamFunctionsParameter = {
 	ids: Array<string>;
-	shouldReplaceHistory: boolean;
 	folderId: string;
 	onActionComplete?: (conversationsIds: Array<string>) => void;
 };
 
 export const useConvSetNotSpamFn = ({
 	ids,
-	shouldReplaceHistory,
 	folderId,
 	onActionComplete
 }: ConvSetNotSpamFunctionsParameter): ActionFn => {
@@ -71,34 +69,24 @@ export const useConvSetNotSpamFn = ({
 
 					onActionComplete && onActionComplete(ids);
 
-					if (currentConversation && shouldReplaceHistory && ids.includes(currentConversation.id)) {
+					if (currentConversation && ids.includes(currentConversation.id)) {
 						closeConversationPanel();
 					}
 				});
 			}
 		}, 3000);
-	}, [
-		closeConversationPanel,
-		createSnackbar,
-		currentConversation,
-		ids,
-		onActionComplete,
-		shouldReplaceHistory,
-		t
-	]);
+	}, [closeConversationPanel, createSnackbar, currentConversation, ids, onActionComplete, t]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
 };
 
 export const useConvSetNotSpamDescriptor = ({
 	ids,
-	shouldReplaceHistory,
 	folderId,
 	onActionComplete
 }: ConvSetNotSpamFunctionsParameter): UIActionDescriptor => {
 	const { canExecute, execute } = useConvSetNotSpamFn({
 		ids,
-		shouldReplaceHistory,
 		folderId,
 		onActionComplete
 	});

--- a/src/hooks/actions/use-conv-set-not-spam.tsx
+++ b/src/hooks/actions/use-conv-set-not-spam.tsx
@@ -7,9 +7,9 @@ import { useCallback, useMemo } from 'react';
 
 import { useSnackbar } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 
-import { ConversationActionsDescriptors, MAILS_ROUTE } from 'constants/index';
+import { useConversationDetailPanelControls } from '../../views/app/detail-panel/detail-panel-controls-hooks';
+import { ConversationActionsDescriptors } from 'constants/index';
 import { isSpam } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
 import { ActionFn, UIActionDescriptor } from 'types/index.d';
@@ -29,7 +29,7 @@ export const useConvSetNotSpamFn = ({
 }: ConvSetNotSpamFunctionsParameter): ActionFn => {
 	const createSnackbar = useSnackbar();
 	const [t] = useTranslation();
-	const navigate = useNavigate();
+	const { closeConversationPanel, currentConversation } = useConversationDetailPanelControls();
 
 	const canExecute = useCallback((): boolean => isSpam(folderId), [folderId]);
 
@@ -71,13 +71,21 @@ export const useConvSetNotSpamFn = ({
 
 					onActionComplete && onActionComplete(ids);
 
-					if (shouldReplaceHistory) {
-						navigate(`/${MAILS_ROUTE}/folder/${folderId}`, { replace: true });
+					if (currentConversation && shouldReplaceHistory && ids.includes(currentConversation.id)) {
+						closeConversationPanel();
 					}
 				});
 			}
 		}, 3000);
-	}, [createSnackbar, folderId, ids, navigate, onActionComplete, shouldReplaceHistory, t]);
+	}, [
+		closeConversationPanel,
+		createSnackbar,
+		currentConversation,
+		ids,
+		onActionComplete,
+		shouldReplaceHistory,
+		t
+	]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
 };

--- a/src/hooks/actions/use-conv-set-spam.tsx
+++ b/src/hooks/actions/use-conv-set-spam.tsx
@@ -7,9 +7,9 @@ import { useCallback, useMemo } from 'react';
 
 import { useSnackbar } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 
-import { ConversationActionsDescriptors, MAILS_ROUTE } from 'constants/index';
+import { useConversationDetailPanelControls } from '../../views/app/detail-panel/detail-panel-controls-hooks';
+import { ConversationActionsDescriptors } from 'constants/index';
 import { isDraft, isSpam } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
 import { ActionFn, UIActionDescriptor } from 'types/index.d';
@@ -35,7 +35,7 @@ export const useConvSetSpamFn = ({
 		[folderId]
 	);
 
-	const navigate = useNavigate();
+	const { closeConversationPanel, currentConversation } = useConversationDetailPanelControls();
 	const execute = useCallback((): void => {
 		let notCanceled = true;
 
@@ -72,13 +72,21 @@ export const useConvSetSpamFn = ({
 					}
 
 					onActionComplete && onActionComplete(ids);
-					if (shouldReplaceHistory) {
-						navigate(`/${MAILS_ROUTE}/folder/${folderId}`, { replace: true });
+					if (currentConversation && shouldReplaceHistory && ids.includes(currentConversation.id)) {
+						closeConversationPanel();
 					}
 				});
 			}
 		}, 3000);
-	}, [createSnackbar, folderId, ids, navigate, onActionComplete, shouldReplaceHistory, t]);
+	}, [
+		closeConversationPanel,
+		createSnackbar,
+		currentConversation,
+		ids,
+		onActionComplete,
+		shouldReplaceHistory,
+		t
+	]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
 };

--- a/src/hooks/actions/use-conv-set-spam.tsx
+++ b/src/hooks/actions/use-conv-set-spam.tsx
@@ -16,14 +16,12 @@ import { ActionFn, UIActionDescriptor } from 'types/index.d';
 
 type ConvSetSpamFunctionsParameter = {
 	ids: Array<string>;
-	shouldReplaceHistory: boolean;
 	folderId: string;
 	onActionComplete?: (conversationsIds: Array<string>) => void;
 };
 
 export const useConvSetSpamFn = ({
 	ids,
-	shouldReplaceHistory,
 	folderId,
 	onActionComplete
 }: ConvSetSpamFunctionsParameter): ActionFn => {
@@ -41,7 +39,7 @@ export const useConvSetSpamFn = ({
 
 		const infoSnackbar = (hideButton = false): void => {
 			createSnackbar({
-				key: `trash-${ids}`,
+				key: `spam-${ids}`,
 				replace: true,
 				severity: 'info',
 				label: t('messages.snackbar.marked_as_spam', 'You’ve marked this e-mail as Spam'),
@@ -62,7 +60,7 @@ export const useConvSetSpamFn = ({
 				}).then((res) => {
 					if ('Fault' in res) {
 						createSnackbar({
-							key: `trash-${ids}`,
+							key: `spam-${ids}`,
 							replace: true,
 							severity: 'error',
 							label: t('label.error_try_again', 'Something went wrong, please try again'),
@@ -72,34 +70,24 @@ export const useConvSetSpamFn = ({
 					}
 
 					onActionComplete && onActionComplete(ids);
-					if (currentConversation && shouldReplaceHistory && ids.includes(currentConversation.id)) {
+					if (currentConversation && ids.includes(currentConversation.id)) {
 						closeConversationPanel();
 					}
 				});
 			}
 		}, 3000);
-	}, [
-		closeConversationPanel,
-		createSnackbar,
-		currentConversation,
-		ids,
-		onActionComplete,
-		shouldReplaceHistory,
-		t
-	]);
+	}, [closeConversationPanel, createSnackbar, currentConversation, ids, onActionComplete, t]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
 };
 
 export const useConvSetSpamDescriptor = ({
 	ids,
-	shouldReplaceHistory,
 	folderId,
 	onActionComplete
 }: ConvSetSpamFunctionsParameter): UIActionDescriptor => {
 	const { canExecute, execute } = useConvSetSpamFn({
 		ids,
-		shouldReplaceHistory,
 		folderId,
 		onActionComplete
 	});

--- a/src/hooks/use-keyboard-shortcuts-for-conv.tsx
+++ b/src/hooks/use-keyboard-shortcuts-for-conv.tsx
@@ -56,14 +56,12 @@ export const useKeyboardShortcutsForConv = ({
 	);
 	const markConvAsSpam = useConvSetSpamFn({
 		ids: conversationIds,
-		folderId,
-		shouldReplaceHistory: true
+		folderId
 	});
 
 	const markConvAsNotSpam = useConvSetNotSpamFn({
 		ids: conversationIds,
-		folderId,
-		shouldReplaceHistory: true
+		folderId
 	});
 
 	const moveConvToTrash = useConvMoveToTrashFn({

--- a/src/views/app/folder-panel/conversations/conversation-list-item-wrapper.tsx
+++ b/src/views/app/folder-panel/conversations/conversation-list-item-wrapper.tsx
@@ -3,7 +3,6 @@ import React, { ReactNode, useMemo } from 'react';
 import { ContainerProps, Dropdown } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 
-import { useShouldReplaceHistory } from '../../../../hooks/use-should-replace-history';
 import { normalizeDropdownActionItem } from 'helpers/actions';
 import { useConvActions } from 'hooks/actions/use-conv-actions';
 import { useTagDropdownItem } from 'hooks/use-tag-dropdown-item';
@@ -31,7 +30,6 @@ export const ConversationListItemActionWrapper = ({
 	conversation: NormalizedConversation;
 }): React.JSX.Element => {
 	const [t] = useTranslation();
-	const shouldReplaceHistory = useShouldReplaceHistory(conversation);
 	const {
 		replyDescriptor,
 		replyAllDescriptor,
@@ -52,8 +50,7 @@ export const ConversationListItemActionWrapper = ({
 		previewOnSeparatedWindowDescriptor,
 		showOriginalDescriptor
 	} = useConvActions({
-		conversation,
-		shouldReplaceHistory
+		conversation
 	});
 	const hoverActions = useMemo(
 		() => [

--- a/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
+++ b/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
@@ -92,7 +92,6 @@ export const ConversationsMultipleSelectionActions = ({
 	});
 	const setAsSpam = useConvSetSpamDescriptor({
 		ids: selectedConversationsIds,
-		shouldReplaceHistory: false,
 		folderId,
 		onActionComplete
 	});

--- a/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
+++ b/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
@@ -97,7 +97,6 @@ export const ConversationsMultipleSelectionActions = ({
 	});
 	const setAsNotSpam = useConvSetNotSpamDescriptor({
 		ids: selectedConversationsIds,
-		shouldReplaceHistory: false,
 		folderId,
 		onActionComplete
 	});

--- a/src/views/tests/app-view-conversation-mode.test.tsx
+++ b/src/views/tests/app-view-conversation-mode.test.tsx
@@ -17,12 +17,10 @@ import {
 import { conversationTestUtilities } from '../../__test__/conversation/ui-interactions';
 import {
 	generateConversationFromAPI,
-	generateConvMessageFromAPI,
-	generateMessageFromAPI
+	generateConvMessageFromAPI
 } from '../../__test__/generators/api';
 import { mockLayoutStorage } from '../../__test__/layouts-utils';
-import { stubSearchMessages } from '../../__test__/message/api-stub';
-import { setupViewByConversation, setupViewByMessage } from '../../__test__/setup-utils';
+import { setupViewByConversation } from '../../__test__/setup-utils';
 import { MAILS_VIEW_LAYOUTS, MAILS_VIEW_SPLIT_LAYOUT_ORIENTATIONS } from '../../constants';
 import AppView from '../app-view';
 import { makeAllItemsVisible } from '../settings/filters/tests/test-utils';
@@ -30,7 +28,7 @@ import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 
-describe('AppView', () => {
+describe('AppView in conversation mode', () => {
 	beforeAll(() => {
 		configure({ asyncUtilTimeout: 5000 });
 	});
@@ -41,27 +39,6 @@ describe('AppView', () => {
 		});
 		populateFoldersStore();
 	});
-	describe('Messages', () => {
-		it('should display received messages on app load', async () => {
-			setupViewByMessage();
-			const incompleteMessage = generateMessageFromAPI({
-				id: '123',
-				su: 'Test message 1',
-				l: '2',
-				fr: 'Test m'
-			});
-			stubSearchMessages({ messages: [incompleteMessage] });
-			setupTest(<AppView />, {
-				initialEntries: [`/folder/2`]
-			});
-
-			// lazy components need longer timeout
-			await screen.findByTestId('message-item-123', {}, { timeout: 10000 });
-			makeAllItemsVisible();
-			expect(await screen.findByText('Test message 1')).toBeInTheDocument();
-		});
-	});
-
 	describe('Conversations', () => {
 		beforeEach(() => {
 			setupViewByConversation();

--- a/src/views/tests/app-view-conversation-mode.test.tsx
+++ b/src/views/tests/app-view-conversation-mode.test.tsx
@@ -6,7 +6,8 @@
 
 import React from 'react';
 
-import { configure, screen, waitFor, within } from '@testing-library/react';
+import { configure, within } from '@testing-library/react';
+import { FOLDERS } from '@zextras/carbonio-ui-commons';
 
 import { TESTID_SELECTORS } from '../../__test__/constants';
 import {
@@ -43,10 +44,12 @@ describe('AppView in conversation mode', () => {
 		beforeEach(() => {
 			setupViewByConversation();
 		});
+		const spamFolderId = `${FOLDERS.SPAM}`;
+		const inboxFolderId = `${FOLDERS.INBOX}`;
 
 		describe('Trash conversation', () => {
 			it('should close panel when deleting conversation from Inbox', async () => {
-				const conversationMessages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
+				const conversationMessages = [generateConvMessageFromAPI({ l: inboxFolderId, id: '1' })];
 				const conversation = generateConversationFromAPI({
 					id: '123',
 					m: conversationMessages
@@ -56,7 +59,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversation({ conversation });
 				stubGetConversation({ conversation });
 				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/2/conversation/123`]
+					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
 				});
 
 				const conversation1Ui = conversationTestUtilities('123');
@@ -73,8 +76,10 @@ describe('AppView in conversation mode', () => {
 			});
 
 			it('should not close the panel when deleting a different conversation', async () => {
-				const conversation1Messages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
-				const conversation2Messages = [generateConvMessageFromAPI({ l: '2', id: '2' })];
+				const conversation1Messages = [generateConvMessageFromAPI({ l: inboxFolderId, id: '1' })];
+				const conversation2Messages = [
+					generateConvMessageFromAPI({ l: inboxFolderId, id: inboxFolderId })
+				];
 
 				const conversation1 = generateConversationFromAPI({
 					id: '123',
@@ -89,7 +94,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversation({ conversation: conversation1 });
 				stubGetConversation({ conversation: conversation1 });
 				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/2/conversation/123`]
+					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
 				});
 				const conversation1Ui = conversationTestUtilities('123');
 				const conversation2Ui = conversationTestUtilities('456');
@@ -121,7 +126,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversation({ conversation });
 				stubGetConversation({ conversation });
 				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/2/conversation/123`]
+					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
 				});
 
 				const conversation1Ui = conversationTestUtilities('123');
@@ -134,7 +139,6 @@ describe('AppView in conversation mode', () => {
 				await user.click(markAsSpamAction);
 				await conversation1Ui.checkPanelClosed();
 			});
-
 			it('should not close the detail panel for opened conversation when marking a different conversation as spam', async () => {
 				const conversation1Messages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
 				const conversation2Messages = [generateConvMessageFromAPI({ l: '2', id: '2' })];
@@ -152,14 +156,13 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversation({ conversation: conversation1 });
 				stubGetConversation({ conversation: conversation1 });
 				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/2/conversation/123`]
+					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
 				});
 				const openedConversation = conversationTestUtilities('123');
 				const otherConversation = conversationTestUtilities('456');
 
 				await openedConversation.checkPanelOpen();
 
-				// mark as spam conversation 2 which is not opened in the detail panel
 				makeAllItemsVisible();
 				const contextMenuOfOtherConversation =
 					await otherConversation.openConversationContextMenu(user);
@@ -170,12 +173,70 @@ describe('AppView in conversation mode', () => {
 				await user.click(markAsSpamAction);
 
 				createSoapAPIInterceptor('ConvAction');
-				await screen.findByText('You’ve marked this e-mail as Spam');
-				await waitFor(() => {
-					expect(screen.queryByText('You’ve marked this e-mail as Spam')).not.toBeInTheDocument();
+				await otherConversation.snackbars.seeConversationMovedToSpam({ status: 'open' });
+				await otherConversation.snackbars.seeConversationMovedToSpam({ status: 'closed' });
+				await openedConversation.checkPanelOpen();
+			});
+		});
+
+		describe('Not Spam', () => {
+			it('should close detail panel when marking opened conversation as not spam from Spam', async () => {
+				const conversationMessages = [generateConvMessageFromAPI({ l: spamFolderId, id: '1' })];
+				const conversation = generateConversationFromAPI({
+					id: '123',
+					m: conversationMessages
+				});
+				stubSearchConversations({ conversations: [conversation] });
+				stubSearchConversation({ conversation });
+				stubGetConversation({ conversation });
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/${spamFolderId}/conversation/123`]
 				});
 
-				// check detail panel for opened Conversation is still open
+				const conversation1Ui = conversationTestUtilities('123');
+				await conversation1Ui.findConversationInList();
+				await conversation1Ui.checkPanelOpen();
+				makeAllItemsVisible();
+				const contextMenu = await conversation1Ui.openConversationContextMenu(user);
+				const notSpamAction = await within(contextMenu).findByText('Not spam');
+				createSoapAPIInterceptor('ConvAction');
+				await user.click(notSpamAction);
+				await conversation1Ui.checkPanelClosed();
+			});
+			it('should not close the detail panel for opened conversation when marking a different conversation as not spam', async () => {
+				const conversation1Messages = [generateConvMessageFromAPI({ l: spamFolderId, id: '1' })];
+				const conversation2Messages = [generateConvMessageFromAPI({ l: spamFolderId, id: '2' })];
+
+				const conversation1 = generateConversationFromAPI({
+					id: '123',
+					m: conversation1Messages
+				});
+				const conversation2 = generateConversationFromAPI({
+					id: '456',
+					m: conversation2Messages
+				});
+
+				stubSearchConversations({ conversations: [conversation1, conversation2] });
+				stubSearchConversation({ conversation: conversation1 });
+				stubGetConversation({ conversation: conversation1 });
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/${spamFolderId}/conversation/123`]
+				});
+				const openedConversation = conversationTestUtilities('123');
+				const otherConversation = conversationTestUtilities('456');
+
+				await openedConversation.checkPanelOpen();
+
+				makeAllItemsVisible();
+				const contextMenuOfOtherConversation =
+					await otherConversation.openConversationContextMenu(user);
+				const notSpamAction = await within(contextMenuOfOtherConversation).findByText('Not spam');
+
+				await user.click(notSpamAction);
+
+				createSoapAPIInterceptor('ConvAction');
+				await otherConversation.snackbars.seeConversationNotSpamAnymore({ status: 'open' });
+				await otherConversation.snackbars.seeConversationNotSpamAnymore({ status: 'closed' });
 				await openedConversation.checkPanelOpen();
 			});
 		});

--- a/src/views/tests/app-view-conversation-mode.test.tsx
+++ b/src/views/tests/app-view-conversation-mode.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 
-import { configure, within } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 import { FOLDERS } from '@zextras/carbonio-ui-commons';
 
 import { TESTID_SELECTORS } from '../../__test__/constants';
@@ -25,14 +25,26 @@ import { setupViewByConversation } from '../../__test__/setup-utils';
 import { MAILS_VIEW_LAYOUTS, MAILS_VIEW_SPLIT_LAYOUT_ORIENTATIONS } from '../../constants';
 import AppView from '../app-view';
 import { makeAllItemsVisible } from '../settings/filters/tests/test-utils';
-import { setupTest } from '@test-setup';
+import { screen, setupTest, UserEvent } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 
-describe('AppView in conversation mode', () => {
-	beforeAll(() => {
-		configure({ asyncUtilTimeout: 5000 });
+const waitForLazySpinnerToDisappear = (): Promise<void> =>
+	waitFor(
+		() => {
+			expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+		},
+		{ timeout: 10000 }
+	);
+
+const setupAppView = async (atUrl: string): Promise<UserEvent> => {
+	const { user } = setupTest(<AppView />, {
+		initialEntries: [atUrl]
 	});
+	await waitForLazySpinnerToDisappear();
+	return user;
+};
+describe('AppView in conversation mode', () => {
 	beforeEach(() => {
 		mockLayoutStorage({
 			layout: MAILS_VIEW_LAYOUTS.SPLIT,
@@ -58,9 +70,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversations({ conversations: [conversation] });
 				stubSearchConversation({ conversation });
 				stubGetConversation({ conversation });
-				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
-				});
+				const user = await setupAppView(`/folder/${inboxFolderId}/conversation/123`);
 
 				const conversation1Ui = conversationTestUtilities('123');
 				await conversation1Ui.findConversationInList();
@@ -93,9 +103,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversations({ conversations: [conversation1, conversation2] });
 				stubSearchConversation({ conversation: conversation1 });
 				stubGetConversation({ conversation: conversation1 });
-				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
-				});
+				const user = await setupAppView(`/folder/${inboxFolderId}/conversation/123`);
 				const conversation1Ui = conversationTestUtilities('123');
 				const conversation2Ui = conversationTestUtilities('456');
 
@@ -125,10 +133,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversations({ conversations: [conversation] });
 				stubSearchConversation({ conversation });
 				stubGetConversation({ conversation });
-				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
-				});
-
+				const user = await setupAppView(`/folder/${inboxFolderId}/conversation/123`);
 				const conversation1Ui = conversationTestUtilities('123');
 				await conversation1Ui.findConversationInList();
 				await conversation1Ui.checkPanelOpen();
@@ -137,6 +142,8 @@ describe('AppView in conversation mode', () => {
 				const markAsSpamAction = await contextMenu.markAsSpam();
 				createSoapAPIInterceptor('ConvAction');
 				await user.click(markAsSpamAction);
+				await conversation1Ui.snackbars.seeConversationMovedToSpam({ status: 'open' });
+				await conversation1Ui.snackbars.seeConversationMovedToSpam({ status: 'closed' });
 				await conversation1Ui.checkPanelClosed();
 			});
 			it('should not close the detail panel for opened conversation when marking a different conversation as spam', async () => {
@@ -155,9 +162,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversations({ conversations: [conversation1, conversation2] });
 				stubSearchConversation({ conversation: conversation1 });
 				stubGetConversation({ conversation: conversation1 });
-				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/${inboxFolderId}/conversation/123`]
-				});
+				const user = await setupAppView(`/folder/${inboxFolderId}/conversation/123`);
 				const openedConversation = conversationTestUtilities('123');
 				const otherConversation = conversationTestUtilities('456');
 
@@ -185,9 +190,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversations({ conversations: [conversation] });
 				stubSearchConversation({ conversation });
 				stubGetConversation({ conversation });
-				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/${spamFolderId}/conversation/123`]
-				});
+				const user = await setupAppView(`/folder/${spamFolderId}/conversation/123`);
 
 				const conversation1Ui = conversationTestUtilities('123');
 				await conversation1Ui.findConversationInList();
@@ -197,6 +200,8 @@ describe('AppView in conversation mode', () => {
 				const notSpamAction = await contextMenu.notSpam();
 				createSoapAPIInterceptor('ConvAction');
 				await user.click(notSpamAction);
+				await conversation1Ui.snackbars.seeConversationNotSpamAnymore({ status: 'open' });
+				await conversation1Ui.snackbars.seeConversationNotSpamAnymore({ status: 'closed' });
 
 				await conversation1Ui.checkPanelClosed();
 			});
@@ -216,9 +221,7 @@ describe('AppView in conversation mode', () => {
 				stubSearchConversations({ conversations: [conversation1, conversation2] });
 				stubSearchConversation({ conversation: conversation1 });
 				stubGetConversation({ conversation: conversation1 });
-				const { user } = setupTest(<AppView />, {
-					initialEntries: [`/folder/${spamFolderId}/conversation/123`]
-				});
+				const user = await setupAppView(`/folder/${spamFolderId}/conversation/123`);
 				const openedConversation = conversationTestUtilities('123');
 				const otherConversation = conversationTestUtilities('456');
 

--- a/src/views/tests/app-view-conversation-mode.test.tsx
+++ b/src/views/tests/app-view-conversation-mode.test.tsx
@@ -134,7 +134,7 @@ describe('AppView in conversation mode', () => {
 				await conversation1Ui.checkPanelOpen();
 				makeAllItemsVisible();
 				const contextMenu = await conversation1Ui.openConversationContextMenu(user);
-				const markAsSpamAction = await within(contextMenu).findByText('Mark as spam');
+				const markAsSpamAction = await contextMenu.markAsSpam();
 				createSoapAPIInterceptor('ConvAction');
 				await user.click(markAsSpamAction);
 				await conversation1Ui.checkPanelClosed();
@@ -164,15 +164,11 @@ describe('AppView in conversation mode', () => {
 				await openedConversation.checkPanelOpen();
 
 				makeAllItemsVisible();
-				const contextMenuOfOtherConversation =
-					await otherConversation.openConversationContextMenu(user);
-				const markAsSpamAction = await within(contextMenuOfOtherConversation).findByText(
-					'Mark as spam'
-				);
-
+				const contextMenu = await otherConversation.openConversationContextMenu(user);
+				const markAsSpamAction = await contextMenu.markAsSpam();
+				createSoapAPIInterceptor('ConvAction');
 				await user.click(markAsSpamAction);
 
-				createSoapAPIInterceptor('ConvAction');
 				await otherConversation.snackbars.seeConversationMovedToSpam({ status: 'open' });
 				await otherConversation.snackbars.seeConversationMovedToSpam({ status: 'closed' });
 				await openedConversation.checkPanelOpen();
@@ -198,9 +194,10 @@ describe('AppView in conversation mode', () => {
 				await conversation1Ui.checkPanelOpen();
 				makeAllItemsVisible();
 				const contextMenu = await conversation1Ui.openConversationContextMenu(user);
-				const notSpamAction = await within(contextMenu).findByText('Not spam');
+				const notSpamAction = await contextMenu.notSpam();
 				createSoapAPIInterceptor('ConvAction');
 				await user.click(notSpamAction);
+
 				await conversation1Ui.checkPanelClosed();
 			});
 			it('should not close the detail panel for opened conversation when marking a different conversation as not spam', async () => {
@@ -228,13 +225,11 @@ describe('AppView in conversation mode', () => {
 				await openedConversation.checkPanelOpen();
 
 				makeAllItemsVisible();
-				const contextMenuOfOtherConversation =
-					await otherConversation.openConversationContextMenu(user);
-				const notSpamAction = await within(contextMenuOfOtherConversation).findByText('Not spam');
-
+				const contextMenu = await otherConversation.openConversationContextMenu(user);
+				const notSpamAction = await contextMenu.notSpam();
+				createSoapAPIInterceptor('ConvAction');
 				await user.click(notSpamAction);
 
-				createSoapAPIInterceptor('ConvAction');
 				await otherConversation.snackbars.seeConversationNotSpamAnymore({ status: 'open' });
 				await otherConversation.snackbars.seeConversationNotSpamAnymore({ status: 'closed' });
 				await openedConversation.checkPanelOpen();

--- a/src/views/tests/app-view-message-mode.test.tsx
+++ b/src/views/tests/app-view-message-mode.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import React from 'react';
+
+import { configure, screen } from '@testing-library/react';
+
+import { generateMessageFromAPI } from '../../__test__/generators/api';
+import { mockLayoutStorage } from '../../__test__/layouts-utils';
+import { stubSearchMessages } from '../../__test__/message/api-stub';
+import { setupViewByMessage } from '../../__test__/setup-utils';
+import { MAILS_VIEW_LAYOUTS, MAILS_VIEW_SPLIT_LAYOUT_ORIENTATIONS } from '../../constants';
+import AppView from '../app-view';
+import { makeAllItemsVisible } from '../settings/filters/tests/test-utils';
+import { setupTest } from '@test-setup';
+import { populateFoldersStore } from '@test-utils/store/folders';
+
+describe('AppView in message mode', () => {
+	beforeAll(() => {
+		configure({ asyncUtilTimeout: 5000 });
+	});
+	beforeEach(() => {
+		mockLayoutStorage({
+			layout: MAILS_VIEW_LAYOUTS.SPLIT,
+			splitOrientation: MAILS_VIEW_SPLIT_LAYOUT_ORIENTATIONS.VERTICAL
+		});
+		populateFoldersStore();
+	});
+	describe('Messages', () => {
+		it('should display received messages on app load', async () => {
+			setupViewByMessage();
+			const incompleteMessage = generateMessageFromAPI({
+				id: '123',
+				su: 'Test message 1',
+				l: '2',
+				fr: 'Test m'
+			});
+			stubSearchMessages({ messages: [incompleteMessage] });
+			setupTest(<AppView />, {
+				initialEntries: [`/folder/2`]
+			});
+
+			// lazy components need longer timeout
+			await screen.findByTestId('message-item-123', {}, { timeout: 10000 });
+			makeAllItemsVisible();
+			expect(await screen.findByText('Test message 1')).toBeInTheDocument();
+		});
+	});
+});

--- a/src/views/tests/app-view.test.tsx
+++ b/src/views/tests/app-view.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 
-import { screen, within } from '@testing-library/react';
+import { configure, screen, waitFor, within } from '@testing-library/react';
 
 import { TESTID_SELECTORS } from '../../__test__/constants';
 import {
@@ -31,6 +31,9 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { populateFoldersStore } from '@test-utils/store/folders';
 
 describe('AppView', () => {
+	beforeAll(() => {
+		configure({ asyncUtilTimeout: 5000 });
+	});
 	beforeEach(() => {
 		mockLayoutStorage({
 			layout: MAILS_VIEW_LAYOUTS.SPLIT,
@@ -63,67 +66,141 @@ describe('AppView', () => {
 		beforeEach(() => {
 			setupViewByConversation();
 		});
-		it('should close panel when deleting conversation from Inbox', async () => {
-			const conversationMessages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
-			const conversation = generateConversationFromAPI({
-				id: '123',
-				m: conversationMessages
+
+		describe('Trash conversation', () => {
+			it('should close panel when deleting conversation from Inbox', async () => {
+				const conversationMessages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
+				const conversation = generateConversationFromAPI({
+					id: '123',
+					m: conversationMessages
+				});
+
+				stubSearchConversations({ conversations: [conversation] });
+				stubSearchConversation({ conversation });
+				stubGetConversation({ conversation });
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/2/conversation/123`]
+				});
+
+				const conversation1Ui = conversationTestUtilities('123');
+				await conversation1Ui.findConversationInList();
+				await conversation1Ui.checkPanelOpen();
+				makeAllItemsVisible();
+				const { hoverActionsContainer } = await conversation1Ui.hoverConversationInList(user);
+				const deleteConversationButton = await within(hoverActionsContainer).findByTestId(
+					TESTID_SELECTORS.icons.trash
+				);
+				createSoapAPIInterceptor('ConvAction');
+				await user.click(deleteConversationButton);
+				await conversation1Ui.checkPanelClosed();
 			});
 
-			stubSearchConversations({ conversations: [conversation] });
-			stubSearchConversation({ conversation });
-			stubGetConversation({ conversation });
-			const { user } = setupTest(<AppView />, {
-				initialEntries: [`/folder/2/conversation/123`]
-			});
+			it('should not close the panel when deleting a different conversation', async () => {
+				const conversation1Messages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
+				const conversation2Messages = [generateConvMessageFromAPI({ l: '2', id: '2' })];
 
-			const conversation1Ui = conversationTestUtilities('123');
-			await conversation1Ui.findConversationInList();
-			await conversation1Ui.checkPanelOpen();
-			makeAllItemsVisible();
-			const { hoverActionsContainer } = await conversation1Ui.hoverConversationInList(user);
-			const deleteConversationButton = await within(hoverActionsContainer).findByTestId(
-				TESTID_SELECTORS.icons.trash
-			);
-			createSoapAPIInterceptor('ConvAction');
-			await user.click(deleteConversationButton);
-			await conversation1Ui.checkPanelClosed();
+				const conversation1 = generateConversationFromAPI({
+					id: '123',
+					m: conversation1Messages
+				});
+				const conversation2 = generateConversationFromAPI({
+					id: '456',
+					m: conversation2Messages
+				});
+
+				stubSearchConversations({ conversations: [conversation1, conversation2] });
+				stubSearchConversation({ conversation: conversation1 });
+				stubGetConversation({ conversation: conversation1 });
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/2/conversation/123`]
+				});
+				const conversation1Ui = conversationTestUtilities('123');
+				const conversation2Ui = conversationTestUtilities('456');
+
+				await conversation1Ui.checkPanelOpen();
+
+				// delete conversation 2 which is not opened in the panel
+				makeAllItemsVisible();
+				const { hoverActionsContainer } = await conversation2Ui.hoverConversationInList(user);
+				const deleteConversationButton = await within(hoverActionsContainer).findByTestId(
+					TESTID_SELECTORS.icons.trash
+				);
+				createSoapAPIInterceptor('ConvAction');
+				await user.click(deleteConversationButton);
+				// check panel for conversation1 is still open
+				await conversation1Ui.checkPanelOpen();
+			});
 		});
 
-		it('should not close the panel when deleting a different conversation', async () => {
-			const conversation1Messages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
-			const conversation2Messages = [generateConvMessageFromAPI({ l: '2', id: '2' })];
+		describe('Mark as Spam', () => {
+			it('should close detail panel when marking opened conversation as spam from Inbox', async () => {
+				const conversationMessages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
+				const conversation = generateConversationFromAPI({
+					id: '123',
+					m: conversationMessages
+				});
 
-			const conversation1 = generateConversationFromAPI({
-				id: '123',
-				m: conversation1Messages
+				stubSearchConversations({ conversations: [conversation] });
+				stubSearchConversation({ conversation });
+				stubGetConversation({ conversation });
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/2/conversation/123`]
+				});
+
+				const conversation1Ui = conversationTestUtilities('123');
+				await conversation1Ui.findConversationInList();
+				await conversation1Ui.checkPanelOpen();
+				makeAllItemsVisible();
+				const contextMenu = await conversation1Ui.openConversationContextMenu(user);
+				const markAsSpamAction = await within(contextMenu).findByText('Mark as spam');
+				createSoapAPIInterceptor('ConvAction');
+				await user.click(markAsSpamAction);
+				await conversation1Ui.checkPanelClosed();
 			});
-			const conversation2 = generateConversationFromAPI({
-				id: '456',
-				m: conversation2Messages
+
+			it('should not close the detail panel for opened conversation when marking a different conversation as spam', async () => {
+				const conversation1Messages = [generateConvMessageFromAPI({ l: '2', id: '1' })];
+				const conversation2Messages = [generateConvMessageFromAPI({ l: '2', id: '2' })];
+
+				const conversation1 = generateConversationFromAPI({
+					id: '123',
+					m: conversation1Messages
+				});
+				const conversation2 = generateConversationFromAPI({
+					id: '456',
+					m: conversation2Messages
+				});
+
+				stubSearchConversations({ conversations: [conversation1, conversation2] });
+				stubSearchConversation({ conversation: conversation1 });
+				stubGetConversation({ conversation: conversation1 });
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/2/conversation/123`]
+				});
+				const openedConversation = conversationTestUtilities('123');
+				const otherConversation = conversationTestUtilities('456');
+
+				await openedConversation.checkPanelOpen();
+
+				// mark as spam conversation 2 which is not opened in the detail panel
+				makeAllItemsVisible();
+				const contextMenuOfOtherConversation =
+					await otherConversation.openConversationContextMenu(user);
+				const markAsSpamAction = await within(contextMenuOfOtherConversation).findByText(
+					'Mark as spam'
+				);
+
+				await user.click(markAsSpamAction);
+
+				createSoapAPIInterceptor('ConvAction');
+				await screen.findByText('You’ve marked this e-mail as Spam');
+				await waitFor(() => {
+					expect(screen.queryByText('You’ve marked this e-mail as Spam')).not.toBeInTheDocument();
+				});
+
+				// check detail panel for opened Conversation is still open
+				await openedConversation.checkPanelOpen();
 			});
-
-			stubSearchConversations({ conversations: [conversation1, conversation2] });
-			stubSearchConversation({ conversation: conversation1 });
-			stubGetConversation({ conversation: conversation1 });
-			const { user } = setupTest(<AppView />, {
-				initialEntries: [`/folder/2/conversation/123`]
-			});
-			const conversation1Ui = conversationTestUtilities('123');
-			const conversation2Ui = conversationTestUtilities('456');
-
-			await conversation1Ui.checkPanelOpen();
-
-			// delete conversation 2 which is not opened in the panel
-			makeAllItemsVisible();
-			const { hoverActionsContainer } = await conversation2Ui.hoverConversationInList(user);
-			const deleteConversationButton = await within(hoverActionsContainer).findByTestId(
-				TESTID_SELECTORS.icons.trash
-			);
-			createSoapAPIInterceptor('ConvAction');
-			await user.click(deleteConversationButton);
-			// check panel for conversation1 is still open
-			await conversation1Ui.checkPanelOpen();
 		});
 	});
 });


### PR DESCRIPTION
Changes:
- use panel controls hook to conversation mark as spam action
- use panel controls hook to conversation not spam action
- removed `useShouldReplaceHistory` and `shouldReplaceHistory` from conversation actions -> shift focus from technical implementation to behavior

We focused only on conversations actions.
We can use the same hook also on:
- messages actions
- list click (open panel)
- detail panel close button

However we think it's best to work on them in separate PRs to reduce scope/context