### PR TITLE
fix(CO-3187): add tag icon display logic and corresponding tests

### DIFF
--- a/src/__test__/constants.ts
+++ b/src/__test__/constants.ts
@@ -105,7 +105,10 @@ export const TESTID_SELECTORS = {
 		trash: 'icon: Trash2Outline',
 		deletePermanently: 'icon: DeletePermanentlyOutline',
 		deleteDraft: 'icon: Trash2Outline',
-		square: 'icon: Square'
+		square: 'icon: Square',
+		tag: 'icon: Tag',
+		tagsMore: 'icon: TagsMoreOutline',
+		flag: 'icon: Flag'
 	},
 	composer: {
 		attachmentAddOriginal: 'composer.attachment.add_original'

--- a/src/views/app/detail-panel/preview/parts/preview-header-actions.tsx
+++ b/src/views/app/detail-panel/preview/parts/preview-header-actions.tsx
@@ -86,13 +86,14 @@ export const PreviewHeaderActions: FC<PreviewHeaderActions> = ({
 		setShowDropdown(false);
 	}, []);
 
-	return (
-		<Row wrap="nowrap" mainAlignment="flex-end">
-			{showMultiTagIcon ? (
+	const showTagsInHeader = useMemo(() => {
+		if (tags.length === 0) return null;
+		if (showMultiTagIcon) {
+			return (
 				<Dropdown items={tags} forceOpen={showDropdown} onClose={onDropdownClose}>
 					<Padding left="small">
 						<Button
-							data-testid="TagIcon"
+							data-testid={tagIcon}
 							icon={tagIcon}
 							type="ghost"
 							color={'gray0'}
@@ -100,13 +101,20 @@ export const PreviewHeaderActions: FC<PreviewHeaderActions> = ({
 						/>
 					</Padding>
 				</Dropdown>
-			) : (
-				<Padding left="small">
-					<Tooltip label={tags?.[0]?.name} disabled={showMultiTagIcon}>
-						<Icon data-testid="TagIcon" icon={tagIcon} color={`${tagIconColor}`} />
-					</Tooltip>
-				</Padding>
-			)}
+			);
+		}
+		return (
+			<Padding left="small">
+				<Tooltip label={tags?.[0]?.name} disabled={showMultiTagIcon}>
+					<Icon icon={tagIcon} color={`${tagIconColor}`} />
+				</Tooltip>
+			</Padding>
+		);
+	}, [tags, showMultiTagIcon, tagIcon, tagIconColor, showDropdown, onDropdownClose, onIconClick]);
+
+	return (
+		<Row wrap="nowrap" mainAlignment="flex-end">
+			{showTagsInHeader}
 			{message.hasAttachment && attachments.length > 0 && (
 				<Padding left="small">
 					<Icon icon="AttachOutline" />
@@ -114,7 +122,7 @@ export const PreviewHeaderActions: FC<PreviewHeaderActions> = ({
 			)}
 			{message.flagged && (
 				<Padding left="small">
-					<Icon color="error" icon="Flag" data-testid="FlagIcon" />
+					<Icon color="error" icon="Flag" />
 				</Padding>
 			)}
 			{dateSection}

--- a/src/views/app/detail-panel/preview/tests/preview-header-actions.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/preview-header-actions.test.tsx
@@ -64,8 +64,6 @@ describe('PreviewHeaderActions', () => {
 
 			const tagIcon = screen.getByTestId(TESTID_SELECTORS.icons.tag);
 			expect(tagIcon).toBeVisible();
-
-			expect(tagIcon).toHaveAttribute('data-testid', TESTID_SELECTORS.icons.tag);
 		});
 
 		it('should display multiple tags icon when there are multiple tags', () => {
@@ -87,25 +85,6 @@ describe('PreviewHeaderActions', () => {
 
 			// After clicking, the dropdown should be open
 			expect(tagIcon).toBeVisible();
-		});
-
-		it('should render correct tag icon for single tag', () => {
-			const message = generateMessage();
-			const singleTag = [mockTags[0]];
-
-			setupTest(<PreviewHeaderActions message={message} tags={singleTag} open={false} isWide />);
-
-			const iconElement = screen.getByTestId(TESTID_SELECTORS.icons.tag);
-			expect(iconElement).toBeInTheDocument();
-		});
-
-		it('should render correct tag icon for multiple tags', () => {
-			const message = generateMessage();
-
-			setupTest(<PreviewHeaderActions message={message} tags={mockTags} open={false} isWide />);
-
-			const iconElement = screen.getByTestId(TESTID_SELECTORS.icons.tagsMore);
-			expect(iconElement).toBeInTheDocument();
 		});
 
 		it('should display flag icon when message is flagged', () => {

--- a/src/views/app/detail-panel/preview/tests/preview-header-actions.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/preview-header-actions.test.tsx
@@ -56,35 +56,12 @@ describe('PreviewHeaderActions', () => {
 			expect(screen.getByTestId(TESTID_SELECTORS.icons.tag)).toBeVisible();
 		});
 
-		it('should display single tag icon with correct color when there is one tag', () => {
-			const message = generateMessage();
-			const singleTag = [mockTags[0]];
-
-			setupTest(<PreviewHeaderActions message={message} tags={singleTag} open={false} isWide />);
-
-			const tagIcon = screen.getByTestId(TESTID_SELECTORS.icons.tag);
-			expect(tagIcon).toBeVisible();
-		});
-
 		it('should display multiple tags icon when there are multiple tags', () => {
 			const message = generateMessage();
 
 			setupTest(<PreviewHeaderActions message={message} tags={mockTags} open={false} isWide />);
 
 			expect(screen.getByTestId(TESTID_SELECTORS.icons.tagsMore)).toBeVisible();
-		});
-
-		it('should display dropdown when tag icon is clicked for multiple tags', async () => {
-			const message = generateMessage();
-			const { user } = setupTest(
-				<PreviewHeaderActions message={message} tags={mockTags} open={false} isWide />
-			);
-
-			const tagIcon = screen.getByTestId('TagsMoreOutline');
-			await user.click(tagIcon);
-
-			// After clicking, the dropdown should be open
-			expect(tagIcon).toBeVisible();
 		});
 
 		it('should display flag icon when message is flagged', () => {

--- a/src/views/app/detail-panel/preview/tests/preview-header-actions.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/preview-header-actions.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import { Tag, ZIMBRA_STANDARD_COLORS } from '@zextras/carbonio-ui-commons';
+
+import { PreviewHeaderActions } from '../parts/preview-header-actions';
+import { setupTest } from '@test-setup';
+import { TESTID_SELECTORS } from '__test__/constants';
+import { generateMessage } from '__test__/generators/generateMessage';
+
+describe('PreviewHeaderActions', () => {
+	const mockTags: Tag[] = [
+		{
+			id: 'tag-1',
+			name: 'Important',
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			color: ZIMBRA_STANDARD_COLORS[1].hex
+		},
+		{
+			id: 'tag-2',
+			name: 'Work',
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			color: ZIMBRA_STANDARD_COLORS[2].hex
+		},
+		{
+			id: 'tag-3',
+			name: 'Personal',
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			color: ZIMBRA_STANDARD_COLORS[3].hex
+		}
+	];
+
+	describe('Tag Icon Display', () => {
+		it('should not display tag icon when there are no tags', () => {
+			const message = generateMessage();
+
+			setupTest(<PreviewHeaderActions message={message} tags={[]} open={false} isWide />);
+
+			expect(screen.queryByTestId(TESTID_SELECTORS.icons.tag)).not.toBeInTheDocument();
+		});
+
+		it('should display tag icon when there is one tag', () => {
+			const message = generateMessage();
+			const singleTag = [mockTags[0]];
+
+			setupTest(<PreviewHeaderActions message={message} tags={singleTag} open={false} isWide />);
+
+			expect(screen.getByTestId(TESTID_SELECTORS.icons.tag)).toBeVisible();
+		});
+
+		it('should display single tag icon with correct color when there is one tag', () => {
+			const message = generateMessage();
+			const singleTag = [mockTags[0]];
+
+			setupTest(<PreviewHeaderActions message={message} tags={singleTag} open={false} isWide />);
+
+			const tagIcon = screen.getByTestId(TESTID_SELECTORS.icons.tag);
+			expect(tagIcon).toBeVisible();
+
+			expect(tagIcon).toHaveAttribute('data-testid', TESTID_SELECTORS.icons.tag);
+		});
+
+		it('should display multiple tags icon when there are multiple tags', () => {
+			const message = generateMessage();
+
+			setupTest(<PreviewHeaderActions message={message} tags={mockTags} open={false} isWide />);
+
+			expect(screen.getByTestId(TESTID_SELECTORS.icons.tagsMore)).toBeVisible();
+		});
+
+		it('should display dropdown when tag icon is clicked for multiple tags', async () => {
+			const message = generateMessage();
+			const { user } = setupTest(
+				<PreviewHeaderActions message={message} tags={mockTags} open={false} isWide />
+			);
+
+			const tagIcon = screen.getByTestId('TagsMoreOutline');
+			await user.click(tagIcon);
+
+			// After clicking, the dropdown should be open
+			expect(tagIcon).toBeVisible();
+		});
+
+		it('should render correct tag icon for single tag', () => {
+			const message = generateMessage();
+			const singleTag = [mockTags[0]];
+
+			setupTest(<PreviewHeaderActions message={message} tags={singleTag} open={false} isWide />);
+
+			const iconElement = screen.getByTestId(TESTID_SELECTORS.icons.tag);
+			expect(iconElement).toBeInTheDocument();
+		});
+
+		it('should render correct tag icon for multiple tags', () => {
+			const message = generateMessage();
+
+			setupTest(<PreviewHeaderActions message={message} tags={mockTags} open={false} isWide />);
+
+			const iconElement = screen.getByTestId(TESTID_SELECTORS.icons.tagsMore);
+			expect(iconElement).toBeInTheDocument();
+		});
+
+		it('should display flag icon when message is flagged', () => {
+			const message = generateMessage({ isFlagged: true });
+
+			setupTest(<PreviewHeaderActions message={message} tags={[]} open={false} isWide />);
+
+			expect(screen.getByTestId(TESTID_SELECTORS.icons.flag)).toBeVisible();
+		});
+
+		it('should display tag icon along with flag icon', () => {
+			const message = generateMessage({ isFlagged: true });
+
+			setupTest(
+				<PreviewHeaderActions message={message} tags={[mockTags[0]]} open={false} isWide />
+			);
+
+			expect(screen.getByTestId(TESTID_SELECTORS.icons.tag)).toBeVisible();
+			expect(screen.getByTestId(TESTID_SELECTORS.icons.flag)).toBeVisible();
+		});
+	});
+});


### PR DESCRIPTION
This PR adds tag icon display logic and corresponding tests to the preview header actions component. The changes fix an issue (CO-3187) related to how tag icons are displayed in message preview headers.

Changes:

Refactored tag icon display logic into a memoized showTagsInHeader variable for better code organization
Added comprehensive test coverage for tag icon display scenarios including single tags, multiple tags, and combinations with flag icons
Added test ID constants for tag and flag icons to standardize test selectors
