### PR TITLE
fix(CO-3219): Read receipt handling based on user settings

### DIFF
--- a/src/views/app/detail-panel/preview/parts/mail-preview-content.tsx
+++ b/src/views/app/detail-panel/preview/parts/mail-preview-content.tsx
@@ -15,7 +15,7 @@ import SharedInviteReply from 'integrations/shared-invite-reply/index';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
 import type { IncompleteMessage, MailMessage } from 'types/index.d';
 import AttachmentsBlock from 'views/app/detail-panel/preview/attachments-block';
-import ReadReceiptModal from 'views/app/detail-panel/preview/read-receipt-modal';
+import { ReadReceiptModal } from 'views/app/detail-panel/preview/read-receipt-modal';
 
 type MailPreviewContentProps = {
 	message: MailMessage | IncompleteMessage;

--- a/src/views/app/detail-panel/preview/read-receipt-modal.tsx
+++ b/src/views/app/detail-panel/preview/read-receipt-modal.tsx
@@ -6,14 +6,14 @@
 import React, { FC, ReactElement, useCallback, useEffect } from 'react';
 
 import { Container, CustomModal, Padding, Text } from '@zextras/carbonio-design-system';
-import { t } from '@zextras/carbonio-shell-ui';
+import { t, useUserSettings } from '@zextras/carbonio-shell-ui';
 import { ModalFooter, ModalHeader } from '@zextras/carbonio-ui-commons';
-import { sendDeliveryReportSoapApi } from 'api/send-delivery-request-soap-api';
-import { useUiUtilities } from 'hooks/use-ui-utilities';
-import type { MailMessage } from 'types/index.d';
 
 import { msgActionEmailStoreAction } from '../../../../store/emails/actions/msg-action-action';
 import { updateMessages } from '../../../../store/emails/store';
+import { sendDeliveryReportSoapApi } from 'api/send-delivery-request-soap-api';
+import { useUiUtilities } from 'hooks/use-ui-utilities';
+import type { MailMessage } from 'types/index.d';
 
 type ReadReceiptModalProps = {
 	open: boolean;
@@ -29,17 +29,20 @@ const ReadReceiptModal: FC<ReadReceiptModalProps> = ({
 	readReceiptSetting
 }): ReactElement => {
 	const { createSnackbar } = useUiUtilities();
+	const { prefs } = useUserSettings();
+	const isMarkManually = prefs?.zimbraPrefMarkMsgRead === '-1';
 
 	const onDoNotConfirm = useCallback(() => {
+		const flag = isMarkManually && !message?.read ? 'nu' : 'n';
 		msgActionEmailStoreAction({
 			operation: 'update',
 			ids: [message?.id],
-			flag: 'n'
+			flag
 		}).then(() => {
 			updateMessages([{ ...message, isReadReceiptRequested: false }]);
 		});
 		onClose();
-	}, [message, onClose]);
+	}, [isMarkManually, message, onClose]);
 
 	const onNotify = useCallback(() => {
 		sendDeliveryReportSoapApi(message.id).then(() => {

--- a/src/views/app/detail-panel/preview/read-receipt-modal.tsx
+++ b/src/views/app/detail-panel/preview/read-receipt-modal.tsx
@@ -22,7 +22,7 @@ type ReadReceiptModalProps = {
 	readReceiptSetting: string | undefined | number | Array<string | number>;
 };
 
-const ReadReceiptModal: FC<ReadReceiptModalProps> = ({
+export const ReadReceiptModal: FC<ReadReceiptModalProps> = ({
 	open,
 	onClose,
 	message,
@@ -95,5 +95,3 @@ const ReadReceiptModal: FC<ReadReceiptModalProps> = ({
 		</CustomModal>
 	);
 };
-
-export default ReadReceiptModal;

--- a/src/views/app/detail-panel/preview/tests/read-receipt-modal.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/read-receipt-modal.test.tsx
@@ -10,7 +10,7 @@ import { act, screen } from '@testing-library/react';
 import { useUserSettings } from '@zextras/carbonio-shell-ui';
 import type { Mock } from 'vitest';
 
-import ReadReceiptModal from '../read-receipt-modal';
+import { ReadReceiptModal } from '../read-receipt-modal';
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { generateMessage } from '__test__/generators/generateMessage';

--- a/src/views/app/detail-panel/preview/tests/read-receipt-modal.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/read-receipt-modal.test.tsx
@@ -14,6 +14,7 @@ import { ReadReceiptModal } from '../read-receipt-modal';
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { generateMessage } from '__test__/generators/generateMessage';
+import type { MsgActionRequest, MsgActionResponse } from 'types/index.d';
 
 const baseMessageWithReadReadReceiptRequested = generateMessage({
 	id: '12345',
@@ -26,6 +27,12 @@ vi.mock('@zextras/carbonio-shell-ui', () => ({
 }));
 
 describe('ReadReceiptModal', () => {
+	beforeEach(() => {
+		(useUserSettings as Mock).mockReturnValue({
+			prefs: {}
+		});
+	});
+
 	it('renders modal with correct texts when open', () => {
 		createSoapAPIInterceptor<{ mid: string }>('SendDeliveryReport');
 		setupTest(
@@ -44,8 +51,11 @@ describe('ReadReceiptModal', () => {
 		expect(screen.getByText('Do not notify')).toBeInTheDocument();
 	});
 
-	// FIXME: Missing api call setup, test fails with error
-	it.skip('should call onClose when "do not notify" action is triggered', async () => {
+	it('should call onClose when "do not notify" action is triggered', async () => {
+		const msgActionInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
+			'MsgAction',
+			{ action: { id: '12345', op: 'update' } }
+		);
 		const mockOnClose = vi.fn();
 		const { user } = setupTest(
 			<ReadReceiptModal
@@ -60,6 +70,88 @@ describe('ReadReceiptModal', () => {
 		await user.click(doNotNotifyButton);
 
 		expect(mockOnClose).toHaveBeenCalledTimes(1);
+		const request = await msgActionInterceptor;
+		expect(request.action.op).toBe('update');
+		expect(request.action.f).toBe('n');
+	});
+
+	it('should send flag "nu" when "do not notify" is clicked and message is unread with "Mark manually" setting', async () => {
+		(useUserSettings as Mock).mockReturnValue({
+			prefs: { zimbraPrefMarkMsgRead: '-1' }
+		});
+
+		const unreadMessage = generateMessage({
+			id: '12345',
+			isReadReceiptRequested: true,
+			isRead: false
+		});
+
+		const msgActionInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
+			'MsgAction',
+			{ action: { id: '12345', op: 'update' } }
+		);
+
+		const { user } = setupTest(
+			<ReadReceiptModal open onClose={vi.fn()} message={unreadMessage} readReceiptSetting="ask" />
+		);
+
+		const doNotNotifyButton = await screen.findByText('Do not notify');
+		await user.click(doNotNotifyButton);
+
+		const request = await msgActionInterceptor;
+		expect(request.action.op).toBe('update');
+		expect(request.action.f).toBe('nu');
+	});
+
+	it('should send flag "n" when "do not notify" is clicked and message is already read, even with "Mark manually" setting', async () => {
+		(useUserSettings as Mock).mockReturnValue({
+			prefs: { zimbraPrefMarkMsgRead: '-1' }
+		});
+
+		const readMessage = generateMessage({
+			id: '12345',
+			isReadReceiptRequested: true,
+			isRead: true
+		});
+
+		const msgActionInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
+			'MsgAction',
+			{ action: { id: '12345', op: 'update' } }
+		);
+
+		const { user } = setupTest(
+			<ReadReceiptModal open onClose={vi.fn()} message={readMessage} readReceiptSetting="ask" />
+		);
+
+		const doNotNotifyButton = await screen.findByText('Do not notify');
+		await user.click(doNotNotifyButton);
+
+		const request = await msgActionInterceptor;
+		expect(request.action.op).toBe('update');
+		expect(request.action.f).toBe('n');
+	});
+
+	it('should send flag "n" when "do not notify" is clicked and default (non-manual) mark-as-read setting is active', async () => {
+		const msgActionInterceptor = createSoapAPIInterceptor<MsgActionRequest, MsgActionResponse>(
+			'MsgAction',
+			{ action: { id: '12345', op: 'update' } }
+		);
+
+		const { user } = setupTest(
+			<ReadReceiptModal
+				open
+				onClose={vi.fn()}
+				message={baseMessageWithReadReadReceiptRequested}
+				readReceiptSetting="ask"
+			/>
+		);
+
+		const doNotNotifyButton = await screen.findByText('Do not notify');
+		await user.click(doNotNotifyButton);
+
+		const request = await msgActionInterceptor;
+		expect(request.action.op).toBe('update');
+		expect(request.action.f).toBe('n');
 	});
 
 	it('should call onClose when "notify" action is triggered', async () => {


### PR DESCRIPTION
Updates read-receipt “Do not notify” handling so the SOAP `MsgAction` flag respects the user’s “mark messages read manually” preference, preventing an unread message from being implicitly marked as read when declining to send a read receipt.

**Changes:**
- Update `ReadReceiptModal` to choose `MsgAction` flag `nu` vs `n` based on `PrefMarkMsgRead` and the message read state.
- Convert `ReadReceiptModal` from default export to named export and update imports accordingly.
- Expand and unskip unit tests to cover the new flag-selection behavior and verify the outgoing `MsgAction` payload.