### PR TITLE
feat: [CO-2871] Add "All" Default in Mails Filter Dropdown

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -531,6 +531,7 @@ export const SORTING_OPTIONS = {
 } as const;
 
 export const FILTER_OPTIONS = {
+	all: { label: 'all', value: undefined },
 	unread: { label: 'unread', value: 'read' },
 	important: { label: 'important', value: 'priority' },
 	flagged: { label: 'flagged', value: 'flag' },

--- a/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
@@ -29,8 +29,13 @@ import {
 	updateSortAndFilterSettings
 } from '../../../../helpers/sorting';
 
-type Option = {
+type SortOption = {
 	value: string;
+	label: string;
+};
+
+type FilterOption = {
+	value: string | undefined;
 	label: string;
 };
 
@@ -52,7 +57,7 @@ const useListHeaderDropdownItems = ({ folderId }: { folderId: string }): Dropdow
 		[folderId, prefSortOrder]
 	);
 
-	const sortingOptions: Option[] = useMemo(
+	const sortingOptions: SortOption[] = useMemo(
 		() => [
 			SORTING_OPTIONS.date,
 			SORTING_OPTIONS.subject,
@@ -62,8 +67,9 @@ const useListHeaderDropdownItems = ({ folderId }: { folderId: string }): Dropdow
 		[folderId]
 	);
 
-	const filteringOptions: Option[] = useMemo(
+	const filteringOptions: FilterOption[] = useMemo(
 		() => [
+			FILTER_OPTIONS.all,
 			FILTER_OPTIONS.unread,
 			FILTER_OPTIONS.important,
 			FILTER_OPTIONS.flagged,
@@ -130,41 +136,58 @@ const useListHeaderDropdownItems = ({ folderId }: { folderId: string }): Dropdow
 
 	const filterItems: DropdownItem[] = useMemo(
 		() =>
-			filteringOptions.map(({ value, label }) => ({
-				id: `filter-${value}`,
-				label: capitalize(t(`sorting_dropdown.${label}`, label)),
-				selected: filterType === value,
-				onClick: (): void => {
-					updateSortAndFilterSettings({
-						folderId,
-						prefSortOrder,
-						sortType,
-						sortDirection,
-						filter: value
-					});
-				},
-				icon: getRadioIcon(filterType, value)
-			})),
+			filteringOptions.map(({ value, label }) => {
+				const isDefaultFilter = value === undefined;
+				const isSelected = (filterType === undefined && isDefaultFilter) || filterType === value;
+				const translatedLabel = capitalize(t(`sorting_dropdown.${label}`, label));
+				const labelWithDefault = isDefaultFilter
+					? `${translatedLabel} (${t('sorting_dropdown.default', 'Default')})`
+					: translatedLabel;
+
+				return {
+					id: `filter-${value ?? 'all'}`,
+					label: labelWithDefault,
+					selected: isSelected,
+					onClick: (): void => {
+						updateSortAndFilterSettings({
+							folderId,
+							prefSortOrder,
+							sortType,
+							sortDirection,
+							filter: value
+						});
+					},
+					icon: getRadioIcon(isSelected ? 'selected' : 'not-selected', 'selected')
+				};
+			}),
 		[filterType, sortDirection, sortType, filteringOptions, folderId, prefSortOrder, t]
 	);
 
 	const sortItems: DropdownItem[] = useMemo(
 		() =>
-			sortingOptions.map(({ value, label }) => ({
-				id: `sort-${value}`,
-				label: capitalize(t(`sorting_dropdown.${label}`, label)),
-				selected: sortType === value,
-				onClick: (): void => {
-					updateSortAndFilterSettings({
-						folderId,
-						prefSortOrder,
-						sortType: value,
-						sortDirection,
-						filter: filterType
-					});
-				},
-				icon: getRadioIcon(sortType, value)
-			})),
+			sortingOptions.map(({ value, label }) => {
+				const isDefaultSort = value === 'date';
+				const translatedLabel = capitalize(t(`sorting_dropdown.${label}`, label));
+				const labelWithDefault = isDefaultSort
+					? `${translatedLabel} (${t('sorting_dropdown.default', 'Default')})`
+					: translatedLabel;
+
+				return {
+					id: `sort-${value}`,
+					label: labelWithDefault,
+					selected: sortType === value,
+					onClick: (): void => {
+						updateSortAndFilterSettings({
+							folderId,
+							prefSortOrder,
+							sortType: value,
+							sortDirection,
+							filter: filterType
+						});
+					},
+					icon: getRadioIcon(sortType, value)
+				};
+			}),
 		[filterType, sortDirection, sortType, folderId, prefSortOrder, sortingOptions, t]
 	);
 

--- a/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
@@ -245,6 +245,7 @@ export const SortAndFilterButtonComponent = ({
 			placement="top"
 		>
 			<Dropdown
+				disableAutoFocus
 				items={dropdownItems}
 				multiple
 				itemPaddingBetween="large"

--- a/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
@@ -36,8 +36,10 @@ const getTranslatedLabelFromValue = (
 	return value;
 };
 
-const isValid = (val: string | undefined, options: Record<string, { value: string }>): boolean =>
-	!!val && Object.values(options).some((opt) => opt.value === val);
+const isValid = (
+	val: string | undefined,
+	options: Record<string, { value: string | undefined }>
+): boolean => !!val && Object.values(options).some((opt) => opt.value === val);
 
 export const SortAndFilterHeaderComponent = ({
 	folderId

--- a/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-header-component.tsx
@@ -138,7 +138,7 @@ export const SortAndFilterHeaderComponent = ({
 				<Padding right="medium" />
 				<Tooltip
 					placement="top"
-					label={t('label.reset_to_sort_by_date', 'Reset to “Sort by: Date”')}
+					label={t('label.reset_sort_and_filter_to_default', 'Reset to default')}
 				>
 					<Button
 						type="ghost"

--- a/src/views/app/folder-panel/parts/tests/breadcrumbs.test.tsx
+++ b/src/views/app/folder-panel/parts/tests/breadcrumbs.test.tsx
@@ -126,11 +126,16 @@ describe('Breadcrumbs sorting', () => {
 		if (sortIcon) await user.click(sortIcon);
 		expect(await screen.findByTestId(dropdownRegex)).toBeInTheDocument();
 		forEach(sortingOptionsWithoutSize, (option) => {
-			if (option.label !== SORTING_OPTIONS.to.label)
+			if (option.label !== SORTING_OPTIONS.to.label) {
+				// Date option has "(Default)" suffix
+				const expectedText =
+					option.label === SORTING_OPTIONS.date.label
+						? `${capitalize(option.label)} (Default)`
+						: capitalize(option.label);
 				expect(
-					within(screen.getByTestId(dropdownRegex)).getByText(capitalize(option.label))
+					within(screen.getByTestId(dropdownRegex)).getByText(expectedText)
 				).toBeInTheDocument();
-			else {
+			} else {
 				const excludedOptionRegexPattern = new RegExp(
 					`sorting_dropdown.${SORTING_OPTIONS.to.label}`,
 					'i'
@@ -153,11 +158,16 @@ describe('Breadcrumbs sorting', () => {
 		if (sortIcon) await user.click(sortIcon);
 		expect(await screen.findByTestId(dropdownRegex)).toBeInTheDocument();
 		forEach(sortingOptionsWithoutSize, (option) => {
-			if (option.label !== SORTING_OPTIONS.from.label)
+			if (option.label !== SORTING_OPTIONS.from.label) {
+				// Date option has "(Default)" suffix
+				const expectedText =
+					option.label === SORTING_OPTIONS.date.label
+						? `${capitalize(option.label)} (Default)`
+						: capitalize(option.label);
 				expect(
-					within(screen.getByTestId(dropdownRegex)).getByText(capitalize(option.label))
+					within(screen.getByTestId(dropdownRegex)).getByText(expectedText)
 				).toBeInTheDocument();
-			else {
+			} else {
 				const excludedOptionRegexPattern = new RegExp(
 					`sorting_dropdown.${SORTING_OPTIONS.from.value}`,
 					'i'

--- a/src/views/app/folder-panel/parts/tests/sort-and-filter-button-component.test.tsx
+++ b/src/views/app/folder-panel/parts/tests/sort-and-filter-button-component.test.tsx
@@ -15,6 +15,11 @@ import { generateSettings } from '@test-utils/settings/settings-generator';
 
 const FOLDER_ID = '123';
 
+vi.mock('@zextras/carbonio-ui-soap-lib', () => ({
+	...vi.importActual('@zextras/carbonio-ui-soap-lib'),
+	soapFetchV2: vi.fn().mockResolvedValue({ Body: {} })
+}));
+
 describe('Sort and filter button component', () => {
 	it('should render a dropdown wrapper with a visible button', async () => {
 		setupTest(<SortAndFilterButtonComponent folderId={FOLDER_ID} />);
@@ -33,18 +38,19 @@ describe('Sort and filter button component', () => {
 		await user.click(screen.getByTestId('icon: AzListOutline'));
 
 		expect(screen.getByTestId('dropdown-popper-list')).toBeVisible();
-		await user.click(screen.getByText('Important'));
+		await user.click(screen.getByText('All (Default)'));
 		expect(screen.getByTestId('dropdown-popper-list')).toBeVisible();
 	});
 
 	const FILTER_OPTION = [
+		{ label: 'All (Default)', value: undefined },
 		{ label: 'Unread', value: 'read' },
 		{ label: 'Important', value: 'priority' },
 		{ label: 'Flagged', value: 'flag' },
 		{ label: 'Attachment', value: 'attach' }
 	];
 	const SORT_OPTION = [
-		{ label: 'Date', value: 'date' },
+		{ label: 'Date (Default)', value: 'date' },
 		{ label: 'Subject', value: 'subj' },
 		{ label: 'From', value: 'name' },
 		{ label: 'Size', value: 'size' }
@@ -78,13 +84,15 @@ describe('Sort and filter button component', () => {
 			await user.click(screen.getByTestId(icon));
 			await user.click(screen.getByText(filterLabel));
 
+			const expectedPref = filterValue
+				? `${FOLDER_ID}:${sortValue}-${directionValue}-${filterValue}`
+				: `${FOLDER_ID}:${sortValue}-${directionValue}`;
+
 			expect(soapFetchV2).toHaveBeenCalledWith(
 				'ModifyPrefs',
 				expect.objectContaining({
 					_attrs: {
-						zimbraPrefSortOrder: expect.stringContaining(
-							`${FOLDER_ID}:${sortValue}-${directionValue}-${filterValue}`
-						)
+						zimbraPrefSortOrder: expect.stringContaining(expectedPref)
 					}
 				})
 			);

--- a/src/views/app/folder-panel/parts/tests/sort-and-filter-header.test.tsx
+++ b/src/views/app/folder-panel/parts/tests/sort-and-filter-header.test.tsx
@@ -82,4 +82,18 @@ describe('Sort and Filter Header Component', () => {
 
 		expect(screen.queryByTestId('sorting-options-container')).not.toBeInTheDocument();
 	});
+
+	it('should display correct tooltip on reset button', async () => {
+		(parseMessageSortingOptions as Mock).mockReturnValue({
+			sortType: SORTING_OPTIONS.subject.value,
+			filterType: FILTER_OPTIONS.unread.value
+		});
+		const { user } = setupTest(<SortAndFilterHeaderComponent folderId={FOLDER_ID} />);
+
+		const resetButton = screen.getByRole('button', { name: /Reset/i });
+
+		await user.hover(resetButton);
+
+		expect(await screen.findByText('Reset to default')).toBeInTheDocument();
+	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,7 +84,6 @@ export default defineConfig({
 						'**/app.test.tsx',
 						'**/use-conversations-list-by-folder.test.ts',
 						'**/certificate-utils.test.ts',
-						'**/sort-and-filter-button-component.test.tsx',
 						'**/recover-messages.test.tsx',
 						'**/rich-text-editor-container.test.tsx',
 						'**/share-folder-actions.test.ts',


### PR DESCRIPTION
Added an "All" default option in the Mails filter dropdown and marked default options with "(Default)" indicators in both filtering and sorting menus. 

see proposed solution for CO-2871 for new weblate keys.