### PR TITLE
fix (CO-3249): Sort by Date Asc doesn't work in trash folder

### DIFF
--- a/src/helpers/sorting.ts
+++ b/src/helpers/sorting.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { updateSettings } from '@zextras/carbonio-shell-ui';
-import { JSNS } from '@zextras/carbonio-ui-commons';
+import { isTrash, JSNS } from '@zextras/carbonio-ui-commons';
 import { AccountSettingsPrefs, soapFetchV2 } from '@zextras/carbonio-ui-soap-lib';
 import { TFunction } from 'i18next';
 
@@ -32,7 +32,9 @@ export function modifySettingString(
 	prefToUpdate: string,
 	folderId: string
 ): string {
-	if (prefToUpdate.endsWith('date-Desc')) {
+	const defaultSortSuffix = isTrash(folderId) ? 'changeDate-Desc' : 'date-Desc';
+
+	if (prefToUpdate.endsWith(defaultSortSuffix)) {
 		const removedFolder = zimbraPrefSortOrder.replaceAll(
 			new RegExp(`(?:^|,)${folderId}:[^,]*`, 'g'),
 			''

--- a/src/helpers/tests/sorting.test.ts
+++ b/src/helpers/tests/sorting.test.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { describe, it } from 'vitest';
 
 import { modifySettingString } from '../sorting';
@@ -150,5 +151,48 @@ describe('modifySettingString', () => {
 
 			expect(result).toBe('10:date-Asc,20:size-Asc,BDLV');
 		});
+	});
+});
+
+describe('modifySettingString - trash folder behavior', () => {
+	const trashFolderId = FOLDERS.TRASH;
+
+	it('should NOT remove trash folder entry when updating to date-Desc (date-Desc is not the trash default)', () => {
+		const input = `${trashFolderId}:date-Asc,20:size-Asc,BDLV`;
+		const prefToUpdate = `${trashFolderId}:date-Desc`;
+
+		const result = modifySettingString(input, prefToUpdate, trashFolderId);
+
+		expect(result).toBe(`${trashFolderId}:date-Desc,20:size-Asc,BDLV`);
+	});
+
+	it('should remove trash folder entry when updating to changeDate-Desc (changeDate-Desc is the trash default)', () => {
+		const input = `${trashFolderId}:date-Asc,20:size-Asc,BDLV`;
+		const prefToUpdate = `${trashFolderId}:changeDate-Desc`;
+
+		const result = modifySettingString(input, prefToUpdate, trashFolderId);
+
+		expect(result).toBe('20:size-Asc,BDLV');
+	});
+
+	it('should insert trash folder entry for date-Asc when not already present', () => {
+		const input = '20:size-Asc,BDLV';
+		const prefToUpdate = `${trashFolderId}:date-Asc`;
+
+		const result = modifySettingString(input, prefToUpdate, trashFolderId);
+
+		expect(result).toBe(`${trashFolderId}:date-Asc,20:size-Asc,BDLV`);
+	});
+
+	it('should preserve date-Desc in trash folder when toggling direction back to Desc after having selected date sort', () => {
+		// User selected 'date' (non-default) in trash, then toggled back to Desc
+		// Previously this was a bug: date-Desc in trash was treated as "default" and removed
+		const input = `${trashFolderId}:date-Asc,BDLV`;
+		const prefToUpdate = `${trashFolderId}:date-Desc`;
+
+		const result = modifySettingString(input, prefToUpdate, trashFolderId);
+
+		// Should update, not remove the entry
+		expect(result).toBe(`${trashFolderId}:date-Desc,BDLV`);
 	});
 });

--- a/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
@@ -237,6 +237,7 @@ export const SortAndFilterButtonComponent = ({
 			placement="top"
 		>
 			<Dropdown
+				maxHeight={'100vh'}
 				disableAutoFocus
 				items={dropdownItems}
 				multiple

--- a/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
+++ b/src/views/app/folder-panel/parts/sort-and-filter-button-component.tsx
@@ -89,7 +89,7 @@ const useListHeaderDropdownItems = ({ folderId }: { folderId: string }): Dropdow
 				<Container
 					style={{ minWidth: '160px' }}
 					crossAlignment="center"
-					mainAlignment="space-between"
+					mainAlignment="flex-start"
 					width="fill"
 					orientation="horizontal"
 				>

--- a/src/views/tests/app-view-sorting.test.tsx
+++ b/src/views/tests/app-view-sorting.test.tsx
@@ -8,14 +8,20 @@ import React from 'react';
 
 import { waitFor, within } from '@testing-library/react';
 import { FOLDERS } from '@zextras/carbonio-ui-commons';
+import { soapFetchV2 } from '@zextras/carbonio-ui-soap-lib';
 import { capitalize } from 'lodash';
 
 import { mockLayoutStorage } from '../../__test__/layouts-utils';
 import { setupViewByConversation } from '../../__test__/setup-utils';
-import { MAILS_VIEW_LAYOUTS, MAILS_VIEW_SPLIT_LAYOUT_ORIENTATIONS } from '../../constants';
-import { SORTING_OPTIONS } from '../../constants';
+import {
+	MAILS_VIEW_LAYOUTS,
+	MAILS_VIEW_SPLIT_LAYOUT_ORIENTATIONS,
+	SORTING_OPTIONS
+} from '../../constants';
 import AppView from '../app-view';
 import { screen, setupTest } from '@test-setup';
+import { useUserSettings } from '@test-utils/carbonio-shell-ui/carbonio-shell-ui';
+import { generateSettings } from '@test-utils/settings/settings-generator';
 import { populateFoldersStore } from '@test-utils/store/folders';
 
 const waitForLazySpinnerToDisappear = (): Promise<void> =>
@@ -25,6 +31,11 @@ const waitForLazySpinnerToDisappear = (): Promise<void> =>
 		},
 		{ timeout: 10000 }
 	);
