### PR TITLE
feat(CO-2848): add read receipt default setting

### DIFF
--- a/src/views/settings/components/utils.ts
+++ b/src/views/settings/components/utils.ts
@@ -12,6 +12,9 @@ import { filter, find, isEqual, isObject, map, reduce, transform } from 'lodash'
 
 import { NO_SIGNATURE_ID } from 'helpers/signatures';
 
+export const boolToPref = (value: boolean): string => (value ? 'TRUE' : 'FALSE');
+export const prefToBool = (value: string): boolean => value === 'TRUE';
+
 const arraysProps = [
 	'zimbraPrefMailTrustedSenderList',
 	'amavisWhitelistSender',

--- a/src/views/settings/compose-msg-settings.tsx
+++ b/src/views/settings/compose-msg-settings.tsx
@@ -11,14 +11,15 @@ import {
 	FormSubSection,
 	RadioGroup,
 	Radio,
-	FormSection
+	FormSection,
+	Switch,
+	Text
 } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 
 import { ColorPicker } from 'commons/color-picker';
 import { UpdateSettingsProps } from 'types/index.d';
-import Heading from 'views/settings/components/settings-heading';
 import { getFontSizesOptions, findLabel, getFonts } from 'views/settings/components/utils';
 import CustomSelect from 'views/settings/filters/parts/custom-select';
 import { composingMsgSubSection } from 'views/settings/subsections';
@@ -71,20 +72,10 @@ const ComposeMessage: FC<ComposeMessagesProps> = ({ settingsObj, updateSettings 
 	);
 	return (
 		<FormSection id={sectionTitle.id} label={sectionTitle.label}>
-			<FormSubSection>
-				<Container crossAlignment="baseline">
-					<Container
-						orientation="horizontal"
-						crossAlignment="flex-start"
-						mainAlignment="flex-start"
-					>
-						<Container
-							width="fit"
-							orientation="horizontal"
-							crossAlignment="flex-start"
-							mainAlignment="flex-start"
-						>
-							<Heading title={t('labels.compose_colin', 'Compose :')} size="small" />
+			<FormSubSection label={t('labels.compose_colin', 'Compose')}>
+				<Container crossAlignment="baseline" height="fit">
+					<Container crossAlignment="flex-start" mainAlignment="flex-start">
+						<Container crossAlignment="flex-start" mainAlignment="flex-start">
 							<RadioGroup
 								style={{ width: '100%' }}
 								value={settingsObj?.zimbraPrefComposeFormat}
@@ -94,8 +85,8 @@ const ComposeMessage: FC<ComposeMessagesProps> = ({ settingsObj, updateSettings 
 									});
 								}}
 							>
-								<Radio width="100%" label={t('label.as_html', 'As HTML')} value="html" />
 								<Radio width="100%" label={t('label.as_text', 'As Text')} value="text" />
+								<Radio width="100%" label={t('label.as_html', 'As HTML')} value="html" />
 							</RadioGroup>
 						</Container>
 						<Container
@@ -140,6 +131,26 @@ const ComposeMessage: FC<ComposeMessagesProps> = ({ settingsObj, updateSettings 
 						</Container>
 					</Container>
 				</Container>
+			</FormSubSection>
+			<FormSubSection label={t('label.read_receipt', 'Read receipt')}>
+				<Switch
+					label={t('label.always_request_read_receipts', 'Always request read receipts')}
+					value={settingsObj.zimbraPrefMailRequestReadReceipts === 'TRUE'}
+					onClick={(): void =>
+						updateSettings({
+							target: {
+								name: 'zimbraPrefMailRequestReadReceipts',
+								value: settingsObj.zimbraPrefMailRequestReadReceipts === 'TRUE' ? 'FALSE' : 'TRUE'
+							}
+						})
+					}
+				/>
+				<Text size="small">
+					{t(
+						'label.read_receipt_description',
+						'Get notified when recipients open your emails. This applies to all messages unless changed manually'
+					)}
+				</Text>
 			</FormSubSection>
 		</FormSection>
 	);

--- a/src/views/settings/compose-msg-settings.tsx
+++ b/src/views/settings/compose-msg-settings.tsx
@@ -20,7 +20,13 @@ import { map } from 'lodash';
 
 import { ColorPicker } from 'commons/color-picker';
 import { UpdateSettingsProps } from 'types/index.d';
-import { getFontSizesOptions, findLabel, getFonts } from 'views/settings/components/utils';
+import {
+	getFontSizesOptions,
+	findLabel,
+	getFonts,
+	prefToBool,
+	boolToPref
+} from 'views/settings/components/utils';
 import CustomSelect from 'views/settings/filters/parts/custom-select';
 import { composingMsgSubSection } from 'views/settings/subsections';
 
@@ -135,12 +141,12 @@ const ComposeMessage: FC<ComposeMessagesProps> = ({ settingsObj, updateSettings 
 			<FormSubSection label={t('label.composing_messages_read_receipt', 'Read receipt')}>
 				<Switch
 					label={t('label.always_request_read_receipts', 'Always request read receipts')}
-					value={settingsObj.zimbraPrefMailRequestReadReceipts === 'TRUE'}
+					value={prefToBool(settingsObj.zimbraPrefMailRequestReadReceipts)}
 					onClick={(): void =>
 						updateSettings({
 							target: {
 								name: 'zimbraPrefMailRequestReadReceipts',
-								value: settingsObj.zimbraPrefMailRequestReadReceipts === 'TRUE' ? 'FALSE' : 'TRUE'
+								value: boolToPref(!prefToBool(settingsObj.zimbraPrefMailRequestReadReceipts))
 							}
 						})
 					}

--- a/src/views/settings/compose-msg-settings.tsx
+++ b/src/views/settings/compose-msg-settings.tsx
@@ -72,7 +72,7 @@ const ComposeMessage: FC<ComposeMessagesProps> = ({ settingsObj, updateSettings 
 	);
 	return (
 		<FormSection id={sectionTitle.id} label={sectionTitle.label}>
-			<FormSubSection label={t('labels.compose_colin', 'Compose')}>
+			<FormSubSection label={t('labels.compose', 'Compose')}>
 				<Container crossAlignment="baseline" height="fit">
 					<Container crossAlignment="flex-start" mainAlignment="flex-start">
 						<Container crossAlignment="flex-start" mainAlignment="flex-start">

--- a/src/views/settings/compose-msg-settings.tsx
+++ b/src/views/settings/compose-msg-settings.tsx
@@ -132,7 +132,7 @@ const ComposeMessage: FC<ComposeMessagesProps> = ({ settingsObj, updateSettings 
 					</Container>
 				</Container>
 			</FormSubSection>
-			<FormSubSection label={t('label.read_receipt', 'Read receipt')}>
+			<FormSubSection label={t('label.composing_messages_read_receipt', 'Read receipt')}>
 				<Switch
 					label={t('label.always_request_read_receipts', 'Always request read receipts')}
 					value={settingsObj.zimbraPrefMailRequestReadReceipts === 'TRUE'}
@@ -148,7 +148,7 @@ const ComposeMessage: FC<ComposeMessagesProps> = ({ settingsObj, updateSettings 
 				<Text size="small">
 					{t(
 						'label.read_receipt_description',
-						'Get notified when recipients open your emails. This applies to all messages unless changed manually'
+						'Get notified when recipients open your emails. This applies to all messages unless changed manually.'
 					)}
 				</Text>
 			</FormSubSection>

--- a/src/views/settings/filters/parts/custom-select.tsx
+++ b/src/views/settings/filters/parts/custom-select.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { FC, ReactElement } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 
 import { Row, Select, Text, Padding, Icon, Container } from '@zextras/carbonio-design-system';
 import { map } from 'lodash';
@@ -26,45 +26,48 @@ const LabelFactory: FC<LabelFactoryPropsType> = ({
 	open,
 	focus,
 	disabled
-}): ReactElement => (
-	<ColorContainer
-		orientation="horizontal"
-		width="fill"
-		crossAlignment="center"
-		mainAlignment="space-between"
-		borderRadius="half"
-		background="gray5"
-		padding={{
-			all: 'extrasmall'
-		}}
-		$disabled={disabled}
-		minHeight="3rem"
-	>
-		<Row width="100%" takeAvailableSpace mainAlignment="space-between">
-			<Row
-				orientation="vertical"
-				crossAlignment="flex-start"
-				mainAlignment="flex-start"
-				padding={{ left: 'small' }}
-			>
-				<Text
-					size="small"
-					// eslint-disable-next-line no-nested-ternary
-					color={disabled ? 'gray2' : open || focus ? 'primary' : 'secondary'}
+}): ReactElement => {
+	const color = useMemo(() => {
+		if (disabled) return 'gray2';
+		if (open || focus) return 'primary';
+		return 'secondary';
+	}, [disabled, open, focus]);
+
+	return (
+		<ColorContainer
+			orientation="horizontal"
+			width="fill"
+			crossAlignment="center"
+			mainAlignment="space-between"
+			borderRadius="half"
+			background="gray5"
+			padding={{ all: 'extrasmall' }}
+			$disabled={disabled}
+			minHeight="3rem"
+		>
+			<Row width="100%" takeAvailableSpace mainAlignment="space-between">
+				<Row
+					orientation="vertical"
+					crossAlignment="flex-start"
+					mainAlignment="flex-start"
+					padding={{ left: 'small' }}
 				>
-					{label}
-				</Text>
-				<TextUpperCase color={disabled ? 'gray2' : 'text'}>{selected?.[0]?.label}</TextUpperCase>
+					<Text size="small" color={color}>
+						{label}
+					</Text>
+					<TextUpperCase color={disabled ? 'gray2' : 'text'}>{selected?.[0]?.label}</TextUpperCase>
+				</Row>
 			</Row>
-		</Row>
-		<Icon
-			size="large"
-			icon={open ? 'ChevronUpOutline' : 'ChevronDownOutline'}
-			color={disabled ? 'gray2' : open || focus ? 'primary' : 'secondary'}
-			style={{ alignSelf: 'center' }}
-		/>
-	</ColorContainer>
-);
+
+			<Icon
+				size="large"
+				icon={open ? 'ChevronUpOutline' : 'ChevronDownOutline'}
+				color={color}
+				style={{ alignSelf: 'center' }}
+			/>
+		</ColorContainer>
+	);
+};
 
 type GetItemsReturnType = Array<{ label: string; value: any; customComponent: ReactElement }>;
 const getItems = (items: Array<{ label: string; value: any }>): GetItemsReturnType =>

--- a/src/views/settings/filters/parts/custom-select.tsx
+++ b/src/views/settings/filters/parts/custom-select.tsx
@@ -50,7 +50,7 @@ const LabelFactory: FC<LabelFactoryPropsType> = ({
 				<Text
 					size="small"
 					// eslint-disable-next-line no-nested-ternary
-					color={open || focus ? 'primary' : disabled ? 'gray2' : 'secondary'}
+					color={disabled ? 'gray2' : open || focus ? 'primary' : 'secondary'}
 				>
 					{label}
 				</Text>
@@ -60,7 +60,7 @@ const LabelFactory: FC<LabelFactoryPropsType> = ({
 		<Icon
 			size="large"
 			icon={open ? 'ChevronUpOutline' : 'ChevronDownOutline'}
-			color={open || focus ? 'primary' : 'secondary'}
+			color={disabled ? 'gray2' : open || focus ? 'primary' : 'secondary'}
 			style={{ alignSelf: 'center' }}
 		/>
 	</ColorContainer>

--- a/src/views/settings/tests/compose-msg-settings.test.tsx
+++ b/src/views/settings/tests/compose-msg-settings.test.tsx
@@ -34,7 +34,7 @@ describe('compose-msg-settings', () => {
 		);
 
 		expect(screen.getByText('labels.composing_messages')).toBeInTheDocument();
-		expect(screen.getByText('labels.compose_colin')).toBeInTheDocument();
+		expect(screen.getByText('labels.compose')).toBeInTheDocument();
 		expect(screen.getByLabelText('label.as_html')).toBeInTheDocument();
 		expect(screen.getByLabelText('label.as_text')).toBeInTheDocument();
 		expect(screen.getByText('settings.font')).toBeInTheDocument();

--- a/src/views/settings/tests/compose-msg-settings.test.tsx
+++ b/src/views/settings/tests/compose-msg-settings.test.tsx
@@ -158,7 +158,7 @@ describe('compose-msg-settings', () => {
 				{}
 			);
 
-			expect(screen.getByText('label.read_receipt')).toBeInTheDocument();
+			expect(screen.getByText('label.composing_messages_read_receipt')).toBeInTheDocument();
 			expect(screen.getByText('label.always_request_read_receipts')).toBeInTheDocument();
 			expect(screen.getByText('label.read_receipt_description')).toBeInTheDocument();
 		});

--- a/src/views/settings/tests/compose-msg-settings.test.tsx
+++ b/src/views/settings/tests/compose-msg-settings.test.tsx
@@ -21,7 +21,8 @@ describe('compose-msg-settings', () => {
 		zimbraPrefHtmlEditorDefaultFontFamily: '',
 		zimbraPrefHtmlEditorDefaultFontSize: '',
 		zimbraPrefHtmlEditorDefaultFontColor: '',
-		zimbraPrefComposeFormat: ''
+		zimbraPrefComposeFormat: '',
+		zimbraPrefMailRequestReadReceipts: ''
 	};
 
 	it('should render correctly', async () => {
@@ -147,6 +148,69 @@ describe('compose-msg-settings', () => {
 		expect(screen.getByRole('radio', { name: 'label.as_html' })).not.toBeChecked();
 	});
 
+	describe('Read Receipt section', () => {
+		it('should render the Read Receipt section with switch and description', () => {
+			const settingObject = generateSettingObject();
+			const mockUpdateSettings = getMockUpdateSettings(settingObject);
+
+			setupTest(
+				<ComposeMessage settingsObj={settingObject} updateSettings={mockUpdateSettings} />,
+				{}
+			);
+
+			expect(screen.getByText('label.read_receipt')).toBeInTheDocument();
+			expect(screen.getByText('label.always_request_read_receipts')).toBeInTheDocument();
+			expect(screen.getByText('label.read_receipt_description')).toBeInTheDocument();
+		});
+
+		it('should call updateSettings when Read Receipt switch is toggled on', async () => {
+			const settingObject = generateSettingObject();
+			const mockUpdateSettings = getMockUpdateSettings(settingObject);
+
+			const { user } = setupTest(
+				<ComposeMessage settingsObj={settingObject} updateSettings={mockUpdateSettings} />,
+				{}
+			);
+
+			const switchElement = screen.getByText('label.always_request_read_receipts');
+			await user.click(switchElement);
+
+			await waitFor(() =>
+				expect(mockUpdateSettings).toHaveBeenCalledWith({
+					target: {
+						name: 'zimbraPrefMailRequestReadReceipts',
+						value: 'TRUE'
+					}
+				})
+			);
+		});
+
+		it('should call updateSettings when Read Receipt switch is toggled off', async () => {
+			const settingObject = {
+				...generateSettingObject(),
+				zimbraPrefMailRequestReadReceipts: 'TRUE'
+			};
+			const mockUpdateSettings = getMockUpdateSettings(settingObject);
+
+			const { user } = setupTest(
+				<ComposeMessage settingsObj={settingObject} updateSettings={mockUpdateSettings} />,
+				{}
+			);
+
+			const switchElement = screen.getByText('label.always_request_read_receipts');
+			await user.click(switchElement);
+
+			await waitFor(() =>
+				expect(mockUpdateSettings).toHaveBeenCalledWith({
+					target: {
+						name: 'zimbraPrefMailRequestReadReceipts',
+						value: 'FALSE'
+					}
+				})
+			);
+		});
+	});
+
 	function getMockUpdateSettings(
 		settingObject: Record<string, string>
 	): Mock<(value: any) => void> {
@@ -162,7 +226,8 @@ describe('compose-msg-settings', () => {
 			zimbraPrefHtmlEditorDefaultFontFamily: 'arial, helvetica, sans-serif',
 			zimbraPrefHtmlEditorDefaultFontSize: '12pt',
 			zimbraPrefHtmlEditorDefaultFontColor: '#24cb77',
-			zimbraPrefComposeFormat: 'html'
+			zimbraPrefComposeFormat: 'html',
+			zimbraPrefMailRequestReadReceipts: 'FALSE'
 		};
 	}
 });

--- a/src/views/settings/tests/compose-msg-settings.test.tsx
+++ b/src/views/settings/tests/compose-msg-settings.test.tsx
@@ -22,7 +22,7 @@ describe('compose-msg-settings', () => {
 		zimbraPrefHtmlEditorDefaultFontSize: '',
 		zimbraPrefHtmlEditorDefaultFontColor: '',
 		zimbraPrefComposeFormat: '',
-		zimbraPrefMailRequestReadReceipts: ''
+		zimbraPrefMailRequestReadReceipts: 'FALSE'
 	};
 
 	it('should render correctly', async () => {
@@ -172,8 +172,7 @@ describe('compose-msg-settings', () => {
 				{}
 			);
 
-			const switchElement = screen.getByText('label.always_request_read_receipts');
-			await user.click(switchElement);
+			await user.click(screen.getByTestId('icon: ToggleLeftOutline'));
 
 			await waitFor(() =>
 				expect(mockUpdateSettings).toHaveBeenCalledWith({
@@ -197,8 +196,7 @@ describe('compose-msg-settings', () => {
 				{}
 			);
 
-			const switchElement = screen.getByText('label.always_request_read_receipts');
-			await user.click(switchElement);
+			await user.click(screen.getByTestId('icon: ToggleRight'));
 
 			await waitFor(() =>
 				expect(mockUpdateSettings).toHaveBeenCalledWith({


### PR DESCRIPTION

Adds a “Read receipt” default setting to Compose Message settings, along with UI updates and test coverage for the new toggle.

**Changes:**
- Adds a new “Read receipt” subsection with a switch to control `zimbraPrefMailRequestReadReceipts`
- Updates the Compose subsection label key from `labels.compose_colin` to `labels.compose`
- Refactors `CustomSelect` label coloring logic to avoid nested ternaries