### PR TITLE
chore: composer stylesheet URL resolution causing invalid CSS request

### DIFF
--- a/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/parts/rich-text-editor-container.tsx
@@ -255,6 +255,7 @@ export const RichTextEditorContainer = ({
 			font_size_formats: fontSizesOptionsToString,
 			font_family_formats: fontsOptionsToString,
 			preview_styles: false,
+			content_css: false,
 			content_style: `${TINYMCE_BASE_CONTENT_STYLES}\n\t\t${userPreferenceStyles}`,
 			style_formats: [
 				// Headers


### PR DESCRIPTION
Prevent Composer from loading document base path as content css 
```
<link rel="stylesheet" href="/carbonio/mails/folder/">
```

this causes the following error in console:

```
Refused to apply style from 'https://localhost/carbonio/mails/folder/' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.
```

In tinyMCE init option default value of `content_css` is `true` (load built in content_css). When user creates composer on URL like `https://localhost/carbonio/mails/folder/`, TinyMCE tries to resolve CSS URLs relative to the current document URL. 

passing `content_css: false` prevents this behavior.

**This has no impact on functionality** it is just a cleanup and one less request to proxy server ;) 