### PR TITLE
feat(CO-2786): add archive functionality for conversations and messages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-ui@1.0.6',
+    identifier: 'jenkins-lib-ui@1.0.7',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-ui@1.0.7',
+    identifier: 'jenkins-lib-ui@1.0.8',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@types/webpack-env": "^1.18.1",
 				"@zextras/carbonio-design-system": "11.0.2",
 				"@zextras/carbonio-shell-ui": "13.0.0-devel.1767956380147",
-				"@zextras/carbonio-ui-commons": "2.1.0-devel.1",
+				"@zextras/carbonio-ui-commons": "2.1.0-devel.2",
 				"@zextras/carbonio-ui-preview": "4.0.1-devel.1",
 				"@zextras/carbonio-ui-soap-lib": "1.0.4",
 				"@zextras/carbonio-ui-text-composer": "1.0.1-devel.2",
@@ -4834,6 +4834,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/scheduler": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/@types/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
@@ -6273,9 +6282,9 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-commons": {
-			"version": "2.1.0-devel.1",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-2.1.0-devel.1.tgz",
-			"integrity": "sha512-youNjLa6qt1grIlBj9K2Njcjupmzg01oHKRg4KszXEJljwHttAc5TWUYmnsbNY5xh0R648ZuFff9ETFqMWytPA==",
+			"version": "2.1.0-devel.2",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-2.1.0-devel.2.tgz",
+			"integrity": "sha512-48K1bDrD0V2krGfVTcw+2+0nAUtlqV+bqQa8BlhCk8K0XKbUhOXUtWQ1PINehfTAvZcXLuYwUKresMprjY+W/g==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"core-js": "^3.36.0",
@@ -6803,6 +6812,20 @@
 			"engines": {
 				"node": "v22",
 				"npm": "v10"
+			}
+		},
+		"node_modules/@zextras/carbonio-ui-sdk/node_modules/@types/react": {
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "^0.16",
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-sdk/node_modules/ansi-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@types/webpack-env": "^1.18.1",
 				"@zextras/carbonio-design-system": "11.0.2",
 				"@zextras/carbonio-shell-ui": "13.0.0-devel.1767956380147",
-				"@zextras/carbonio-ui-commons": "2.0.1-devel.4",
+				"@zextras/carbonio-ui-commons": "2.1.0-devel.1",
 				"@zextras/carbonio-ui-preview": "4.0.1-devel.1",
 				"@zextras/carbonio-ui-soap-lib": "1.0.4",
 				"@zextras/carbonio-ui-text-composer": "1.0.1-devel.2",
@@ -79,7 +79,6 @@
 				"eslint-plugin-testing-library": "^5.10.1",
 				"eslint-plugin-unused-imports": "^2.0.0",
 				"eslint-stats": "^1.0.1",
-				"is-ci": "^3.0.1",
 				"jsdom": "20.0.3",
 				"msw": "^2.2.3",
 				"npm": "^10.5.0",
@@ -4835,15 +4834,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/scheduler": {
-			"version": "0.16.8",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@types/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
@@ -6283,9 +6273,9 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-commons": {
-			"version": "2.0.1-devel.4",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-2.0.1-devel.4.tgz",
-			"integrity": "sha512-ki2+UjapLI03lPRL1fPD+3tw2OfFCPexn+3NWCZCZNRCLw1YYVX1klswOCxiUm+YRjJiqAa2mVJflSOsChB9Ag==",
+			"version": "2.1.0-devel.1",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-2.1.0-devel.1.tgz",
+			"integrity": "sha512-youNjLa6qt1grIlBj9K2Njcjupmzg01oHKRg4KszXEJljwHttAc5TWUYmnsbNY5xh0R648ZuFff9ETFqMWytPA==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"core-js": "^3.36.0",
@@ -6813,20 +6803,6 @@
 			"engines": {
 				"node": "v22",
 				"npm": "v10"
-			}
-		},
-		"node_modules/@zextras/carbonio-ui-sdk/node_modules/@types/react": {
-			"version": "17.0.91",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
-			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/prop-types": "*",
-				"@types/scheduler": "^0.16",
-				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-sdk/node_modules/ansi-regex": {
@@ -8377,22 +8353,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0"
-			}
-		},
-		"node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/circular-dependency-plugin": {
@@ -12522,19 +12482,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ci-info": "^3.2.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
 			}
 		},
 		"node_modules/is-core-module": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"@types/webpack-env": "^1.18.1",
 		"@zextras/carbonio-design-system": "11.0.2",
 		"@zextras/carbonio-shell-ui": "13.0.0-devel.1767956380147",
-		"@zextras/carbonio-ui-commons": "2.1.0-devel.1",
+		"@zextras/carbonio-ui-commons": "2.1.0-devel.2",
 		"@zextras/carbonio-ui-preview": "4.0.1-devel.1",
 		"@zextras/carbonio-ui-soap-lib": "1.0.4",
 		"@zextras/carbonio-ui-text-composer": "1.0.1-devel.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"@types/webpack-env": "^1.18.1",
 		"@zextras/carbonio-design-system": "11.0.2",
 		"@zextras/carbonio-shell-ui": "13.0.0-devel.1767956380147",
-		"@zextras/carbonio-ui-commons": "2.0.1-devel.4",
+		"@zextras/carbonio-ui-commons": "2.1.0-devel.1",
 		"@zextras/carbonio-ui-preview": "4.0.1-devel.1",
 		"@zextras/carbonio-ui-soap-lib": "1.0.4",
 		"@zextras/carbonio-ui-text-composer": "1.0.1-devel.2",

