### PR TITLE
feat: [CO-3104] remove Undo option when marking or unmarking conversations as Spam

### DIFF
--- a/src/__test__/conversation/ui-interactions.ts
+++ b/src/__test__/conversation/ui-interactions.ts
@@ -46,7 +46,7 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 		}: {
 			status: 'open' | 'closed';
 		}): Promise<void> => {
-			const spamMessage = 'You’ve marked this e-mail as Spam';
+			const spamMessage = 'Conversation marked as Spam';
 			if (status === 'open') {
 				await screen.findByText(spamMessage);
 			} else {
@@ -61,7 +61,7 @@ export const conversationTestUtilities = (id: string): ConversationTestUtilities
 		}: {
 			status: 'open' | 'closed';
 		}): Promise<void> => {
-			const notSpamMessage = 'You’ve marked this e-mail as Not Spam';
+			const notSpamMessage = 'Conversation marked as Not Spam';
 			if (status === 'open') {
 				await screen.findByText(notSpamMessage);
 			} else {

--- a/src/hooks/actions/tests/use-conv-set-not-spam.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-not-spam.test.ts
@@ -112,9 +112,8 @@ describe('useConvSetNotSpam', () => {
 					initialProps: [{ ids, folderId: FOLDERS.SPAM }]
 				});
 
-				act(() => {
+				await act(async () => {
 					functions.execute();
-					vi.advanceTimersByTime(TIMEOUTS.SET_AS_SPAM);
 				});
 
 				const requestParameter = await apiInterceptor;
@@ -135,7 +134,6 @@ describe('useConvSetNotSpam', () => {
 				});
 				await act(async () => {
 					functions.execute();
-					vi.advanceTimersByTime(TIMEOUTS.SET_AS_SPAM);
 				});
 
 				expect(onActionComplete).toHaveBeenCalledWith(ids);

--- a/src/hooks/actions/tests/use-conv-set-spam.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-spam.test.ts
@@ -109,9 +109,8 @@ describe('useConvSetSpam', () => {
 					initialProps: [{ ids, folderId: FOLDERS.INBOX }]
 				});
 
-				act(() => {
+				await act(async () => {
 					functions.execute();
-					vi.advanceTimersByTime(TIMEOUTS.SET_AS_SPAM);
 				});
 
 				const requestParameter = await apiInterceptor;
@@ -132,7 +131,6 @@ describe('useConvSetSpam', () => {
 				});
 				await act(async () => {
 					functions.execute();
-					vi.advanceTimersByTime(TIMEOUTS.SET_AS_SPAM);
 				});
 
 				expect(onActionComplete).toHaveBeenCalledWith(ids);

--- a/src/hooks/actions/use-conv-set-not-spam.tsx
+++ b/src/hooks/actions/use-conv-set-not-spam.tsx
@@ -57,7 +57,7 @@ export const useConvSetNotSpamFn = ({
 				closeConversationPanel();
 			}
 			createSnackbar({
-				key: `trash-${ids}`,
+				key: `not-spam-${ids}`,
 				replace: true,
 				severity: 'info',
 				label: t(

--- a/src/hooks/actions/use-conv-set-not-spam.tsx
+++ b/src/hooks/actions/use-conv-set-not-spam.tsx
@@ -32,6 +32,9 @@ export const useConvSetNotSpamFn = ({
 	const canExecute = useCallback((): boolean => isSpam(folderId), [folderId]);
 
 	const execute = useCallback((): void => {
+		if (!canExecute()) {
+			return;
+		}
 		convActionEmailStoreAction({
 			operation: '!spam',
 			ids
@@ -57,12 +60,23 @@ export const useConvSetNotSpamFn = ({
 				key: `trash-${ids}`,
 				replace: true,
 				severity: 'info',
-				label: t('messages.snackbar.marked_as_non_spam', "You've marked this e-mail as Not Spam"),
+				label: t(
+					'messages.snackbar.conversation_marked_as_non_spam',
+					'Conversation marked as Not Spam'
+				),
 				autoHideTimeout: 3000,
 				hideButton: true
 			});
 		});
-	}, [closeConversationPanel, createSnackbar, currentConversation, ids, onActionComplete, t]);
+	}, [
+		canExecute,
+		closeConversationPanel,
+		createSnackbar,
+		currentConversation,
+		ids,
+		onActionComplete,
+		t
+	]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
 };

--- a/src/hooks/actions/use-conv-set-not-spam.tsx
+++ b/src/hooks/actions/use-conv-set-not-spam.tsx
@@ -32,49 +32,36 @@ export const useConvSetNotSpamFn = ({
 	const canExecute = useCallback((): boolean => isSpam(folderId), [folderId]);
 
 	const execute = useCallback((): void => {
-		let notCanceled = true;
+		convActionEmailStoreAction({
+			operation: '!spam',
+			ids
+		}).then((res) => {
+			if ('Fault' in res) {
+				createSnackbar({
+					key: `trash-${ids}`,
+					replace: true,
+					severity: 'error',
+					label: t('label.error_try_again', 'Something went wrong, please try again'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+				return;
+			}
 
-		const infoSnackbar = (hideButton = false): void => {
+			onActionComplete && onActionComplete(ids);
+
+			if (currentConversation && ids.includes(currentConversation.id)) {
+				closeConversationPanel();
+			}
 			createSnackbar({
 				key: `trash-${ids}`,
 				replace: true,
 				severity: 'info',
-				label: t('messages.snackbar.marked_as_non_spam', 'You’ve marked this e-mail as Not Spam'),
+				label: t('messages.snackbar.marked_as_non_spam', "You've marked this e-mail as Not Spam"),
 				autoHideTimeout: 3000,
-				hideButton,
-				actionLabel: t('label.undo', 'Undo'),
-				onActionClick: (): void => {
-					notCanceled = false;
-				}
+				hideButton: true
 			});
-		};
-		infoSnackbar();
-		setTimeout((): void => {
-			if (notCanceled) {
-				convActionEmailStoreAction({
-					operation: '!spam',
-					ids
-				}).then((res) => {
-					if ('Fault' in res) {
-						createSnackbar({
-							key: `trash-${ids}`,
-							replace: true,
-							severity: 'error',
-							label: t('label.error_try_again', 'Something went wrong, please try again'),
-							autoHideTimeout: 3000
-						});
-
-						return;
-					}
-
-					onActionComplete && onActionComplete(ids);
-
-					if (currentConversation && ids.includes(currentConversation.id)) {
-						closeConversationPanel();
-					}
-				});
-			}
-		}, 3000);
+		});
 	}, [closeConversationPanel, createSnackbar, currentConversation, ids, onActionComplete, t]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);

--- a/src/hooks/actions/use-conv-set-spam.tsx
+++ b/src/hooks/actions/use-conv-set-spam.tsx
@@ -35,47 +35,35 @@ export const useConvSetSpamFn = ({
 
 	const { closeConversationPanel, currentConversation } = useConversationDetailPanelControls();
 	const execute = useCallback((): void => {
-		let notCanceled = true;
+		convActionEmailStoreAction({
+			operation: 'spam',
+			ids
+		}).then((res) => {
+			if ('Fault' in res) {
+				createSnackbar({
+					key: `spam-${ids}`,
+					replace: true,
+					severity: 'error',
+					label: t('label.error_try_again', 'Something went wrong, please try again'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+				return;
+			}
 
-		const infoSnackbar = (hideButton = false): void => {
+			onActionComplete && onActionComplete(ids);
+			if (currentConversation && ids.includes(currentConversation.id)) {
+				closeConversationPanel();
+			}
 			createSnackbar({
 				key: `spam-${ids}`,
 				replace: true,
 				severity: 'info',
-				label: t('messages.snackbar.marked_as_spam', 'You’ve marked this e-mail as Spam'),
+				label: t('messages.snackbar.marked_as_spam', "You've marked this e-mail as Spam"),
 				autoHideTimeout: 3000,
-				hideButton,
-				actionLabel: t('label.undo', 'Undo'),
-				onActionClick: (): void => {
-					notCanceled = false;
-				}
+				hideButton: true
 			});
-		};
-		infoSnackbar();
-		setTimeout((): void => {
-			if (notCanceled) {
-				convActionEmailStoreAction({
-					operation: 'spam',
-					ids
-				}).then((res) => {
-					if ('Fault' in res) {
-						createSnackbar({
-							key: `spam-${ids}`,
-							replace: true,
-							severity: 'error',
-							label: t('label.error_try_again', 'Something went wrong, please try again'),
-							autoHideTimeout: 3000
-						});
-						return;
-					}
-
-					onActionComplete && onActionComplete(ids);
-					if (currentConversation && ids.includes(currentConversation.id)) {
-						closeConversationPanel();
-					}
-				});
-			}
-		}, 3000);
+		});
 	}, [closeConversationPanel, createSnackbar, currentConversation, ids, onActionComplete, t]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);

--- a/src/hooks/actions/use-conv-set-spam.tsx
+++ b/src/hooks/actions/use-conv-set-spam.tsx
@@ -35,6 +35,9 @@ export const useConvSetSpamFn = ({
 
 	const { closeConversationPanel, currentConversation } = useConversationDetailPanelControls();
 	const execute = useCallback((): void => {
+		if (!canExecute()) {
+			return;
+		}
 		convActionEmailStoreAction({
 			operation: 'spam',
 			ids
@@ -64,7 +67,15 @@ export const useConvSetSpamFn = ({
 				hideButton: true
 			});
 		});
-	}, [closeConversationPanel, createSnackbar, currentConversation, ids, onActionComplete, t]);
+	}, [
+		canExecute,
+		closeConversationPanel,
+		createSnackbar,
+		currentConversation,
+		ids,
+		onActionComplete,
+		t
+	]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
 };

--- a/src/hooks/actions/use-conv-set-spam.tsx
+++ b/src/hooks/actions/use-conv-set-spam.tsx
@@ -62,7 +62,7 @@ export const useConvSetSpamFn = ({
 				key: `spam-${ids}`,
 				replace: true,
 				severity: 'info',
-				label: t('messages.snackbar.marked_as_spam', "You've marked this e-mail as Spam"),
+				label: t('messages.snackbar.conversation_marked_as_spam', 'Conversation marked as Spam'),
 				autoHideTimeout: 3000,
 				hideButton: true
 			});


### PR DESCRIPTION
This PR removes the "Undo" functionality from spam/not-spam operations, making these actions immediately execute without a delay period. The changes simplify the code by eliminating the timeout-based cancellation mechanism and updating success messages to be more generic.

**Changes:**
- Removed the 3-second delay and undo button for marking conversations as spam or not spam
- Updated snackbar messages to remove references to email-specific wording
- Removed timer advancement calls from tests since the delay is no longer present

**New Labels for translation:**

| Key                                           | Fallback Value                       | Description                                                     |
|----------------------------------------------|--------------------------------------|-----------------------------------------------------------------|
| `messages.snackbar.conversation_marked_as_non_spam` | Conversation marked as Not Spam | **Not Spam** conversation action success snackbar message label     |
| `messages.snackbar.conversation_marked_as_spam`     | Conversation marked as Spam     | **Mark as Spam** conversation action success snackbar message label |