+
+vi.mock('@zextras/carbonio-ui-soap-lib', () => ({
+	...vi.importActual('@zextras/carbonio-ui-soap-lib'),
+	soapFetchV2: vi.fn().mockResolvedValue({ Body: {} })
+}));
 
 describe('AppView sorting functionality', () => {
 	beforeEach(() => {
@@ -123,6 +134,128 @@ describe('AppView sorting functionality', () => {
 
 			const dateLabel = capitalize(SORTING_OPTIONS.date.label);
 			expect(within(dropdownList).getByText(`${dateLabel} (Default)`)).toBeInTheDocument();
+		});
+
+		describe('api call for sorting change', () => {
+			it('should call the API with date-Asc when user selects date sort and toggles to ascending in trash folder', async () => {
+				// Trash default is changeDate-Desc; user picks "date" then toggles direction to Asc
+				const settings = generateSettings({
+					prefs: {
+						zimbraPrefGroupMailBy: 'conversation',
+						zimbraPrefSortOrder: `${trashFolderId}:date-Desc`
+					}
+				});
+				useUserSettings.mockReturnValue(settings);
+
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/${trashFolderId}`]
+				});
+				await waitForLazySpinnerToDisappear();
+
+				// Direction button shows ZaListOutline when current direction is Desc
+				await user.click(screen.getByTestId('icon: AzListOutline'));
+				const dropdownList = await screen.findByTestId(/dropdown-popper-list/i);
+				await user.click(within(dropdownList).getByTestId('icon: ZaListOutline'));
+
+				expect(soapFetchV2).toHaveBeenCalledWith(
+					'ModifyPrefs',
+					expect.objectContaining({
+						_attrs: expect.objectContaining({
+							zimbraPrefSortOrder: expect.stringContaining(`${trashFolderId}:date-Asc`)
+						})
+					})
+				);
+			});
+
+			it('should call the API with date-Desc when user toggles back to descending after having chosen date sort in trash folder', async () => {
+				// User previously set date-Asc; toggling back to Desc must NOT fall back to changeDate-Desc
+				const settings = generateSettings({
+					prefs: {
+						zimbraPrefGroupMailBy: 'conversation',
+						zimbraPrefSortOrder: `${trashFolderId}:date-Asc`
+					}
+				});
+				useUserSettings.mockReturnValue(settings);
+
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/${trashFolderId}`]
+				});
+				await waitForLazySpinnerToDisappear();
+
+				// Direction button shows AzListOutline when current direction is Asc
+				await user.click(screen.getByTestId('icon: ZaListOutline'));
+				const dropdownList = await screen.findByTestId(/dropdown-popper-list/i);
+				await user.click(within(dropdownList).getByTestId('icon: AzListOutline'));
+
+				expect(soapFetchV2).toHaveBeenCalledWith(
+					'ModifyPrefs',
+					expect.objectContaining({
+						_attrs: expect.objectContaining({
+							zimbraPrefSortOrder: expect.stringContaining(`${trashFolderId}:date-Desc`)
+						})
+					})
+				);
+			});
+
+			it('should call the API without a trash folder entry when user resets to changeDate-Desc (the trash default)', async () => {
+				// After picking date-Asc, user switches back to changeDate sort — entry should be cleaned from prefs
+				const settings = generateSettings({
+					prefs: {
+						zimbraPrefGroupMailBy: 'conversation',
+						zimbraPrefSortOrder: `${trashFolderId}:date-Desc`
+					}
+				});
+				useUserSettings.mockReturnValue(settings);
+
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/${trashFolderId}`]
+				});
+				await waitForLazySpinnerToDisappear();
+
+				await user.click(screen.getByTestId('icon: AzListOutline'));
+				const dropdownList = await screen.findByTestId(/dropdown-popper-list/i);
+				const changeDateLabel = capitalize(SORTING_OPTIONS.changeDate.label);
+				await user.click(within(dropdownList).getByText(`${changeDateLabel} (Default)`));
+
+				expect(soapFetchV2).toHaveBeenCalledWith(
+					'ModifyPrefs',
+					expect.objectContaining({
+						_attrs: expect.objectContaining({
+							zimbraPrefSortOrder: expect.not.stringContaining(`${trashFolderId}:`)
+						})
+					})
+				);
+			});
+
+			it('should call the API with date-Desc when user selects date sort in non-trash folder', async () => {
+				const settings = generateSettings({
+					prefs: {
+						zimbraPrefGroupMailBy: 'conversation',
+						zimbraPrefSortOrder: `${inboxFolderId}:subj-Desc`
+					}
+				});
+				useUserSettings.mockReturnValue(settings);
+
+				const { user } = setupTest(<AppView />, {
+					initialEntries: [`/folder/${inboxFolderId}`]
+				});
+				await waitForLazySpinnerToDisappear();
+
+				await user.click(screen.getByTestId('icon: AzListOutline'));
+				const dropdownList = await screen.findByTestId(/dropdown-popper-list/i);
+				const dateLabel = capitalize(SORTING_OPTIONS.date.label);
+				await user.click(within(dropdownList).getByText(`${dateLabel} (Default)`));
+
+				// Selecting the default (date-Desc) for inbox removes the entry from prefs
+				expect(soapFetchV2).toHaveBeenCalledWith(
+					'ModifyPrefs',
+					expect.objectContaining({
+						_attrs: expect.objectContaining({
+							zimbraPrefSortOrder: expect.not.stringContaining(`${inboxFolderId}:`)
+						})
+					})
+				);
+			});
 		});
 	});
 

--- a/src/views/tests/app-view-sorting.test.tsx
+++ b/src/views/tests/app-view-sorting.test.tsx
@@ -32,10 +32,15 @@ const waitForLazySpinnerToDisappear = (): Promise<void> =>
 		{ timeout: 10000 }
 	);
 
-vi.mock('@zextras/carbonio-ui-soap-lib', () => ({
-	...vi.importActual('@zextras/carbonio-ui-soap-lib'),
-	soapFetchV2: vi.fn().mockResolvedValue({ Body: {} })
-}));
+vi.mock('@zextras/carbonio-ui-soap-lib', async () => {
+	const actual = await vi.importActual<typeof import('@zextras/carbonio-ui-soap-lib')>(
+		'@zextras/carbonio-ui-soap-lib'
+	);
+	return {
+		...actual,
+		soapFetchV2: vi.fn().mockResolvedValue({ Body: {} })
+	};
+});
 
 describe('AppView sorting functionality', () => {
 	beforeEach(() => {

--- a/src/views/tests/app-view-sorting.test.tsx
+++ b/src/views/tests/app-view-sorting.test.tsx
@@ -157,7 +157,7 @@ describe('AppView sorting functionality', () => {
 				});
 				await waitForLazySpinnerToDisappear();
 
-				// Direction button shows ZaListOutline when current direction is Desc
+				// Direction button shows AzListOutline when current direction is Desc
 				await user.click(screen.getByTestId('icon: AzListOutline'));
 				const dropdownList = await screen.findByTestId(/dropdown-popper-list/i);
 				await user.click(within(dropdownList).getByTestId('icon: ZaListOutline'));
@@ -187,7 +187,7 @@ describe('AppView sorting functionality', () => {
 				});
 				await waitForLazySpinnerToDisappear();
 
-				// Direction button shows AzListOutline when current direction is Asc
+				// Direction button shows ZaListOutline when current direction is Asc
 				await user.click(screen.getByTestId('icon: ZaListOutline'));
 				const dropdownList = await screen.findByTestId(/dropdown-popper-list/i);
 				await user.click(within(dropdownList).getByTestId('icon: AzListOutline'));
@@ -203,7 +203,7 @@ describe('AppView sorting functionality', () => {
 			});
 
 			it('should call the API without a trash folder entry when user resets to changeDate-Desc (the trash default)', async () => {
-				// After picking date-Asc, user switches back to changeDate sort — entry should be cleaned from prefs
+				// After picking date-Desc, user switches back to changeDate sort — entry should be cleaned from prefs
 				const settings = generateSettings({
 					prefs: {
 						zimbraPrefGroupMailBy: 'conversation',


### PR DESCRIPTION

This PR addresses a bug where changing sorting to **Date Asc** does not persist correctly in the **Trash** folder, by treating Trash’s default sort as `changeDate-Desc` (instead of `date-Desc`) when updating `prefSortOrder`.

**Changes:**
- Update sorting preference cleanup logic to use `changeDate-Desc` as the default only for Trash.
- Add unit tests for `modifySettingString` to cover Trash-specific default behavior.
- Add AppView integration tests to verify the SOAP `ModifyPrefs` call payload when changing sort/direction in Trash vs non-Trash folders.

**Other changes:**
- Update the alignment of Asc/Desc toggle button in sorting dropdown
- Update the height of dropdown to take full screen size if required