--- a/src/__test__/constants.ts
+++ b/src/__test__/constants.ts
@@ -105,7 +105,8 @@ export const TESTID_SELECTORS = {
 		trash: 'icon: Trash2Outline',
 		deletePermanently: 'icon: DeletePermanentlyOutline',
 		deleteDraft: 'icon: Trash2Outline',
-		square: 'icon: Square'
+		square: 'icon: Square',
+		archive: 'icon: ArchiveOutline'
 	},
 	composer: {
 		attachmentAddOriginal: 'composer.attachment.add_original'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -354,6 +354,10 @@ export const MessageActionsDescriptors = {
 	APPLY_TAG: {
 		id: 'apply-tag',
 		desc: 'Apply tag'
+	},
+	ARCHIVE: {
+		id: 'message-archive',
+		desc: 'Move to archive'
 	}
 } as const;
 
@@ -429,6 +433,10 @@ export const ConversationActionsDescriptors = {
 	SHOW_SOURCE: {
 		id: 'conversation-show_original',
 		desc: 'Show original'
+	},
+	ARCHIVE: {
+		id: 'conversation-archive',
+		desc: 'Move to archive'
 	}
 } as const;
 
@@ -470,6 +478,10 @@ export const FOLDERS_DESCRIPTORS = {
 	USER_DEFINED: {
 		id: '1234567',
 		desc: 'user defined'
+	},
+	ARCHIVE: {
+		id: FOLDERS.ARCHIVE,
+		desc: 'archive'
 	}
 };
 
@@ -506,7 +518,8 @@ export const EditViewActions = {
 	MAIL_TO: 'mailTo',
 	COMPOSE: 'compose',
 	PREFILL_COMPOSE: 'prefillCompose',
-	RESUME: 'resume'
+	RESUME: 'resume',
+	ARCHIVE: 'archive'
 } as const;
 
 export const PROCESS_STATUS = {

--- a/src/helpers/folders.ts
+++ b/src/helpers/folders.ts
@@ -141,7 +141,7 @@ export const isA = (folderId: string | undefined, folderType: keyof Folders): bo
 export const isRoot = (folderId: string): boolean => isA(folderId, FOLDERS.USER_ROOT);
 
 /**
- * Tells if a folder with the given id is am inbox folder
+ * Tells if a folder with the given id is an inbox folder
  * @param folderId
  */
 export const isInbox = (folderId: string): boolean => isA(folderId, FOLDERS.INBOX);
@@ -159,7 +159,7 @@ export const isTrash = (folderId: string): boolean => isA(folderId, FOLDERS.TRAS
 export const isSpam = (folderId: string): boolean => isA(folderId, FOLDERS.SPAM);
 
 /**
- * Tells if a folder with the given id is a spam folder
+ * Tells if a folder with the given id is a sent folder
  * @param folderId
  */
 export const isSent = (folderId: string): boolean => isA(folderId, FOLDERS.SENT);
@@ -169,6 +169,18 @@ export const isSent = (folderId: string): boolean => isA(folderId, FOLDERS.SENT)
  * @param folderId
  */
 export const isDraft = (folderId: string): boolean => isA(folderId, FOLDERS.DRAFTS);
+
+/**
+ * Tells if a folder with the given id is an archive folder
+ * @param folderId
+ */
+export const isArchive = (folderId: string): boolean => isA(folderId, FOLDERS.ARCHIVE);
+
+/**
+ * Tells if the system archive folder is available to use
+ */
+export const isSystemArchiveAvailable = (): boolean =>
+	Boolean(useFolderStore.getState()?.folders?.[FOLDERS.ARCHIVE]);
 
 /**
  * Tells if a folder is a trashed folder

--- a/src/helpers/folders.ts
+++ b/src/helpers/folders.ts
@@ -183,6 +183,21 @@ export const isSystemArchiveAvailable = (): boolean =>
 	Boolean(useFolderStore.getState()?.folders?.[FOLDERS.ARCHIVE]);
 
 /**
+ * Returns the archive folder id for the given folder
+ * If the folder belongs to a shared account, returns the shared account's archive folder
+ * Otherwise returns the main account's archive folder
+ * @param folderId - the folder id (can be from main or shared account)
+ * @returns the archive folder id (with zid if from shared account, without zid for main account)
+ */
+export const getArchiveFolderId = (folderId: string): string => {
+	const { zid } = getFolderIdParts(folderId);
+	if (zid) {
+		return `${zid}:${FOLDERS.ARCHIVE}`;
+	}
+	return FOLDERS.ARCHIVE;
+};
+
+/**
  * Tells if a folder is a trashed folder
  * @param folder
  * @param folderId

--- a/src/helpers/identities.ts
+++ b/src/helpers/identities.ts
@@ -6,11 +6,12 @@
 import { Account, getUserAccount, t } from '@zextras/carbonio-shell-ui';
 import type { Folders } from '@zextras/carbonio-ui-commons';
 import { getRootsMap, ParticipantRole } from '@zextras/carbonio-ui-commons';
+import { TFunction } from 'i18next';
+import { filter, findIndex, flatten, map, remove } from 'lodash';
+
 import { NO_ACCOUNT_NAME } from 'constants/index';
 import { getFolderIdParts, getMessageOwnerAccountName } from 'helpers/folders';
 import { getAvailableAddresses } from 'helpers/get-available-addresses';
-import { TFunction } from 'i18next';
-import { filter, findIndex, flatten, map, remove } from 'lodash';
 import type { MailMessage, Participant } from 'types/index.d';
 
 /**

--- a/src/helpers/tests/folders.test.ts
+++ b/src/helpers/tests/folders.test.ts
@@ -15,12 +15,14 @@ import {
 
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { getMocksContext } from '@test-utils/utils/mocks-context';
+import { generateMessage } from '__test__/generators/generateMessage';
 import { NO_ACCOUNT_NAME } from 'constants/index';
 import {
 	getFolderIdParts,
 	getFolderOwnerAccountName,
 	getFoldersArray,
 	getParentFolderId,
+	getArchiveFolderId,
 	isDraft,
 	isInbox,
 	isInboxSubfolder,
@@ -29,7 +31,6 @@ import {
 	isTrash,
 	isTrashed
 } from 'helpers/folders';
-import { generateMessage } from '__test__/generators/generateMessage';
 
 describe('Folder id', () => {
 	test('with zid', () => {
@@ -362,5 +363,35 @@ describe('getParentFolderId', () => {
 		populateFoldersStore();
 		const msg = generateMessage({ folderId: 'supercalifragilisticexpialidocious:42' });
 		expect(getParentFolderId(msg.parent)).toBeNull();
+	});
+});
+
+describe('getArchiveFolderId', () => {
+	test('if the folder is from the main account, returns the main account archive folder id', () => {
+		const folderId = FOLDERS.INBOX;
+		const archiveId = getArchiveFolderId(folderId);
+		expect(archiveId).toBe(FOLDERS.ARCHIVE);
+	});
+
+	test('if the folder is from a shared account, returns the shared account archive folder id', () => {
+		populateFoldersStore();
+		const sharedAccountIdentity = getMocksContext().identities.sendAs[0].identity;
+		const sharedAccountFolderId = `${sharedAccountIdentity.id}:${FOLDERS.INBOX}`;
+		const archiveId = getArchiveFolderId(sharedAccountFolderId);
+		expect(archiveId).toBe(`${sharedAccountIdentity.id}:${FOLDERS.ARCHIVE}`);
+	});
+
+	test('if the folder id is from trash folder in main account, returns main account archive folder id', () => {
+		const folderId = FOLDERS.TRASH;
+		const archiveId = getArchiveFolderId(folderId);
+		expect(archiveId).toBe(FOLDERS.ARCHIVE);
+	});
+
+	test('if the folder id is from trash folder in shared account, returns shared account archive folder id', () => {
+		populateFoldersStore();
+		const sharedAccountIdentity = getMocksContext().identities.sendAs[0].identity;
+		const sharedAccountTrashId = `${sharedAccountIdentity.id}:${FOLDERS.TRASH}`;
+		const archiveId = getArchiveFolderId(sharedAccountTrashId);
+		expect(archiveId).toBe(`${sharedAccountIdentity.id}:${FOLDERS.ARCHIVE}`);
 	});
 });

--- a/src/hooks/actions/tests/use-conv-archive.test.ts
+++ b/src/hooks/actions/tests/use-conv-archive.test.ts
@@ -17,7 +17,7 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { TIMERS } from '__test__/constants';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
-import { ConvActionRequest, MsgActionRequest, MsgActionResponse } from 'types';
+import { ConvActionRequest, ConvActionResponse } from 'types';
 
 describe('useConvArchive', () => {
 	const conversationsId = times(faker.number.int({ max: 42 }), () =>
@@ -27,7 +27,7 @@ describe('useConvArchive', () => {
 	describe('Conversation Archive Action not usable when system ARCHIVE folder is not available', () => {
 		it('should not call the API if the action cannot be executed', async () => {
 			const apiCallSpy = vi.fn();
-			createSoapAPIInterceptor<MsgActionRequest>('ConvAction').then(apiCallSpy);
+			createSoapAPIInterceptor<ConvActionRequest>('ConvAction').then(apiCallSpy);
 
 			const {
 				result: { current: functions }
@@ -112,13 +112,13 @@ describe('useConvArchive', () => {
 
 			describe('execute', () => {
 				it('should call the API with the proper parameters', async () => {
-					const apiResponse: MsgActionResponse = {
+					const apiResponse: ConvActionResponse = {
 						action: {
 							id: conversationsId.join(','),
 							op: 'move'
 						}
 					};
-					const apiInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
+					const apiInterceptor = createSoapAPIInterceptor<ConvActionRequest, ConvActionResponse>(
 						'ConvAction',
 						apiResponse
 					);
@@ -137,7 +137,6 @@ describe('useConvArchive', () => {
 					expect(requestParameter.action.id).toBe(conversationsId.join(','));
 					expect(requestParameter.action.op).toBe('move');
 					expect(requestParameter.action.l).toBe(FOLDERS.ARCHIVE);
-					expect(requestParameter.action.f).toBeUndefined();
 					expect(requestParameter.action.tn).toBeUndefined();
 				});
 

--- a/src/hooks/actions/tests/use-conv-archive.test.ts
+++ b/src/hooks/actions/tests/use-conv-archive.test.ts
@@ -32,7 +32,7 @@ describe('useConvArchive', () => {
 			const {
 				result: { current: functions }
 			} = setupHook(useConvArchiveFn, {
-				initialProps: [{ conversationIds: conversationsId }]
+				initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
 			});
 
 			act(() => functions.execute());
@@ -52,7 +52,7 @@ describe('useConvArchive', () => {
 				const {
 					result: { current: descriptor }
 				} = setupHook(useConvArchiveDescriptor, {
-					initialProps: [{ conversationIds: conversationsId }]
+					initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
 				});
 
 				expect(descriptor).toEqual({
@@ -70,7 +70,7 @@ describe('useConvArchive', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvArchiveFn, {
-					initialProps: [{ conversationIds: conversationsId }]
+					initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
 				});
 
 				expect(functions).toEqual({
@@ -88,14 +88,25 @@ describe('useConvArchive', () => {
 					${FOLDERS_DESCRIPTORS.TRASH}        | ${true}
 					${FOLDERS_DESCRIPTORS.SPAM}         | ${true}
 					${FOLDERS_DESCRIPTORS.USER_DEFINED} | ${true}
-				`(`should return $assertion if the folder is $folder.desc`, ({ assertion }) => {
+					${FOLDERS_DESCRIPTORS.ARCHIVE}      | ${false}
+				`(`should return $assertion if the folder is $folder.desc`, ({ folder, assertion }) => {
 					const {
 						result: { current: functions }
 					} = setupHook(useConvArchiveFn, {
-						initialProps: [{ conversationIds: conversationsId }]
+						initialProps: [{ conversationIds: conversationsId, folderId: folder.id }]
 					});
 
 					expect(functions.canExecute()).toEqual(assertion);
+				});
+
+				it('should return false when conversations are already in the Archive folder - archive action should not appear', () => {
+					const {
+						result: { current: functions }
+					} = setupHook(useConvArchiveFn, {
+						initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.ARCHIVE }]
+					});
+
+					expect(functions.canExecute()).toBe(false);
 				});
 			});
 
@@ -115,7 +126,7 @@ describe('useConvArchive', () => {
 					const {
 						result: { current: functions }
 					} = setupHook(useConvArchiveFn, {
-						initialProps: [{ conversationIds: conversationsId }]
+						initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
 					});
 
 					await act(async () => {
@@ -137,7 +148,13 @@ describe('useConvArchive', () => {
 					const {
 						result: { current: functions }
 					} = setupHook(useConvArchiveFn, {
-						initialProps: [{ conversationIds: conversationsId, onActionComplete }]
+						initialProps: [
+							{
+								conversationIds: conversationsId,
+								folderId: FOLDERS.INBOX,
+								onActionComplete
+							}
+						]
 					});
 
 					await act(async () => {

--- a/src/hooks/actions/tests/use-conv-archive.test.ts
+++ b/src/hooks/actions/tests/use-conv-archive.test.ts
@@ -10,11 +10,11 @@ import { faker } from '@faker-js/faker';
 import { FOLDER_VIEW, FOLDERS } from '@zextras/carbonio-ui-commons';
 import { times } from 'lodash';
 
-import { createSoapAPIInterceptor } from '../../../__test__/mocks/network/msw/create-api-interceptor';
-import { populateFoldersStore } from '../../../__test__/mocks/store/folders';
 import { useConvArchiveDescriptor, useConvArchiveFn } from '../use-conv-archive';
 import { setupHook } from '@test-setup';
 import { generateFolder } from '@test-utils/folders/folders-generator';
+import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { populateFoldersStore } from '@test-utils/store/folders';
 import { TIMERS } from '__test__/constants';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { ConvActionRequest, MsgActionRequest, MsgActionResponse } from 'types';
@@ -32,7 +32,7 @@ describe('useConvArchive', () => {
 			const {
 				result: { current: functions }
 			} = setupHook(useConvArchiveFn, {
-				initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
+				initialProps: [{ conversationIds: conversationsId }]
 			});
 
 			act(() => functions.execute());
@@ -52,7 +52,7 @@ describe('useConvArchive', () => {
 				const {
 					result: { current: descriptor }
 				} = setupHook(useConvArchiveDescriptor, {
-					initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
+					initialProps: [{ conversationIds: conversationsId }]
 				});
 
 				expect(descriptor).toEqual({
@@ -70,7 +70,7 @@ describe('useConvArchive', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useConvArchiveFn, {
-					initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
+					initialProps: [{ conversationIds: conversationsId }]
 				});
 
 				expect(functions).toEqual({
@@ -85,14 +85,14 @@ describe('useConvArchive', () => {
 					${FOLDERS_DESCRIPTORS.INBOX}        | ${true}
 					${FOLDERS_DESCRIPTORS.SENT}         | ${true}
 					${FOLDERS_DESCRIPTORS.DRAFTS}       | ${true}
-					${FOLDERS_DESCRIPTORS.TRASH}        | ${false}
+					${FOLDERS_DESCRIPTORS.TRASH}        | ${true}
 					${FOLDERS_DESCRIPTORS.SPAM}         | ${true}
 					${FOLDERS_DESCRIPTORS.USER_DEFINED} | ${true}
-				`(`should return $assertion if the folder is $folder.desc`, ({ folder, assertion }) => {
+				`(`should return $assertion if the folder is $folder.desc`, ({ assertion }) => {
 					const {
 						result: { current: functions }
 					} = setupHook(useConvArchiveFn, {
-						initialProps: [{ conversationIds: conversationsId, folderId: folder.id }]
+						initialProps: [{ conversationIds: conversationsId }]
 					});
 
 					expect(functions.canExecute()).toEqual(assertion);
@@ -104,7 +104,7 @@ describe('useConvArchive', () => {
 					const apiResponse: MsgActionResponse = {
 						action: {
 							id: conversationsId.join(','),
-							op: 'archive'
+							op: 'move'
 						}
 					};
 					const apiInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
@@ -115,7 +115,7 @@ describe('useConvArchive', () => {
 					const {
 						result: { current: functions }
 					} = setupHook(useConvArchiveFn, {
-						initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.ARCHIVE }]
+						initialProps: [{ conversationIds: conversationsId }]
 					});
 
 					await act(async () => {
@@ -124,25 +124,10 @@ describe('useConvArchive', () => {
 
 					const requestParameter = await apiInterceptor;
 					expect(requestParameter.action.id).toBe(conversationsId.join(','));
-					expect(requestParameter.action.op).toBe('archive');
-					expect(requestParameter.action.l).toBeUndefined();
+					expect(requestParameter.action.op).toBe('move');
+					expect(requestParameter.action.l).toBe(FOLDERS.ARCHIVE);
 					expect(requestParameter.action.f).toBeUndefined();
 					expect(requestParameter.action.tn).toBeUndefined();
-				});
-
-				it('should not call the API if the action cannot be executed', async () => {
-					const apiCallSpy = vi.fn();
-					createSoapAPIInterceptor<MsgActionRequest>('ConvAction').then(apiCallSpy);
-
-					const {
-						result: { current: functions }
-					} = setupHook(useConvArchiveFn, {
-						initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.TRASH }]
-					});
-
-					act(() => functions.execute());
-
-					expect(apiCallSpy).not.toHaveBeenCalled();
 				});
 
 				it('should call onActionComplete when provided after successful archive', async () => {
@@ -152,9 +137,7 @@ describe('useConvArchive', () => {
 					const {
 						result: { current: functions }
 					} = setupHook(useConvArchiveFn, {
-						initialProps: [
-							{ folderId: FOLDERS.INBOX, conversationIds: conversationsId, onActionComplete }
-						]
+						initialProps: [{ conversationIds: conversationsId, onActionComplete }]
 					});
 
 					await act(async () => {

--- a/src/hooks/actions/tests/use-conv-archive.test.ts
+++ b/src/hooks/actions/tests/use-conv-archive.test.ts
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { act } from 'react';
+
+import { faker } from '@faker-js/faker';
+import { FOLDER_VIEW, FOLDERS } from '@zextras/carbonio-ui-commons';
+import { times } from 'lodash';
+
+import { createSoapAPIInterceptor } from '../../../__test__/mocks/network/msw/create-api-interceptor';
+import { populateFoldersStore } from '../../../__test__/mocks/store/folders';
+import { useConvArchiveDescriptor, useConvArchiveFn } from '../use-conv-archive';
+import { setupHook } from '@test-setup';
+import { generateFolder } from '@test-utils/folders/folders-generator';
+import { TIMERS } from '__test__/constants';
+import { FOLDERS_DESCRIPTORS } from 'constants/index';
+import { ConvActionRequest, MsgActionRequest, MsgActionResponse } from 'types';
+
+describe('useConvArchive', () => {
+	const conversationsId = times(faker.number.int({ max: 42 }), () =>
+		faker.number.int({ max: 42000 }).toString()
+	);
+
+	describe('Conversation Archive Action not usable when system ARCHIVE folder is not available', () => {
+		it('should not call the API if the action cannot be executed', async () => {
+			const apiCallSpy = vi.fn();
+			createSoapAPIInterceptor<MsgActionRequest>('ConvAction').then(apiCallSpy);
+
+			const {
+				result: { current: functions }
+			} = setupHook(useConvArchiveFn, {
+				initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
+			});
+
+			act(() => functions.execute());
+
+			expect(apiCallSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('useConvArchive when system Archive folder is available', () => {
+		populateFoldersStore({
+			view: FOLDER_VIEW.conversation,
+			customFolders: [generateFolder({ id: FOLDERS.ARCHIVE, name: 'Archive', deletable: false })]
+		});
+
+		describe('descriptor', () => {
+			it('Should return an object with specific id, icon, label and 2 functions', () => {
+				const {
+					result: { current: descriptor }
+				} = setupHook(useConvArchiveDescriptor, {
+					initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
+				});
+
+				expect(descriptor).toEqual({
+					id: 'conversation-archive',
+					icon: 'ArchiveOutline',
+					label: 'Archive',
+					execute: expect.any(Function),
+					canExecute: expect.any(Function)
+				});
+			});
+		});
+
+		describe('functions', () => {
+			it('Should return an object with execute and canExecute functions', () => {
+				const {
+					result: { current: functions }
+				} = setupHook(useConvArchiveFn, {
+					initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.INBOX }]
+				});
+
+				expect(functions).toEqual({
+					execute: expect.any(Function),
+					canExecute: expect.any(Function)
+				});
+			});
+
+			describe('canExecute', () => {
+				it.each`
+					folder                              | assertion
+					${FOLDERS_DESCRIPTORS.INBOX}        | ${true}
+					${FOLDERS_DESCRIPTORS.SENT}         | ${true}
+					${FOLDERS_DESCRIPTORS.DRAFTS}       | ${true}
+					${FOLDERS_DESCRIPTORS.TRASH}        | ${false}
+					${FOLDERS_DESCRIPTORS.SPAM}         | ${true}
+					${FOLDERS_DESCRIPTORS.USER_DEFINED} | ${true}
+				`(`should return $assertion if the folder is $folder.desc`, ({ folder, assertion }) => {
+					const {
+						result: { current: functions }
+					} = setupHook(useConvArchiveFn, {
+						initialProps: [{ conversationIds: conversationsId, folderId: folder.id }]
+					});
+
+					expect(functions.canExecute()).toEqual(assertion);
+				});
+			});
+
+			describe('execute', () => {
+				it('should call the API with the proper parameters', async () => {
+					const apiResponse: MsgActionResponse = {
+						action: {
+							id: conversationsId.join(','),
+							op: 'archive'
+						}
+					};
+					const apiInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
+						'ConvAction',
+						apiResponse
+					);
+
+					const {
+						result: { current: functions }
+					} = setupHook(useConvArchiveFn, {
+						initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.ARCHIVE }]
+					});
+
+					await act(async () => {
+						functions.execute();
+					});
+
+					const requestParameter = await apiInterceptor;
+					expect(requestParameter.action.id).toBe(conversationsId.join(','));
+					expect(requestParameter.action.op).toBe('archive');
+					expect(requestParameter.action.l).toBeUndefined();
+					expect(requestParameter.action.f).toBeUndefined();
+					expect(requestParameter.action.tn).toBeUndefined();
+				});
+
+				it('should not call the API if the action cannot be executed', async () => {
+					const apiCallSpy = vi.fn();
+					createSoapAPIInterceptor<MsgActionRequest>('ConvAction').then(apiCallSpy);
+
+					const {
+						result: { current: functions }
+					} = setupHook(useConvArchiveFn, {
+						initialProps: [{ conversationIds: conversationsId, folderId: FOLDERS.TRASH }]
+					});
+
+					act(() => functions.execute());
+
+					expect(apiCallSpy).not.toHaveBeenCalled();
+				});
+
+				it('should call onActionComplete when provided after successful archive', async () => {
+					const onActionComplete = vi.fn();
+					createSoapAPIInterceptor<ConvActionRequest>('ConvAction');
+
+					const {
+						result: { current: functions }
+					} = setupHook(useConvArchiveFn, {
+						initialProps: [
+							{ folderId: FOLDERS.INBOX, conversationIds: conversationsId, onActionComplete }
+						]
+					});
+
+					await act(async () => {
+						functions.execute();
+					});
+
+					act(() => {
+						vi.advanceTimersByTime(TIMERS.modal_open_delay);
+					});
+
+					expect(onActionComplete).toHaveBeenCalledWith(conversationsId);
+				});
+			});
+		});
+	});
+});

--- a/src/hooks/actions/tests/use-conv-move-to-trash.test.ts
+++ b/src/hooks/actions/tests/use-conv-move-to-trash.test.ts
@@ -67,6 +67,7 @@ describe('useConMoveToTrash', () => {
 				${FOLDERS_DESCRIPTORS.DRAFTS}       | ${true}
 				${FOLDERS_DESCRIPTORS.TRASH}        | ${false}
 				${FOLDERS_DESCRIPTORS.SPAM}         | ${true}
+				${FOLDERS_DESCRIPTORS.ARCHIVE}      | ${true}
 				${FOLDERS_DESCRIPTORS.USER_DEFINED} | ${true}
 			`(`should return $assertion if the folder is $folder.desc`, ({ folder, assertion }) => {
 				const {

--- a/src/hooks/actions/tests/use-msg-archive.test.tsx
+++ b/src/hooks/actions/tests/use-msg-archive.test.tsx
@@ -40,9 +40,11 @@ describe('useMsgArchive', () => {
 	});
 
 	describe('useMsgArchive when system Archive folder is available', () => {
-		populateFoldersStore({
-			view: FOLDER_VIEW.message,
-			customFolders: [generateFolder({ id: FOLDERS.ARCHIVE, name: 'Archive', deletable: false })]
+		beforeEach(() => {
+			populateFoldersStore({
+				view: FOLDER_VIEW.message,
+				customFolders: [generateFolder({ id: FOLDERS.ARCHIVE, name: 'Archive', deletable: false })]
+			});
 		});
 		describe('Descriptor', () => {
 			it('Should return an object with specific id, icon, label and 2 functions', () => {

--- a/src/hooks/actions/tests/use-msg-archive.test.tsx
+++ b/src/hooks/actions/tests/use-msg-archive.test.tsx
@@ -30,7 +30,7 @@ describe('useMsgArchive', () => {
 			const {
 				result: { current: functions }
 			} = setupHook(useMsgArchiveFn, {
-				initialProps: [{ messagesIds: messagesId }]
+				initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
 			});
 
 			act(() => functions.execute());
@@ -49,7 +49,7 @@ describe('useMsgArchive', () => {
 				const {
 					result: { current: descriptor }
 				} = setupHook(useMsgArchiveDescriptor, {
-					initialProps: [{ messagesIds: messagesId }]
+					initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
 				});
 
 				expect(descriptor).toEqual({
@@ -67,7 +67,7 @@ describe('useMsgArchive', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useMsgArchiveFn, {
-					initialProps: [{ messagesIds: messagesId }]
+					initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
 				});
 
 				expect(functions).toEqual({
@@ -85,14 +85,25 @@ describe('useMsgArchive', () => {
 					${FOLDERS_DESCRIPTORS.TRASH}        | ${true}
 					${FOLDERS_DESCRIPTORS.SPAM}         | ${true}
 					${FOLDERS_DESCRIPTORS.USER_DEFINED} | ${true}
-				`(`should return $assertion if the folder is $folder.desc`, ({ assertion }) => {
+					${FOLDERS_DESCRIPTORS.ARCHIVE}      | ${false}
+				`(`should return $assertion if the folder is $folder.desc`, ({ folder, assertion }) => {
 					const {
 						result: { current: functions }
 					} = setupHook(useMsgArchiveFn, {
-						initialProps: [{ messagesIds: messagesId }]
+						initialProps: [{ messagesIds: messagesId, folderId: folder.id }]
 					});
 
 					expect(functions.canExecute()).toEqual(assertion);
+				});
+
+				it('should return false when messages are already in the Archive folder - archive action should not appear', () => {
+					const {
+						result: { current: functions }
+					} = setupHook(useMsgArchiveFn, {
+						initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.ARCHIVE }]
+					});
+
+					expect(functions.canExecute()).toBe(false);
 				});
 			});
 
@@ -112,7 +123,7 @@ describe('useMsgArchive', () => {
 					const {
 						result: { current: functions }
 					} = setupHook(useMsgArchiveFn, {
-						initialProps: [{ messagesIds: messagesId }]
+						initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
 					});
 
 					await act(async () => {
@@ -137,6 +148,7 @@ describe('useMsgArchive', () => {
 						initialProps: [
 							{
 								messagesIds: messagesId,
+								folderId: FOLDERS.INBOX,
 								onActionComplete
 							}
 						]

--- a/src/hooks/actions/tests/use-msg-archive.test.tsx
+++ b/src/hooks/actions/tests/use-msg-archive.test.tsx
@@ -30,7 +30,7 @@ describe('useMsgArchive', () => {
 			const {
 				result: { current: functions }
 			} = setupHook(useMsgArchiveFn, {
-				initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+				initialProps: [{ messagesIds: messagesId }]
 			});
 
 			act(() => functions.execute());
@@ -49,7 +49,7 @@ describe('useMsgArchive', () => {
 				const {
 					result: { current: descriptor }
 				} = setupHook(useMsgArchiveDescriptor, {
-					initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+					initialProps: [{ messagesIds: messagesId }]
 				});
 
 				expect(descriptor).toEqual({
@@ -67,7 +67,7 @@ describe('useMsgArchive', () => {
 				const {
 					result: { current: functions }
 				} = setupHook(useMsgArchiveFn, {
-					initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+					initialProps: [{ messagesIds: messagesId }]
 				});
 
 				expect(functions).toEqual({
@@ -82,14 +82,14 @@ describe('useMsgArchive', () => {
 					${FOLDERS_DESCRIPTORS.INBOX}        | ${true}
 					${FOLDERS_DESCRIPTORS.SENT}         | ${true}
 					${FOLDERS_DESCRIPTORS.DRAFTS}       | ${true}
-					${FOLDERS_DESCRIPTORS.TRASH}        | ${false}
+					${FOLDERS_DESCRIPTORS.TRASH}        | ${true}
 					${FOLDERS_DESCRIPTORS.SPAM}         | ${true}
 					${FOLDERS_DESCRIPTORS.USER_DEFINED} | ${true}
-				`(`should return $assertion if the folder is $folder.desc`, ({ folder, assertion }) => {
+				`(`should return $assertion if the folder is $folder.desc`, ({ assertion }) => {
 					const {
 						result: { current: functions }
 					} = setupHook(useMsgArchiveFn, {
-						initialProps: [{ messagesIds: messagesId, folderId: folder.id }]
+						initialProps: [{ messagesIds: messagesId }]
 					});
 
 					expect(functions.canExecute()).toEqual(assertion);
@@ -101,7 +101,7 @@ describe('useMsgArchive', () => {
 					const apiResponse: MsgActionResponse = {
 						action: {
 							id: messagesId.join(','),
-							op: 'archive'
+							op: 'move'
 						}
 					};
 					const apiInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
@@ -112,7 +112,7 @@ describe('useMsgArchive', () => {
 					const {
 						result: { current: functions }
 					} = setupHook(useMsgArchiveFn, {
-						initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+						initialProps: [{ messagesIds: messagesId }]
 					});
 
 					await act(async () => {
@@ -121,27 +121,10 @@ describe('useMsgArchive', () => {
 
 					const requestParameter = await apiInterceptor;
 					expect(requestParameter.action.id).toBe(messagesId.join(','));
-					expect(requestParameter.action.op).toBe('archive');
-					expect(requestParameter.action.l).toBeUndefined();
+					expect(requestParameter.action.op).toBe('move');
+					expect(requestParameter.action.l).toBe(FOLDERS.ARCHIVE);
 					expect(requestParameter.action.f).toBeUndefined();
 					expect(requestParameter.action.tn).toBeUndefined();
-				});
-
-				it('should not call the API if the action cannot be executed', async () => {
-					const apiCallSpy = vi.fn();
-					createSoapAPIInterceptor<MsgActionRequest>('MsgAction').then(apiCallSpy);
-
-					const {
-						result: { current: functions }
-					} = setupHook(useMsgArchiveFn, {
-						initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.TRASH }]
-					});
-
-					await act(async () => {
-						functions.execute();
-					});
-
-					expect(apiCallSpy).not.toHaveBeenCalled();
 				});
 
 				it('should call onActionComplete when provided after archiving messages', async () => {
@@ -154,7 +137,6 @@ describe('useMsgArchive', () => {
 						initialProps: [
 							{
 								messagesIds: messagesId,
-								folderId: FOLDERS.INBOX,
 								onActionComplete
 							}
 						]

--- a/src/hooks/actions/tests/use-msg-archive.test.tsx
+++ b/src/hooks/actions/tests/use-msg-archive.test.tsx
@@ -1,0 +1,172 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { act } from 'react';
+
+import { faker } from '@faker-js/faker';
+import { FOLDER_VIEW, FOLDERS } from '@zextras/carbonio-ui-commons';
+import { times } from 'lodash';
+
+import { useMsgArchiveDescriptor, useMsgArchiveFn } from '../use-msg-archive';
+import { setupHook } from '@test-setup';
+import { generateFolder } from '@test-utils/folders/folders-generator';
+import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { populateFoldersStore } from '@test-utils/store/folders';
+import { FOLDERS_DESCRIPTORS } from 'constants/index';
+import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+
+describe('useMsgArchive', () => {
+	const messagesId = times(faker.number.int({ max: 42 }), () =>
+		faker.number.int({ max: 42000 }).toString()
+	);
+
+	describe('Message Archive Action not usable when system ARCHIVE folder is not available', () => {
+		it('should not call the API if the action cannot be executed', async () => {
+			const apiCallSpy = vi.fn();
+			createSoapAPIInterceptor<MsgActionRequest>('MsgAction').then(apiCallSpy);
+
+			const {
+				result: { current: functions }
+			} = setupHook(useMsgArchiveFn, {
+				initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+			});
+
+			act(() => functions.execute());
+
+			expect(apiCallSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('useMsgArchive when system Archive folder is available', () => {
+		populateFoldersStore({
+			view: FOLDER_VIEW.message,
+			customFolders: [generateFolder({ id: FOLDERS.ARCHIVE, name: 'Archive', deletable: false })]
+		});
+		describe('Descriptor', () => {
+			it('Should return an object with specific id, icon, label and 2 functions', () => {
+				const {
+					result: { current: descriptor }
+				} = setupHook(useMsgArchiveDescriptor, {
+					initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+				});
+
+				expect(descriptor).toEqual({
+					id: 'message-archive',
+					icon: 'ArchiveOutline',
+					label: 'Archive',
+					execute: expect.any(Function),
+					canExecute: expect.any(Function)
+				});
+			});
+		});
+
+		describe('Functions', () => {
+			it('Should return an object with execute and canExecute functions', () => {
+				const {
+					result: { current: functions }
+				} = setupHook(useMsgArchiveFn, {
+					initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+				});
+
+				expect(functions).toEqual({
+					execute: expect.any(Function),
+					canExecute: expect.any(Function)
+				});
+			});
+
+			describe('canExecute', () => {
+				it.each`
+					folder                              | assertion
+					${FOLDERS_DESCRIPTORS.INBOX}        | ${true}
+					${FOLDERS_DESCRIPTORS.SENT}         | ${true}
+					${FOLDERS_DESCRIPTORS.DRAFTS}       | ${true}
+					${FOLDERS_DESCRIPTORS.TRASH}        | ${false}
+					${FOLDERS_DESCRIPTORS.SPAM}         | ${true}
+					${FOLDERS_DESCRIPTORS.USER_DEFINED} | ${true}
+				`(`should return $assertion if the folder is $folder.desc`, ({ folder, assertion }) => {
+					const {
+						result: { current: functions }
+					} = setupHook(useMsgArchiveFn, {
+						initialProps: [{ messagesIds: messagesId, folderId: folder.id }]
+					});
+
+					expect(functions.canExecute()).toEqual(assertion);
+				});
+			});
+
+			describe('execute', () => {
+				it('should call the API with the proper parameters', async () => {
+					const apiResponse: MsgActionResponse = {
+						action: {
+							id: messagesId.join(','),
+							op: 'archive'
+						}
+					};
+					const apiInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
+						'MsgAction',
+						apiResponse
+					);
+
+					const {
+						result: { current: functions }
+					} = setupHook(useMsgArchiveFn, {
+						initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.INBOX }]
+					});
+
+					await act(async () => {
+						functions.execute();
+					});
+
+					const requestParameter = await apiInterceptor;
+					expect(requestParameter.action.id).toBe(messagesId.join(','));
+					expect(requestParameter.action.op).toBe('archive');
+					expect(requestParameter.action.l).toBeUndefined();
+					expect(requestParameter.action.f).toBeUndefined();
+					expect(requestParameter.action.tn).toBeUndefined();
+				});
+
+				it('should not call the API if the action cannot be executed', async () => {
+					const apiCallSpy = vi.fn();
+					createSoapAPIInterceptor<MsgActionRequest>('MsgAction').then(apiCallSpy);
+
+					const {
+						result: { current: functions }
+					} = setupHook(useMsgArchiveFn, {
+						initialProps: [{ messagesIds: messagesId, folderId: FOLDERS.TRASH }]
+					});
+
+					await act(async () => {
+						functions.execute();
+					});
+
+					expect(apiCallSpy).not.toHaveBeenCalled();
+				});
+
+				it('should call onActionComplete when provided after archiving messages', async () => {
+					const onActionComplete = vi.fn();
+					createSoapAPIInterceptor('MsgAction');
+
+					const {
+						result: { current: functions }
+					} = setupHook(useMsgArchiveFn, {
+						initialProps: [
+							{
+								messagesIds: messagesId,
+								folderId: FOLDERS.INBOX,
+								onActionComplete
+							}
+						]
+					});
+
+					await act(async () => {
+						functions.execute();
+					});
+
+					expect(onActionComplete).toHaveBeenCalledWith(messagesId);
+				});
+			});
+		});
+	});
+});

--- a/src/hooks/actions/use-conv-actions.ts
+++ b/src/hooks/actions/use-conv-actions.ts
@@ -145,7 +145,8 @@ export const useConvActions = ({
 	});
 
 	const archiveDescriptor = useConvArchiveDescriptor({
-		conversationIds: [conversation.id]
+		conversationIds: [conversation.id],
+		folderId
 	});
 
 	return useMemo(

--- a/src/hooks/actions/use-conv-actions.ts
+++ b/src/hooks/actions/use-conv-actions.ts
@@ -145,8 +145,7 @@ export const useConvActions = ({
 	});
 
 	const archiveDescriptor = useConvArchiveDescriptor({
-		conversationIds: [conversation.id],
-		folderId
+		conversationIds: [conversation.id]
 	});
 
 	return useMemo(

--- a/src/hooks/actions/use-conv-actions.ts
+++ b/src/hooks/actions/use-conv-actions.ts
@@ -8,6 +8,7 @@ import { useMemo } from 'react';
 import { isTrash } from '@zextras/carbonio-ui-commons';
 import { find } from 'lodash';
 
+import { useConvArchiveDescriptor } from './use-conv-archive';
 import { getFolderIdParts, getParentFolderId, isDraft } from 'helpers/folders';
 import { useConvApplyTagDescriptor } from 'hooks/actions/use-conv-apply-tag';
 import { useConvDeletePermanentlyDescriptor } from 'hooks/actions/use-conv-delete-permanently';
@@ -53,6 +54,7 @@ type ConversationActionsReturnType = {
 	printDescriptor: UIActionDescriptor;
 	previewOnSeparatedWindowDescriptor: UIActionDescriptor;
 	showOriginalDescriptor: UIActionDescriptor;
+	archiveDescriptor: UIActionDescriptor;
 };
 
 export const useConvActions = ({
@@ -142,6 +144,11 @@ export const useConvActions = ({
 		folderId
 	});
 
+	const archiveDescriptor = useConvArchiveDescriptor({
+		conversationIds: [conversation.id],
+		folderId
+	});
+
 	return useMemo(
 		() => ({
 			replyDescriptor,
@@ -159,6 +166,7 @@ export const useConvActions = ({
 			applyTagDescriptor,
 			moveToFolderDescriptor,
 			restoreFolderDescriptor,
+			archiveDescriptor,
 			printDescriptor,
 			previewOnSeparatedWindowDescriptor,
 			showOriginalDescriptor
@@ -181,7 +189,8 @@ export const useConvActions = ({
 			restoreFolderDescriptor,
 			printDescriptor,
 			previewOnSeparatedWindowDescriptor,
-			showOriginalDescriptor
+			showOriginalDescriptor,
+			archiveDescriptor
 		]
 	);
 };

--- a/src/hooks/actions/use-conv-archive.tsx
+++ b/src/hooks/actions/use-conv-archive.tsx
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useCallback, useMemo } from 'react';
+
+import { useSnackbar } from '@zextras/carbonio-design-system';
+import { FOLDERS, isTrash } from '@zextras/carbonio-ui-commons';
+import { useTranslation } from 'react-i18next';
+
+import { ConversationActionsDescriptors } from 'constants/index';
+import { isSystemArchiveAvailable } from 'helpers/folders';
+import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
+import { useInSearchModule } from 'ui-actions/utils';
+import { useConversationDetailPanelControls } from 'views/app/detail-panel/detail-panel-controls-hooks';
+
+type ConvArchiveFunctionsParameter = {
+	folderId: string;
+	conversationIds: string[];
+	onActionComplete?: (conversationsIds: string[]) => void;
+};
+
+export const useConvArchiveFn = ({
+	folderId = FOLDERS.ARCHIVE,
+	conversationIds,
+	onActionComplete
+}: ConvArchiveFunctionsParameter): ActionFn => {
+	const canExecute = useCallback(
+		(): boolean => isSystemArchiveAvailable() && !isTrash(folderId),
+		[folderId]
+	);
+	const createSnackbar = useSnackbar();
+	const inSearchModule = useInSearchModule();
+	const [t] = useTranslation();
+	const { closeConversationPanel, currentConversation } = useConversationDetailPanelControls();
+
+	const execute = useCallback((): void => {
+		if (!canExecute()) {
+			return;
+		}
+		convActionEmailStoreAction({
+			operation: `archive`,
+			ids: conversationIds
+		}).then((res) => {
+			if ('Fault' in res) {
+				createSnackbar({
+					key: `archive-${conversationIds.join('-')}`,
+					replace: true,
+					severity: 'error',
+					label: t('label.error_try_again', 'Something went wrong, please try again'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+			} else {
+				onActionComplete?.(conversationIds);
+				if (
+					currentConversation &&
+					!inSearchModule &&
+					conversationIds.includes(currentConversation.id)
+				) {
+					closeConversationPanel();
+				}
+				createSnackbar({
+					key: `archive-${conversationIds.join('-')}`,
+					replace: true,
+					severity: 'info',
+					label: t('snackbar.conversation_moved_to_archive', 'Conversation moved to Archive'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+			}
+		});
+	}, [
+		canExecute,
+		conversationIds,
+		onActionComplete,
+		currentConversation,
+		inSearchModule,
+		createSnackbar,
+		t,
+		closeConversationPanel
+	]);
+
+	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
+};
+
+export const useConvArchiveDescriptor = ({
+	conversationIds,
+	folderId,
+	onActionComplete
+}: ConvArchiveFunctionsParameter): UIActionDescriptor => {
+	const { canExecute, execute } = useConvArchiveFn({
+		conversationIds,
+		folderId,
+		onActionComplete
+	});
+	const [t] = useTranslation();
+	return {
+		id: ConversationActionsDescriptors.ARCHIVE.id,
+		icon: 'ArchiveOutline',
+		label: t('label.archive', 'Archive'),
+		execute,
+		canExecute
+	};
+};

--- a/src/hooks/actions/use-conv-archive.tsx
+++ b/src/hooks/actions/use-conv-archive.tsx
@@ -6,11 +6,10 @@
 import { useCallback, useMemo } from 'react';
 
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
-import { isArchive, isSystemArchiveAvailable } from 'helpers/folders';
+import { getArchiveFolderId, isArchive, isSystemArchiveAvailable } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
 import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { useInSearchModule } from 'ui-actions/utils';
@@ -43,7 +42,7 @@ export const useConvArchiveFn = ({
 		convActionEmailStoreAction({
 			operation: `move`,
 			ids: conversationIds,
-			parent: FOLDERS.ARCHIVE
+			parent: getArchiveFolderId(folderId)
 		}).then((res) => {
 			if ('Fault' in res) {
 				createSnackbar({

--- a/src/hooks/actions/use-conv-archive.tsx
+++ b/src/hooks/actions/use-conv-archive.tsx
@@ -10,7 +10,7 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
-import { isSystemArchiveAvailable } from 'helpers/folders';
+import { isArchive, isSystemArchiveAvailable } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
 import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { useInSearchModule } from 'ui-actions/utils';
@@ -18,14 +18,19 @@ import { useConversationDetailPanelControls } from 'views/app/detail-panel/detai
 
 type ConvArchiveFunctionsParameter = {
 	conversationIds: string[];
+	folderId: string;
 	onActionComplete?: (conversationsIds: string[]) => void;
 };
 
 export const useConvArchiveFn = ({
 	conversationIds,
+	folderId,
 	onActionComplete
 }: ConvArchiveFunctionsParameter): ActionFn => {
-	const canExecute = useCallback((): boolean => isSystemArchiveAvailable(), []);
+	const canExecute = useCallback(
+		(): boolean => isSystemArchiveAvailable() && !isArchive(folderId),
+		[folderId]
+	);
 	const createSnackbar = useSnackbar();
 	const inSearchModule = useInSearchModule();
 	const [t] = useTranslation();
@@ -84,10 +89,12 @@ export const useConvArchiveFn = ({
 
 export const useConvArchiveDescriptor = ({
 	conversationIds,
+	folderId,
 	onActionComplete
 }: ConvArchiveFunctionsParameter): UIActionDescriptor => {
 	const { canExecute, execute } = useConvArchiveFn({
 		conversationIds,
+		folderId,
 		onActionComplete
 	});
 	const [t] = useTranslation();

--- a/src/hooks/actions/use-conv-archive.tsx
+++ b/src/hooks/actions/use-conv-archive.tsx
@@ -6,7 +6,7 @@
 import { useCallback, useMemo } from 'react';
 
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import { FOLDERS, isTrash } from '@zextras/carbonio-ui-commons';
+import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
@@ -17,20 +17,15 @@ import { useInSearchModule } from 'ui-actions/utils';
 import { useConversationDetailPanelControls } from 'views/app/detail-panel/detail-panel-controls-hooks';
 
 type ConvArchiveFunctionsParameter = {
-	folderId: string;
 	conversationIds: string[];
 	onActionComplete?: (conversationsIds: string[]) => void;
 };
 
 export const useConvArchiveFn = ({
-	folderId = FOLDERS.ARCHIVE,
 	conversationIds,
 	onActionComplete
 }: ConvArchiveFunctionsParameter): ActionFn => {
-	const canExecute = useCallback(
-		(): boolean => isSystemArchiveAvailable() && !isTrash(folderId),
-		[folderId]
-	);
+	const canExecute = useCallback((): boolean => isSystemArchiveAvailable(), []);
 	const createSnackbar = useSnackbar();
 	const inSearchModule = useInSearchModule();
 	const [t] = useTranslation();
@@ -41,8 +36,9 @@ export const useConvArchiveFn = ({
 			return;
 		}
 		convActionEmailStoreAction({
-			operation: `archive`,
-			ids: conversationIds
+			operation: `move`,
+			ids: conversationIds,
+			parent: FOLDERS.ARCHIVE
 		}).then((res) => {
 			if ('Fault' in res) {
 				createSnackbar({
@@ -88,12 +84,10 @@ export const useConvArchiveFn = ({
 
 export const useConvArchiveDescriptor = ({
 	conversationIds,
-	folderId,
 	onActionComplete
 }: ConvArchiveFunctionsParameter): UIActionDescriptor => {
 	const { canExecute, execute } = useConvArchiveFn({
 		conversationIds,
-		folderId,
 		onActionComplete
 	});
 	const [t] = useTranslation();

--- a/src/hooks/actions/use-conv-archive.tsx
+++ b/src/hooks/actions/use-conv-archive.tsx
@@ -62,11 +62,15 @@ export const useConvArchiveFn = ({
 				) {
 					closeConversationPanel();
 				}
+				const snackbarLabel =
+					conversationIds.length === 1
+						? t('snackbar.conversation_moved_to_archive', 'Conversation moved to Archive')
+						: t('snackbar.conversations_moved_to_archive', 'Conversations moved to Archive');
 				createSnackbar({
 					key: `archive-${conversationIds.join('-')}`,
 					replace: true,
 					severity: 'info',
-					label: t('snackbar.conversation_moved_to_archive', 'Conversation moved to Archive'),
+					label: snackbarLabel,
 					autoHideTimeout: 3000,
 					hideButton: true
 				});
@@ -74,13 +78,14 @@ export const useConvArchiveFn = ({
 		});
 	}, [
 		canExecute,
+		closeConversationPanel,
 		conversationIds,
-		onActionComplete,
-		currentConversation,
-		inSearchModule,
 		createSnackbar,
-		t,
-		closeConversationPanel
+		currentConversation,
+		folderId,
+		inSearchModule,
+		onActionComplete,
+		t
 	]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);

--- a/src/hooks/actions/use-msg-actions.ts
+++ b/src/hooks/actions/use-msg-actions.ts
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 
 import { useParams } from 'react-router-dom';
 
+import { useMsgArchiveDescriptor } from './use-msg-archive';
 import { getParentFolderId } from 'helpers/folders';
 import { useMsgApplyTagDescriptor } from 'hooks/actions/use-msg-apply-tag';
 import { useMsgCreateAppointmentDescriptor } from 'hooks/actions/use-msg-create-appointment';
@@ -62,6 +63,7 @@ type MessageActionsReturnType = {
 	editAsNewDescriptor: UIActionDescriptor;
 	showOriginalDescriptor: UIActionDescriptor;
 	downloadEmlDescriptor: UIActionDescriptor;
+	archiveDescriptor: UIActionDescriptor;
 };
 
 export const useMsgActions = ({
@@ -124,6 +126,10 @@ export const useMsgActions = ({
 	});
 	const createAppointmentDescriptor = useMsgCreateAppointmentDescriptor(message, folderId);
 	const printDescriptor = useMsgPrintDescriptor(message, folderId);
+	const archiveDescriptor = useMsgArchiveDescriptor({
+		folderId,
+		messageId: message.id
+	});
 
 	const redirectDescriptor = useMsgRedirectDescriptor(message.id, folderId);
 	const editDraftDescriptor = useMsgEditDraftDescriptor(message.id, message.isScheduled, folderId);
@@ -160,13 +166,15 @@ export const useMsgActions = ({
 			editDraftDescriptor,
 			editAsNewDescriptor,
 			showOriginalDescriptor,
-			downloadEmlDescriptor
+			downloadEmlDescriptor,
+			archiveDescriptor
 		}),
 		[
 			applyTagDescriptor,
 			createAppointmentDescriptor,
 			deletePermanentlyDescriptor,
 			downloadEmlDescriptor,
+			archiveDescriptor,
 			editAsNewDescriptor,
 			editDraftDescriptor,
 			flagDescriptor,

--- a/src/hooks/actions/use-msg-actions.ts
+++ b/src/hooks/actions/use-msg-actions.ts
@@ -127,7 +127,6 @@ export const useMsgActions = ({
 	const createAppointmentDescriptor = useMsgCreateAppointmentDescriptor(message, folderId);
 	const printDescriptor = useMsgPrintDescriptor(message, folderId);
 	const archiveDescriptor = useMsgArchiveDescriptor({
-		folderId,
 		messagesIds: [message.id]
 	});
 

--- a/src/hooks/actions/use-msg-actions.ts
+++ b/src/hooks/actions/use-msg-actions.ts
@@ -127,7 +127,8 @@ export const useMsgActions = ({
 	const createAppointmentDescriptor = useMsgCreateAppointmentDescriptor(message, folderId);
 	const printDescriptor = useMsgPrintDescriptor(message, folderId);
 	const archiveDescriptor = useMsgArchiveDescriptor({
-		messagesIds: [message.id]
+		messagesIds: [message.id],
+		folderId
 	});
 
 	const redirectDescriptor = useMsgRedirectDescriptor(message.id, folderId);

--- a/src/hooks/actions/use-msg-actions.ts
+++ b/src/hooks/actions/use-msg-actions.ts
@@ -128,7 +128,7 @@ export const useMsgActions = ({
 	const printDescriptor = useMsgPrintDescriptor(message, folderId);
 	const archiveDescriptor = useMsgArchiveDescriptor({
 		folderId,
-		messageId: message.id
+		messagesIds: [message.id]
 	});
 
 	const redirectDescriptor = useMsgRedirectDescriptor(message.id, folderId);

--- a/src/hooks/actions/use-msg-archive.tsx
+++ b/src/hooks/actions/use-msg-archive.tsx
@@ -58,11 +58,15 @@ export const useMsgArchiveFn = ({
 				if (currentMessage && !inSearchModule && messagesIds.includes(currentMessage.id)) {
 					closeMessagePanel();
 				}
+				const snackbarLabel =
+					messagesIds.length === 1
+						? t('snackbar.message_moved_to_archive', 'E-mail moved to Archive')
+						: t('snackbar.messages_moved_to_archive', 'E-mails moved to Archive');
 				createSnackbar({
 					key: `archive-${messagesIds.join(',')}`,
 					replace: true,
 					severity: 'info',
-					label: t('snackbar.message_moved_to_archive', 'E-mail moved to Archive'),
+					label: snackbarLabel,
 					autoHideTimeout: 3000,
 					hideButton: true
 				});

--- a/src/hooks/actions/use-msg-archive.tsx
+++ b/src/hooks/actions/use-msg-archive.tsx
@@ -14,7 +14,7 @@ import { isArchive, isSystemArchiveAvailable } from 'helpers/folders';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
 import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { useInSearchModule } from 'ui-actions/utils';
-import { useConversationDetailPanelControls } from 'views/app/detail-panel/detail-panel-controls-hooks';
+import { useMessageDetailPanelControls } from 'views/app/detail-panel/detail-panel-controls-hooks';
 
 type MsgArchiveFunctionsParameter = {
 	messagesIds: string[];
@@ -34,7 +34,7 @@ export const useMsgArchiveFn = ({
 	const createSnackbar = useSnackbar();
 	const inSearchModule = useInSearchModule();
 	const [t] = useTranslation();
-	const { closeConversationPanel, currentConversation } = useConversationDetailPanelControls();
+	const { closeMessagePanel, currentMessage } = useMessageDetailPanelControls();
 
 	const execute = useCallback((): void => {
 		if (!canExecute()) {
@@ -56,12 +56,8 @@ export const useMsgArchiveFn = ({
 				});
 			} else {
 				onActionComplete?.(messagesIds);
-				if (
-					currentConversation &&
-					!inSearchModule &&
-					messagesIds.includes(currentConversation.id)
-				) {
-					closeConversationPanel();
+				if (currentMessage && !inSearchModule && messagesIds.includes(currentMessage.id)) {
+					closeMessagePanel();
 				}
 				createSnackbar({
 					key: `archive-${messagesIds.join(',')}`,
@@ -75,13 +71,13 @@ export const useMsgArchiveFn = ({
 		});
 	}, [
 		canExecute,
+		closeMessagePanel,
+		createSnackbar,
+		currentMessage,
+		inSearchModule,
 		messagesIds,
 		onActionComplete,
-		currentConversation,
-		inSearchModule,
-		createSnackbar,
-		t,
-		closeConversationPanel
+		t
 	]);
 
 	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);

--- a/src/hooks/actions/use-msg-archive.tsx
+++ b/src/hooks/actions/use-msg-archive.tsx
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useCallback, useMemo } from 'react';
+
+import { useSnackbar } from '@zextras/carbonio-design-system';
+import { isTrash } from '@zextras/carbonio-ui-commons';
+import { useTranslation } from 'react-i18next';
+
+import { MessageActionsDescriptors } from 'constants/index';
+import { isSystemArchiveAvailable } from 'helpers/folders';
+import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
+import { useInSearchModule } from 'ui-actions/utils';
+import { useConversationDetailPanelControls } from 'views/app/detail-panel/detail-panel-controls-hooks';
+
+type MsgArchiveFunctionsParameter = {
+	folderId: string;
+	messagesIds: string[];
+	onActionComplete?: (messagesIds: string[]) => void;
+};
+
+export const useMsgArchiveFn = ({
+	folderId,
+	messagesIds,
+	onActionComplete
+}: MsgArchiveFunctionsParameter): ActionFn => {
+	const canExecute = useCallback(
+		(): boolean => isSystemArchiveAvailable() && !isTrash(folderId),
+		[folderId]
+	);
+	const createSnackbar = useSnackbar();
+	const inSearchModule = useInSearchModule();
+	const [t] = useTranslation();
+	const { closeConversationPanel, currentConversation } = useConversationDetailPanelControls();
+
+	const execute = useCallback((): void => {
+		if (!canExecute()) {
+			return;
+		}
+		msgActionEmailStoreAction({
+			operation: `archive`,
+			ids: messagesIds
+		}).then((res) => {
+			if ('Fault' in res) {
+				createSnackbar({
+					key: `archive-${messagesIds.join(',')}`,
+					replace: true,
+					severity: 'error',
+					label: t('label.error_try_again', 'Something went wrong, please try again'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+			} else {
+				onActionComplete?.(messagesIds);
+				if (
+					currentConversation &&
+					!inSearchModule &&
+					messagesIds.includes(currentConversation.id)
+				) {
+					closeConversationPanel();
+				}
+				createSnackbar({
+					key: `archive-${messagesIds.join(',')}`,
+					replace: true,
+					severity: 'info',
+					label: t('snackbar.message_moved_to_archive', 'E-mail moved to Archive'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+			}
+		});
+	}, [
+		canExecute,
+		messagesIds,
+		onActionComplete,
+		currentConversation,
+		inSearchModule,
+		createSnackbar,
+		t,
+		closeConversationPanel
+	]);
+
+	return useMemo(() => ({ canExecute, execute }), [canExecute, execute]);
+};
+
+export const useMsgArchiveDescriptor = ({
+	messagesIds,
+	folderId,
+	onActionComplete
+}: MsgArchiveFunctionsParameter): UIActionDescriptor => {
+	const { canExecute, execute } = useMsgArchiveFn({
+		messagesIds,
+		folderId,
+		onActionComplete
+	});
+	const [t] = useTranslation();
+	return {
+		id: MessageActionsDescriptors.ARCHIVE.id,
+		icon: 'ArchiveOutline',
+		label: t('label.archive', 'Archive'),
+		execute,
+		canExecute
+	};
+};

--- a/src/hooks/actions/use-msg-archive.tsx
+++ b/src/hooks/actions/use-msg-archive.tsx
@@ -6,7 +6,7 @@
 import { useCallback, useMemo } from 'react';
 
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import { isTrash } from '@zextras/carbonio-ui-commons';
+import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
@@ -17,20 +17,15 @@ import { useInSearchModule } from 'ui-actions/utils';
 import { useConversationDetailPanelControls } from 'views/app/detail-panel/detail-panel-controls-hooks';
 
 type MsgArchiveFunctionsParameter = {
-	folderId: string;
 	messagesIds: string[];
 	onActionComplete?: (messagesIds: string[]) => void;
 };
 
 export const useMsgArchiveFn = ({
-	folderId,
 	messagesIds,
 	onActionComplete
 }: MsgArchiveFunctionsParameter): ActionFn => {
-	const canExecute = useCallback(
-		(): boolean => isSystemArchiveAvailable() && !isTrash(folderId),
-		[folderId]
-	);
+	const canExecute = useCallback((): boolean => isSystemArchiveAvailable(), []);
 	const createSnackbar = useSnackbar();
 	const inSearchModule = useInSearchModule();
 	const [t] = useTranslation();
@@ -41,8 +36,9 @@ export const useMsgArchiveFn = ({
 			return;
 		}
 		msgActionEmailStoreAction({
-			operation: `archive`,
-			ids: messagesIds
+			operation: `move`,
+			ids: messagesIds,
+			parent: FOLDERS.ARCHIVE
 		}).then((res) => {
 			if ('Fault' in res) {
 				createSnackbar({
@@ -88,12 +84,10 @@ export const useMsgArchiveFn = ({
 
 export const useMsgArchiveDescriptor = ({
 	messagesIds,
-	folderId,
 	onActionComplete
 }: MsgArchiveFunctionsParameter): UIActionDescriptor => {
 	const { canExecute, execute } = useMsgArchiveFn({
 		messagesIds,
-		folderId,
 		onActionComplete
 	});
 	const [t] = useTranslation();

--- a/src/hooks/actions/use-msg-archive.tsx
+++ b/src/hooks/actions/use-msg-archive.tsx
@@ -6,11 +6,10 @@
 import { useCallback, useMemo } from 'react';
 
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
-import { isArchive, isSystemArchiveAvailable } from 'helpers/folders';
+import { getArchiveFolderId, isArchive, isSystemArchiveAvailable } from 'helpers/folders';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
 import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { useInSearchModule } from 'ui-actions/utils';
@@ -43,7 +42,7 @@ export const useMsgArchiveFn = ({
 		msgActionEmailStoreAction({
 			operation: `move`,
 			ids: messagesIds,
-			parent: FOLDERS.ARCHIVE
+			parent: getArchiveFolderId(folderId)
 		}).then((res) => {
 			if ('Fault' in res) {
 				createSnackbar({
@@ -74,6 +73,7 @@ export const useMsgArchiveFn = ({
 		closeMessagePanel,
 		createSnackbar,
 		currentMessage,
+		folderId,
 		inSearchModule,
 		messagesIds,
 		onActionComplete,

--- a/src/hooks/actions/use-msg-archive.tsx
+++ b/src/hooks/actions/use-msg-archive.tsx
@@ -10,7 +10,7 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
-import { isSystemArchiveAvailable } from 'helpers/folders';
+import { isArchive, isSystemArchiveAvailable } from 'helpers/folders';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
 import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { useInSearchModule } from 'ui-actions/utils';
@@ -18,14 +18,19 @@ import { useConversationDetailPanelControls } from 'views/app/detail-panel/detai
 
 type MsgArchiveFunctionsParameter = {
 	messagesIds: string[];
+	folderId: string;
 	onActionComplete?: (messagesIds: string[]) => void;
 };
 
 export const useMsgArchiveFn = ({
 	messagesIds,
+	folderId,
 	onActionComplete
 }: MsgArchiveFunctionsParameter): ActionFn => {
-	const canExecute = useCallback((): boolean => isSystemArchiveAvailable(), []);
+	const canExecute = useCallback(
+		(): boolean => isSystemArchiveAvailable() && !isArchive(folderId),
+		[folderId]
+	);
 	const createSnackbar = useSnackbar();
 	const inSearchModule = useInSearchModule();
 	const [t] = useTranslation();
@@ -84,10 +89,12 @@ export const useMsgArchiveFn = ({
 
 export const useMsgArchiveDescriptor = ({
 	messagesIds,
+	folderId,
 	onActionComplete
 }: MsgArchiveFunctionsParameter): UIActionDescriptor => {
 	const { canExecute, execute } = useMsgArchiveFn({
 		messagesIds,
+		folderId,
 		onActionComplete
 	});
 	const [t] = useTranslation();

--- a/src/hooks/use-folders.ts
+++ b/src/hooks/use-folders.ts
@@ -14,16 +14,20 @@ import { getFolderIdParts } from 'helpers/folders';
 /**
  * calculate the sorting criteria for a given folder
  * system folders are placed before user folders
- * the trash folder is always the last one
+ * the trash folder is always the second last one
+ * the archive folder is always the last one
  * @param folder
  * @returns the sorting criteria
  */
 export const getSortCriteria = (folder: Folder): string => {
 	const { id } = getFolderIdParts(folder.id);
-	if (id === FOLDERS.TRASH) {
+	if (id === FOLDERS.ARCHIVE) {
 		return FOLDERS.LAST_SYSTEM_FOLDER_POSITION;
 	}
-	return parseInt(id ?? '', 10) < 17 ? `   ${id}` : folder.name.toLowerCase();
+	if (id === FOLDERS.TRASH) {
+		return (Number.parseFloat(FOLDERS.LAST_SYSTEM_FOLDER_POSITION) - 1).toString();
+	}
+	return Number.parseInt(id ?? '', 10) < 18 ? `   ${id}` : folder.name.toLowerCase();
 };
 
 /**

--- a/src/hooks/use-folders.ts
+++ b/src/hooks/use-folders.ts
@@ -27,7 +27,10 @@ export const getSortCriteria = (folder: Folder): string => {
 	if (id === FOLDERS.TRASH) {
 		return (Number.parseFloat(FOLDERS.LAST_SYSTEM_FOLDER_POSITION) - 1).toString();
 	}
-	return Number.parseInt(id ?? '', 10) < 18 ? `   ${id}` : folder.name.toLowerCase();
+	const higherThanSystemFolders = Number.parseInt(FOLDERS.LAST_SYSTEM_FOLDER_POSITION, 10) + 1;
+	return Number.parseInt(id ?? '', 10) < higherThanSystemFolders
+		? `   ${id}`
+		: folder.name.toLowerCase();
 };
 
 /**

--- a/src/types/soap/conv-action.ts
+++ b/src/types/soap/conv-action.ts
@@ -18,8 +18,7 @@ export type ConvActionOperation =
 	| 'delete'
 	| 'spam'
 	| '!spam'
-	| 'update'
-	| 'archive';
+	| 'update';
 
 export type ConvActionRequest = ZimbraRequest & {
 	action: {

--- a/src/types/soap/conv-action.ts
+++ b/src/types/soap/conv-action.ts
@@ -18,7 +18,8 @@ export type ConvActionOperation =
 	| 'delete'
 	| 'spam'
 	| '!spam'
-	| 'update';
+	| 'update'
+	| 'archive';
 
 export type ConvActionRequest = ZimbraRequest & {
 	action: {

--- a/src/types/soap/msg-action.ts
+++ b/src/types/soap/msg-action.ts
@@ -17,7 +17,8 @@ export type MsgActionOperation =
 	| 'delete'
 	| 'spam'
 	| '!spam'
-	| 'update';
+	| 'update'
+	| 'archive';
 
 export type MsgActionRequest = ZimbraRequest & {
 	action: {

--- a/src/types/soap/msg-action.ts
+++ b/src/types/soap/msg-action.ts
@@ -17,8 +17,7 @@ export type MsgActionOperation =
 	| 'delete'
 	| 'spam'
 	| '!spam'
-	| 'update'
-	| 'archive';
+	| 'update';
 
 export type MsgActionRequest = ZimbraRequest & {
 	action: {

--- a/src/views/app/detail-panel/detail-panel-controls-hooks.ts
+++ b/src/views/app/detail-panel/detail-panel-controls-hooks.ts
@@ -33,3 +33,28 @@ export const useConversationDetailPanelControls = (): ConversationDetailPanelCon
 		currentConversation: itemId ? { id: itemId } : undefined
 	};
 };
+
+type MessagePanelState = {
+	id: string;
+};
+type MessageDetailPanelControls = {
+	closeMessagePanel: () => void;
+	openMessagePanel: (toOpen: string) => void;
+	currentMessage?: MessagePanelState;
+};
+export const useMessageDetailPanelControls = (): MessageDetailPanelControls => {
+	const { folderId, itemId } = useParams<FolderPanelRouteParams>();
+	const navigate = useNavigate();
+
+	return {
+		closeMessagePanel: (): void => {
+			navigate(`/${MAILS_ROUTE}/folder/${folderId}`, { replace: true });
+		},
+		openMessagePanel: (toOpen: string): void => {
+			navigate(`/${MAILS_ROUTE}/folder/${folderId}/message/${toOpen}`, {
+				replace: true
+			});
+		},
+		currentMessage: itemId ? { id: itemId } : undefined
+	};
+};

--- a/src/views/app/folder-panel/conversations/conversation-list-item-wrapper.tsx
+++ b/src/views/app/folder-panel/conversations/conversation-list-item-wrapper.tsx
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 import React, { ReactNode, useMemo } from 'react';
 
 import { ContainerProps, Dropdown } from '@zextras/carbonio-design-system';
@@ -11,11 +16,6 @@ import { HoverBarContainer } from 'views/app/folder-panel/parts/hover-bar-contai
 import { HoverContainer } from 'views/app/folder-panel/parts/hover-container';
 import { ListItemHoverActions } from 'views/app/folder-panel/parts/list-item-hover-actions';
 
-/*
- * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
 export const ConversationListItemActionWrapper = ({
 	conversation,
 	active,
@@ -48,10 +48,12 @@ export const ConversationListItemActionWrapper = ({
 		restoreFolderDescriptor,
 		printDescriptor,
 		previewOnSeparatedWindowDescriptor,
-		showOriginalDescriptor
+		showOriginalDescriptor,
+		archiveDescriptor
 	} = useConvActions({
 		conversation
 	});
+
 	const hoverActions = useMemo(
 		() => [
 			moveToTrashDescriptor,
@@ -72,7 +74,9 @@ export const ConversationListItemActionWrapper = ({
 			restoreFolderDescriptor
 		]
 	);
+
 	const tagItem = useTagDropdownItem(applyTagDescriptor, conversation.tags);
+
 	const dropdownItems = useMemo(
 		() =>
 			[
@@ -88,6 +92,7 @@ export const ConversationListItemActionWrapper = ({
 						normalizeDropdownActionItem(forwardAsAttachmentDescriptor)
 					]
 				},
+				normalizeDropdownActionItem(archiveDescriptor),
 				normalizeDropdownActionItem(moveToTrashDescriptor),
 				normalizeDropdownActionItem(deletePermanentlyDescriptor),
 				normalizeDropdownActionItem(setAsReadDescriptor),
@@ -122,9 +127,11 @@ export const ConversationListItemActionWrapper = ({
 			printDescriptor,
 			previewOnSeparatedWindowDescriptor,
 			showOriginalDescriptor,
+			archiveDescriptor,
 			t
 		]
 	);
+
 	return (
 		<Dropdown
 			contextMenu

--- a/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
+++ b/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
@@ -110,6 +110,7 @@ export const ConversationsMultipleSelectionActions = ({
 	const actions = [
 		setAsRead,
 		setAsUnread,
+		convArchiveDescriptor,
 		moveToTrash,
 		deletePermanently,
 		{
@@ -119,7 +120,6 @@ export const ConversationsMultipleSelectionActions = ({
 			items: [
 				normalizeDropdownActionItem(flagDescriptor),
 				normalizeDropdownActionItem(unflagDescriptor),
-				normalizeDropdownActionItem(convArchiveDescriptor),
 				normalizeDropdownActionItem(moveToFolderDescriptor),
 				tagItem,
 				normalizeDropdownActionItem(setAsSpam),

--- a/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
+++ b/src/views/app/folder-panel/conversations/conversations-multiple-selection-actions.tsx
@@ -9,6 +9,7 @@ import { DropdownItem } from '@zextras/carbonio-design-system';
 import { intersection, map, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
+import { useConvArchiveDescriptor } from '../../../../hooks/actions/use-conv-archive';
 import { normalizeDropdownActionItem } from 'helpers/actions';
 import { useConvApplyTagDescriptor } from 'hooks/actions/use-conv-apply-tag';
 import { useConvDeletePermanentlyDescriptor } from 'hooks/actions/use-conv-delete-permanently';
@@ -85,6 +86,12 @@ export const ConversationsMultipleSelectionActions = ({
 		selectedConversationsIds,
 		!atLeastOneConvIsUnflagged
 	);
+
+	const convArchiveDescriptor = useConvArchiveDescriptor({
+		conversationIds: selectedConversationsIds,
+		folderId,
+		onActionComplete
+	});
 	const moveToFolderDescriptor = useConvMoveToFolderDescriptor({
 		folderId,
 		ids: selectedConversationsIds,
@@ -112,6 +119,7 @@ export const ConversationsMultipleSelectionActions = ({
 			items: [
 				normalizeDropdownActionItem(flagDescriptor),
 				normalizeDropdownActionItem(unflagDescriptor),
+				normalizeDropdownActionItem(convArchiveDescriptor),
 				normalizeDropdownActionItem(moveToFolderDescriptor),
 				tagItem,
 				normalizeDropdownActionItem(setAsSpam),

--- a/src/views/app/folder-panel/messages/message-list-item-action-wrapper.tsx
+++ b/src/views/app/folder-panel/messages/message-list-item-action-wrapper.tsx
@@ -26,6 +26,7 @@ type MessageListItemActionWrapperProps = {
 	active?: boolean;
 	item: MailMessage;
 };
+
 export const MessageListItemActionWrapper = ({
 	item,
 	active,
@@ -57,7 +58,8 @@ export const MessageListItemActionWrapper = ({
 		editDraftDescriptor,
 		editAsNewDescriptor,
 		showOriginalDescriptor,
-		downloadEmlDescriptor
+		downloadEmlDescriptor,
+		archiveDescriptor
 	} = useMsgActions({ message: item, shouldReplaceHistory });
 
 	const tagItem = useTagDropdownItem(applyTagDescriptor, item.tags);
@@ -78,6 +80,7 @@ export const MessageListItemActionWrapper = ({
 						normalizeDropdownActionItem(forwardAsAttachmentDescriptor)
 					]
 				},
+				normalizeDropdownActionItem(archiveDescriptor),
 				normalizeDropdownActionItem(moveToTrashDescriptor),
 				normalizeDropdownActionItem(deletePermanentlyDescriptor),
 				normalizeDropdownActionItem(messageReadDescriptor),
@@ -99,31 +102,32 @@ export const MessageListItemActionWrapper = ({
 				normalizeDropdownActionItem(downloadEmlDescriptor)
 			].filter((action) => !action.disabled && !(draftItem && action.id === 'ForwardMenu')),
 		[
-			createAppointmentDescriptor,
-			deletePermanentlyDescriptor,
-			downloadEmlDescriptor,
-			editAsNewDescriptor,
-			editDraftDescriptor,
-			flagDescriptor,
+			replyDescriptor,
+			replyAllDescriptor,
+			t,
 			forwardDescriptor,
 			forwardAsAttachmentDescriptor,
-			markAsNotSpamDescriptor,
-			markAsSpamDescriptor,
+			moveToTrashDescriptor,
+			deletePermanentlyDescriptor,
 			messageReadDescriptor,
 			messageUnreadDescriptor,
-			moveToFolderDescriptor,
-			moveToTrashDescriptor,
-			previewOnSeparatedWindowDescriptor,
-			printDescriptor,
-			redirectDescriptor,
-			replyAllDescriptor,
-			replyDescriptor,
-			restoreFolderDescriptor,
-			showOriginalDescriptor,
-			tagItem,
+			flagDescriptor,
 			unflagDescriptor,
-			draftItem,
-			t
+			markAsSpamDescriptor,
+			markAsNotSpamDescriptor,
+			tagItem,
+			moveToFolderDescriptor,
+			restoreFolderDescriptor,
+			createAppointmentDescriptor,
+			printDescriptor,
+			previewOnSeparatedWindowDescriptor,
+			redirectDescriptor,
+			editDraftDescriptor,
+			editAsNewDescriptor,
+			showOriginalDescriptor,
+			downloadEmlDescriptor,
+			archiveDescriptor,
+			draftItem
 		]
 	);
 

--- a/src/views/app/folder-panel/messages/messages-multiple-selection-actions.tsx
+++ b/src/views/app/folder-panel/messages/messages-multiple-selection-actions.tsx
@@ -11,6 +11,7 @@ import { filter, intersection, map, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
+import { useMsgArchiveDescriptor } from '../../../../hooks/actions/use-msg-archive';
 import { normalizeDropdownActionItem } from 'helpers/actions';
 import { useMsgApplyTagDescriptor } from 'hooks/actions/use-msg-apply-tag';
 import { useMsgDeletePermanentlyDescriptor } from 'hooks/actions/use-msg-delete-permanently';
@@ -81,6 +82,11 @@ export const MessagesMultipleSelectionActions = ({
 
 	const flagDescriptor = useMsgSetFlagDescriptor(ids, !atLeastOneMsgIsUnflagged);
 	const unflagDescriptor = useMsgSetUnflagDescriptor(ids, !atLeastOneMsgIsUnflagged);
+	const msgArchiveDescriptor = useMsgArchiveDescriptor({
+		messagesIds: ids,
+		folderId,
+		onActionComplete
+	});
 	const moveToFolderDescriptor = useMsgMoveToFolderDescriptor({ folderId, ids, onActionComplete });
 	const setAsSpam = useMsgSetSpamDescriptor({
 		ids,
@@ -107,6 +113,7 @@ export const MessagesMultipleSelectionActions = ({
 			items: [
 				normalizeDropdownActionItem(flagDescriptor),
 				normalizeDropdownActionItem(unflagDescriptor),
+				normalizeDropdownActionItem(msgArchiveDescriptor),
 				normalizeDropdownActionItem(moveToFolderDescriptor),
 				tagItem,
 				normalizeDropdownActionItem(setAsSpam),

--- a/src/views/app/folder-panel/messages/messages-multiple-selection-actions.tsx
+++ b/src/views/app/folder-panel/messages/messages-multiple-selection-actions.tsx
@@ -72,6 +72,13 @@ export const MessagesMultipleSelectionActions = ({
 		routeFolderId,
 		onActionComplete
 	});
+
+	const moveToArchive = useMsgArchiveDescriptor({
+		messagesIds: ids,
+		folderId,
+		onActionComplete
+	});
+
 	const deletePermanently = useMsgDeletePermanentlyDescriptor({ ids, folderId, onActionComplete });
 	const applyTagDescriptor = useMsgApplyTagDescriptor({
 		ids,
@@ -82,11 +89,7 @@ export const MessagesMultipleSelectionActions = ({
 
 	const flagDescriptor = useMsgSetFlagDescriptor(ids, !atLeastOneMsgIsUnflagged);
 	const unflagDescriptor = useMsgSetUnflagDescriptor(ids, !atLeastOneMsgIsUnflagged);
-	const msgArchiveDescriptor = useMsgArchiveDescriptor({
-		messagesIds: ids,
-		folderId,
-		onActionComplete
-	});
+
 	const moveToFolderDescriptor = useMsgMoveToFolderDescriptor({ folderId, ids, onActionComplete });
 	const setAsSpam = useMsgSetSpamDescriptor({
 		ids,
@@ -104,6 +107,7 @@ export const MessagesMultipleSelectionActions = ({
 	const actions = [
 		setAsRead,
 		setAsUnread,
+		moveToArchive,
 		moveToTrash,
 		deletePermanently,
 		{
@@ -113,7 +117,6 @@ export const MessagesMultipleSelectionActions = ({
 			items: [
 				normalizeDropdownActionItem(flagDescriptor),
 				normalizeDropdownActionItem(unflagDescriptor),
-				normalizeDropdownActionItem(msgArchiveDescriptor),
 				normalizeDropdownActionItem(moveToFolderDescriptor),
 				tagItem,
 				normalizeDropdownActionItem(setAsSpam),

--- a/src/views/sidebar/tests/use-folder-actions.test.tsx
+++ b/src/views/sidebar/tests/use-folder-actions.test.tsx
@@ -456,4 +456,27 @@ describe('useFolderActions', () => {
 		expect(newAction.disabled).toBe(true);
 		expect(editAction.disabled).toBe(true);
 	});
+
+	it('should disable the  move, delete and edit actions for the archive folder', async () => {
+		const folder = {
+			...defaultFolder,
+			id: FOLDERS.ARCHIVE
+		} as Folder;
+
+		const { result: actions } = renderHook(() => useFolderActions(folder));
+
+		const moveAction = actions.current.find(
+			(action) => action.id === FolderActionsType.MOVE
+		) as FolderActionsProps;
+		const deleteAction = actions.current.find(
+			(action) => action.id === FolderActionsType.DELETE
+		) as FolderActionsProps;
+		const editAction = actions.current.find(
+			(action) => action.id === FolderActionsType.EDIT
+		) as FolderActionsProps;
+
+		expect(moveAction.disabled).toBe(true);
+		expect(deleteAction.disabled).toBe(true);
+		expect(editAction.disabled).toBe(true);
+	});
 });

--- a/src/views/sidebar/use-folder-actions.tsx
+++ b/src/views/sidebar/use-folder-actions.tsx
@@ -376,6 +376,14 @@ export const useFolderActions = (folder: Folder): Array<FolderActionsProps> => {
 					? { ...action, disabled: true }
 					: action
 			);
+		case FOLDERS.ARCHIVE:
+			return defaultFolderActions.map((action) =>
+				action.id === FolderActionsType.MOVE ||
+				action.id === FolderActionsType.DELETE ||
+				action.id === FolderActionsType.EDIT
+					? { ...action, disabled: true }
+					: action
+			);
 		// customizable folders
 		default:
 			return folder.isLink

--- a/src/views/sidebar/utils.ts
+++ b/src/views/sidebar/utils.ts
@@ -76,6 +76,9 @@ export const getFolderIconName = (
 			case FOLDERS.TRASH:
 				iconName = 'Trash2Outline';
 				break;
+			case FOLDERS.ARCHIVE:
+				iconName = 'ArchiveOutline';
+				break;
 			default:
 				iconName = 'FolderOutline';
 		}
@@ -95,7 +98,8 @@ export const useTranslatedSystemFolders = (): Array<string> => {
 			translate('folders.drafts', 'Drafts'),
 			translate('folders.trash', 'Trash'),
 			translate('folders.spam', 'Spam'),
-			translate('folders.junk', 'Junk')
+			translate('folders.junk', 'Junk'),
+			translate('folders.archive', 'Archive')
 		],
 		[translate]
 	);
@@ -121,6 +125,8 @@ export const getSystemFolderTranslatedName = ({ folderName }: GetSystemFolderPro
 				return t('folders.spam', 'Spam');
 			case 'Junk':
 				return t('folders.junk', 'Junk');
+			case 'Archive':
+				return t('folders.archive', 'Archive');
 			default:
 				return folderName;
 		}


### PR DESCRIPTION
Adds **Archive** support across the mail UI by introducing new archive actions for both **messages** and **conversations**, wiring them into list item action menus, and updating folder-related helpers (icons, translations, and sorting) to recognize the system Archive folder.

**Changes:**
- Add new archive action hooks/descriptors for messages and conversations and surface them in item action dropdowns.
- Extend folder utilities to include Archive (icon + translated name) and adjust system folder sorting (Archive last).
- Bump `@zextras/carbonio-ui-commons` to a version that includes `FOLDERS.ARCHIVE`, and add/update related tests/constants.


THIS PR CAN BE MERGED ONLY AFTER THIS ONE https://github.com/zextras/carbonio-mailbox/pull/926