### PR TITLE
feat: integrate devtools middleware for zustand state management in editors and emails stores

### DIFF
--- a/src/store/editor/store.ts
+++ b/src/store/editor/store.ts
@@ -6,6 +6,7 @@
 import { produce } from 'immer';
 import { remove } from 'lodash';
 import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 import { selectUnsavedAttachmentByUploadId } from './store-selectors';
 import {
@@ -21,375 +22,462 @@ import {
 	UnsavedAttachment
 } from 'types/index.d';
 
-// extra currying as suggested in https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#basic-usage
-export const useEditorsStore = create<EditorsStateTypeV2>()((set, get) => ({
-	editors: {},
-	addEditor: (id: MailsEditorV2['id'], editor: MailsEditorV2): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				state.editors[id] = editor;
-			})
-		);
-	},
-	deleteEditor: (id: MailsEditorV2['id']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				delete state.editors[id];
-			})
-		);
-	},
-	setSubject: (id: MailsEditorV2['id'], subject: MailsEditorV2['subject']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].subject = subject;
-				}
-			})
-		);
-	},
-	setText: (id: MailsEditorV2['id'], text: MailsEditorV2['text']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].text = text;
-				}
-			})
-		);
-	},
-	setAutoSendTime: (id: MailsEditorV2['id'], autoSendTime: MailsEditorV2['autoSendTime']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].autoSendTime = autoSendTime;
-				}
-			})
-		);
-	},
-	setDid: (id: MailsEditorV2['id'], did: MailsEditorV2['did']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].did = did;
-				}
-			})
-		);
-	},
-	setSize: (id: MailsEditorV2['id'], size: MailsEditorV2['size']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].size = size;
-				}
-			})
-		);
-	},
-	setIsDirty: (id: MailsEditorV2['id'], value: MailsEditorV2['isDirty']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id] && state.editors[id].isDirty !== value) {
-					state.editors[id].isDirty = value;
-				}
-			})
-		);
-	},
-	setIsRichText: (id: MailsEditorV2['id'], value: MailsEditorV2['isRichText']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].isRichText = value;
-				}
-			})
-		);
-	},
-	setOriginalId: (id: MailsEditorV2['id'], originalId: MailsEditorV2['originalId']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].originalId = originalId;
-				}
-			})
-		);
-	},
-	setRecipients: (id: MailsEditorV2['id'], recipients: MailsEditorV2['recipients']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].recipients = recipients;
-				}
-			})
-		);
-	},
-	setToRecipients: (
-		id: MailsEditorV2['id'],
-		recipients: MailsEditorV2['recipients']['to']
-	): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].recipients.to = recipients;
-				}
-			})
-		);
-	},
-	setCcRecipients: (
-		id: MailsEditorV2['id'],
-		recipients: MailsEditorV2['recipients']['cc']
-	): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].recipients.cc = recipients;
-				}
-			})
-		);
-	},
-	setBccRecipients: (
-		id: MailsEditorV2['id'],
-		recipients: MailsEditorV2['recipients']['bcc']
-	): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].recipients.bcc = recipients;
-				}
-			})
-		);
-	},
-	setIdentityId: (id: MailsEditorV2['id'], from: MailsEditorV2['identityId']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].identityId = from;
-				}
-			})
-		);
-	},
-	setIsUrgent: (id: MailsEditorV2['id'], value: MailsEditorV2['isUrgent']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].isUrgent = value;
-				}
-			})
-		);
-	},
-	setRequestReadReceipt: (
-		id: MailsEditorV2['id'],
-		value: MailsEditorV2['requestReadReceipt']
-	): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].requestReadReceipt = value;
-				}
-			})
-		);
-	},
-	setDraftSaveAllowedStatus: (id, status): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].draftSaveAllowedStatus = status;
-				}
-			})
-		);
-	},
-	setDraftSaveProcessStatus: (id, status): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].draftSaveProcessStatus = status;
-				}
-			})
-		);
-	},
-	setSendAllowedStatus: (id, status): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].sendAllowedStatus = status;
-				}
-			})
-		);
-	},
-	setSendProcessStatus: (id, status): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].sendProcessStatus = status;
-				}
-			})
-		);
-	},
-	setSavedAttachments: (id: MailsEditorV2['id'], attachment: Array<SavedAttachment>): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].savedAttachments = [...attachment];
-				}
-			})
-		);
-	},
-	removeSavedAttachment: (id: MailsEditorV2['id'], partName: string): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					remove(state.editors[id].savedAttachments, ['partName', partName]);
-				}
-			})
-		);
-	},
-	removeUnsavedAttachments: (id: MailsEditorV2['id']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].unsavedAttachments = [];
-				}
-			})
-		);
-	},
-	addUnsavedAttachment: (id: MailsEditorV2['id'], attachment: UnsavedAttachment): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].unsavedAttachments.push(attachment);
-				}
-			})
-		);
-	},
-	addUnsavedAttachments: (id: MailsEditorV2['id'], attachments: Array<UnsavedAttachment>): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].unsavedAttachments.push(...attachments);
-				}
-			})
-		);
-	},
-	addSavedAttachment: (id: MailsEditorV2['id'], attachment: SavedAttachment): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].savedAttachments.push(attachment);
-				}
-			})
-		);
-	},
-	setAttachmentUploadStatus: (
-		id: MailsEditorV2['id'],
-		uploadId: string,
-		status: AttachmentUploadProcessStatus
-	): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				const unsavedAttachment = selectUnsavedAttachmentByUploadId(state, id, uploadId);
-				if (!unsavedAttachment) {
-					return;
-				}
+export const useEditorsStore = create<EditorsStateTypeV2>()(
+	devtools(
+		(set, get) => ({
+			editors: {},
+			addEditor: (id: MailsEditorV2['id'], editor: MailsEditorV2): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						state.editors[id] = editor;
+					}),
+					false,
+					'EDITOR/ADD_EDITOR'
+				);
+			},
+			deleteEditor: (id: MailsEditorV2['id']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						delete state.editors[id];
+					}),
+					false,
+					'EDITOR/DELETE_EDITOR'
+				);
+			},
+			setSubject: (id: MailsEditorV2['id'], subject: MailsEditorV2['subject']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].subject = subject;
+						}
+					}),
+					false,
+					'EDITOR/SET_SUBJECT'
+				);
+			},
+			setText: (id: MailsEditorV2['id'], text: MailsEditorV2['text']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].text = text;
+						}
+					}),
+					false,
+					'EDITOR/SET_TEXT'
+				);
+			},
+			setAutoSendTime: (
+				id: MailsEditorV2['id'],
+				autoSendTime: MailsEditorV2['autoSendTime']
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].autoSendTime = autoSendTime;
+						}
+					}),
+					false,
+					'EDITOR/SET_AUTO_SEND_TIME'
+				);
+			},
+			setDid: (id: MailsEditorV2['id'], did: MailsEditorV2['did']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].did = did;
+						}
+					}),
+					false,
+					'EDITOR/SET_DID'
+				);
+			},
+			setSize: (id: MailsEditorV2['id'], size: MailsEditorV2['size']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].size = size;
+						}
+					}),
+					false,
+					'EDITOR/SET_SIZE'
+				);
+			},
+			setIsDirty: (id: MailsEditorV2['id'], value: MailsEditorV2['isDirty']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id] && state.editors[id].isDirty !== value) {
+							state.editors[id].isDirty = value;
+						}
+					}),
+					false,
+					'EDITOR/SET_IS_DIRTY'
+				);
+			},
+			setIsRichText: (id: MailsEditorV2['id'], value: MailsEditorV2['isRichText']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].isRichText = value;
+						}
+					}),
+					false,
+					'EDITOR/SET_IS_RICH_TEXT'
+				);
+			},
+			setOriginalId: (id: MailsEditorV2['id'], originalId: MailsEditorV2['originalId']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].originalId = originalId;
+						}
+					}),
+					false,
+					'EDITOR/SET_ORIGINAL_ID'
+				);
+			},
+			setRecipients: (id: MailsEditorV2['id'], recipients: MailsEditorV2['recipients']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].recipients = recipients;
+						}
+					}),
+					false,
+					'EDITOR/SET_RECIPIENTS'
+				);
+			},
+			setToRecipients: (
+				id: MailsEditorV2['id'],
+				recipients: MailsEditorV2['recipients']['to']
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].recipients.to = recipients;
+						}
+					}),
+					false,
+					'EDITOR/SET_TO_RECIPIENTS'
+				);
+			},
+			setCcRecipients: (
+				id: MailsEditorV2['id'],
+				recipients: MailsEditorV2['recipients']['cc']
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].recipients.cc = recipients;
+						}
+					}),
+					false,
+					'EDITOR/SET_CC_RECIPIENTS'
+				);
+			},
+			setBccRecipients: (
+				id: MailsEditorV2['id'],
+				recipients: MailsEditorV2['recipients']['bcc']
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].recipients.bcc = recipients;
+						}
+					}),
+					false,
+					'EDITOR/SET_BCC_RECIPIENTS'
+				);
+			},
+			setIdentityId: (id: MailsEditorV2['id'], from: MailsEditorV2['identityId']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].identityId = from;
+						}
+					}),
+					false,
+					'EDITOR/SET_IDENTITY_ID'
+				);
+			},
+			setIsUrgent: (id: MailsEditorV2['id'], value: MailsEditorV2['isUrgent']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].isUrgent = value;
+						}
+					}),
+					false,
+					'EDITOR/SET_IS_URGENT'
+				);
+			},
+			setRequestReadReceipt: (
+				id: MailsEditorV2['id'],
+				value: MailsEditorV2['requestReadReceipt']
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].requestReadReceipt = value;
+						}
+					}),
+					false,
+					'EDITOR/SET_REQUEST_READ_RECEIPT'
+				);
+			},
+			setDraftSaveAllowedStatus: (id, status): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].draftSaveAllowedStatus = status;
+						}
+					}),
+					false,
+					'EDITOR/SET_DRAFT_SAVE_ALLOWED_STATUS'
+				);
+			},
+			setDraftSaveProcessStatus: (id, status): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].draftSaveProcessStatus = status;
+						}
+					}),
+					false,
+					'EDITOR/SET_DRAFT_SAVE_PROCESS_STATUS'
+				);
+			},
+			setSendAllowedStatus: (id, status): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].sendAllowedStatus = status;
+						}
+					}),
+					false,
+					'EDITOR/SET_SEND_ALLOWED_STATUS'
+				);
+			},
+			setSendProcessStatus: (id, status): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].sendProcessStatus = status;
+						}
+					}),
+					false,
+					'EDITOR/SET_SEND_PROCESS_STATUS'
+				);
+			},
+			setSavedAttachments: (id: MailsEditorV2['id'], attachment: Array<SavedAttachment>): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].savedAttachments = [...attachment];
+						}
+					}),
+					false,
+					'EDITOR/SET_SAVED_ATTACHMENTS'
+				);
+			},
+			removeSavedAttachment: (id: MailsEditorV2['id'], partName: string): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							remove(state.editors[id].savedAttachments, ['partName', partName]);
+						}
+					}),
+					false,
+					'EDITOR/REMOVE_SAVED_ATTACHMENT'
+				);
+			},
+			removeUnsavedAttachments: (id: MailsEditorV2['id']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].unsavedAttachments = [];
+						}
+					}),
+					false,
+					'EDITOR/REMOVE_UNSAVED_ATTACHMENTS'
+				);
+			},
+			addUnsavedAttachment: (id: MailsEditorV2['id'], attachment: UnsavedAttachment): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].unsavedAttachments.push(attachment);
+						}
+					}),
+					false,
+					'EDITOR/ADD_UNSAVED_ATTACHMENT'
+				);
+			},
+			addUnsavedAttachments: (
+				id: MailsEditorV2['id'],
+				attachments: Array<UnsavedAttachment>
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].unsavedAttachments.push(...attachments);
+						}
+					}),
+					false,
+					'EDITOR/ADD_UNSAVED_ATTACHMENTS'
+				);
+			},
+			addSavedAttachment: (id: MailsEditorV2['id'], attachment: SavedAttachment): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].savedAttachments.push(attachment);
+						}
+					}),
+					false,
+					'EDITOR/ADD_SAVED_ATTACHMENT'
+				);
+			},
+			setAttachmentUploadStatus: (
+				id: MailsEditorV2['id'],
+				uploadId: string,
+				status: AttachmentUploadProcessStatus
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						const unsavedAttachment = selectUnsavedAttachmentByUploadId(state, id, uploadId);
+						if (!unsavedAttachment) {
+							return;
+						}
 
-				unsavedAttachment.uploadStatus = status;
-			})
-		);
-	},
-	setAttachmentUploadCompleted: (id: MailsEditorV2['id'], uploadId: string, aid: string): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				const unsavedAttachment = selectUnsavedAttachmentByUploadId(state, id, uploadId);
-				if (!unsavedAttachment) {
-					return;
-				}
+						unsavedAttachment.uploadStatus = status;
+					}),
+					false,
+					'EDITOR/SET_ATTACHMENT_UPLOAD_STATUS'
+				);
+			},
+			setAttachmentUploadCompleted: (
+				id: MailsEditorV2['id'],
+				uploadId: string,
+				aid: string
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						const unsavedAttachment = selectUnsavedAttachmentByUploadId(state, id, uploadId);
+						if (!unsavedAttachment) {
+							return;
+						}
 
-				unsavedAttachment.aid = aid;
-				unsavedAttachment.uploadStatus = {
-					status: 'completed'
-				};
-			})
-		);
-	},
-	removeUnsavedAttachment: (id: MailsEditorV2['id'], uploadId: string): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					remove(state.editors[id].unsavedAttachments, ['uploadId', uploadId]);
-				}
-			})
-		);
-	},
-	clearStandardAttachments: (id: MailsEditorV2['id']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].savedAttachments = filterSavedInlineAttachment(
-						state.editors[id].savedAttachments
-					);
-					state.editors[id].unsavedAttachments = filterUnsavedInlineAttachment(
-						state.editors[id].unsavedAttachments
-					);
-				}
-			})
-		);
-	},
-	/**
-	 * Function for messages store
-	 * @param id
-	 */
+						unsavedAttachment.aid = aid;
+						unsavedAttachment.uploadStatus = {
+							status: 'completed'
+						};
+					}),
+					false,
+					'EDITOR/SET_ATTACHMENT_UPLOAD_COMPLETED'
+				);
+			},
+			removeUnsavedAttachment: (id: MailsEditorV2['id'], uploadId: string): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							remove(state.editors[id].unsavedAttachments, ['uploadId', uploadId]);
+						}
+					}),
+					false,
+					'EDITOR/REMOVE_UNSAVED_ATTACHMENT'
+				);
+			},
+			clearStandardAttachments: (id: MailsEditorV2['id']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].savedAttachments = filterSavedInlineAttachment(
+								state.editors[id].savedAttachments
+							);
+							state.editors[id].unsavedAttachments = filterUnsavedInlineAttachment(
+								state.editors[id].unsavedAttachments
+							);
+						}
+					}),
+					false,
+					'EDITOR/CLEAR_STANDARD_ATTACHMENTS'
+				);
+			},
+			/**
+			 * Function for messages store
+			 * @param id
+			 */
 
-	setSignatureId: (id: MailsEditorV2['id'], signId: MailsEditorV2['signatureId']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].signatureId = signId;
-				}
-			})
-		);
-	},
-	setIsSmimeSign: (id: MailsEditorV2['id'], value: MailsEditorV2['isSmimeSign']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].isSmimeSign = value;
-				}
-			})
-		);
-	},
-	setIsSmimeEncrypt: (id: MailsEditorV2['id'], value: MailsEditorV2['isSmimeEncrypt']): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].isSmimeEncrypt = value;
-				}
-			})
-		);
-	},
-	setTextProvider: (id: MailsEditorV2['id'], provider: EditorTextProvider): void => {
-		set(
-			produce((state: EditorsStateTypeV2) => {
-				if (state?.editors?.[id]) {
-					state.editors[id].textProvider = provider;
-				}
-			})
-		);
-	},
+			setSignatureId: (id: MailsEditorV2['id'], signId: MailsEditorV2['signatureId']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].signatureId = signId;
+						}
+					}),
+					false,
+					'EDITOR/SET_SIGNATURE_ID'
+				);
+			},
+			setIsSmimeSign: (id: MailsEditorV2['id'], value: MailsEditorV2['isSmimeSign']): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].isSmimeSign = value;
+						}
+					}),
+					false,
+					'EDITOR/SET_IS_SMIME_SIGN'
+				);
+			},
+			setIsSmimeEncrypt: (
+				id: MailsEditorV2['id'],
+				value: MailsEditorV2['isSmimeEncrypt']
+			): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].isSmimeEncrypt = value;
+						}
+					}),
+					false,
+					'EDITOR/SET_IS_SMIME_ENCRYPT'
+				);
+			},
+			setTextProvider: (id: MailsEditorV2['id'], provider: EditorTextProvider): void => {
+				set(
+					produce((state: EditorsStateTypeV2) => {
+						if (state?.editors?.[id]) {
+							state.editors[id].textProvider = provider;
+						}
+					}),
+					false,
+					'EDITOR/SET_TEXT_PROVIDER'
+				);
+			},
 
-	// Iterate through editors to find one with matching draftId and return it. Return null if not found
-	getEditorByDraftId: (draftId: string): MailsEditorV2 | null => {
-		let foundEditor: MailsEditorV2 | null = null;
-		Object.values(get().editors).forEach((editor) => {
-			if (editor.did === draftId) {
-				foundEditor = editor;
+			// Iterate through editors to find one with matching draftId and return it. Return null if not found
+			getEditorByDraftId: (draftId: string): MailsEditorV2 | null => {
+				let foundEditor: MailsEditorV2 | null = null;
+				Object.values(get().editors).forEach((editor) => {
+					if (editor.did === draftId) {
+						foundEditor = editor;
+					}
+				});
+				return foundEditor;
+			},
+
+			// Return all editors matching any of the provided draft IDs
+			getEditorsByDraftsId: (draftsId: Array<string>): Array<MailsEditorV2 & { did: string }> => {
+				const foundEditors: Array<MailsEditorV2 & { did: string }> = [];
+				Object.values(get().editors).forEach((editor) => {
+					if (editor.did && draftsId.includes(editor.did)) {
+						foundEditors.push(editor as MailsEditorV2 & { did: string });
+					}
+				});
+				return foundEditors;
 			}
-		});
-		return foundEditor;
-	},
-
-	// Return all editors matching any of the provided draft IDs
-	getEditorsByDraftsId: (draftsId: Array<string>): Array<MailsEditorV2 & { did: string }> => {
-		const foundEditors: Array<MailsEditorV2 & { did: string }> = [];
-		Object.values(get().editors).forEach((editor) => {
-			if (editor.did && draftsId.includes(editor.did)) {
-				foundEditors.push(editor as MailsEditorV2 & { did: string });
-			}
-		});
-		return foundEditors;
-	}
-}));
+		}),
+		{ name: 'carbonio-mails-ui-EDITORS-SLICE' }
+	)
+);

--- a/src/store/emails/store.ts
+++ b/src/store/emails/store.ts
@@ -7,6 +7,7 @@
 
 import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
 import { create, StoreApi, UseBoundStore } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 import { RemoveAttachmentsResponse } from 'api/delete-all-attachments-soap-api';
 import { NormalizedPartialConversation } from 'normalizations/normalize-conversation';
@@ -41,19 +42,24 @@ type TaskManagement = {
 	executeTasks: () => Promise<void>;
 };
 
-const useEmailsStore = create<EmailsStoreState & TaskManagement>()((set, get, ...a) => ({
-	...createSearchIndexSlice(set, get, ...a),
-	...createMessageIndexSlice(set, get, ...a),
-	...createConversationIndexSlice(set, get, ...a),
-	...createPopulatedItemsSlice(set, get, ...a),
+const useEmailsStore = create<EmailsStoreState & TaskManagement>()(
+	devtools(
+		(set, get, ...a) => ({
+			...createSearchIndexSlice(set, get, ...a),
+			...createMessageIndexSlice(set, get, ...a),
+			...createConversationIndexSlice(set, get, ...a),
+			...createPopulatedItemsSlice(set, get, ...a),
 
-	/**
-	 * TaskQueueManager is a store extension that provides functionality
-	 * for managing and executing asynchronous tasks sequentially in a queue.
-	 * This implementation safeguards against race conditions.
-	 */
-	...createTaskQueueManager(set, get, ...a)
-}));
+			/**
+			 * TaskQueueManager is a store extension that provides functionality
+			 * for managing and executing asynchronous tasks sequentially in a queue.
+			 * This implementation safeguards against race conditions.
+			 */
+			...createTaskQueueManager(set, get, ...a)
+		}),
+		{ name: 'carbonio-mails-ui' }
+	)
+);
 
 const { addTask } = useEmailsStore.getState();
 


### PR DESCRIPTION
This pull request enhances the `useEditorsStore` in `src/store/editor/store.ts` by integrating the Zustand `devtools` middleware for improved debugging and state management. It also adds descriptive action names to all state updates, making it easier to track changes in development tools. Additionally, several editor store methods are refactored for consistency and clarity.

**State management and debugging improvements:**

* Integrated Zustand `devtools` middleware into the `useEditorsStore` to enable advanced debugging and state inspection features. (`src/store/editor/store.ts`) [[1]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596R9) [[2]](diffhunk://#diff-ff7932fda92e28619a5c5c848dde947d8f3c8e9ffba0a19c8c2795e61c534953R10)
* Added descriptive action names (e.g., `'EDITOR/ADD_EDITOR'`, `'EDITOR/SET_SUBJECT'`) to every state-changing action for better traceability in devtools. (`src/store/editor/store.ts`) [[1]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L24-R44) [[2]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L47-R55) [[3]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L56-R80) [[4]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L74-R91) [[5]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L83-R102) [[6]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L92-R113) [[7]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L101-R124) [[8]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L110-R135) [[9]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L119-R146) [[10]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L131-R160) [[11]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L143-R174) [[12]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L155-R188) [[13]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L164-R199) [[14]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L173-R210) [[15]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L185-R224) [[16]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L194-R235) [[17]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L203-R246) [[18]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L212-R257) [[19]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L221-R268) [[20]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L230-R279) [[21]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L239-R290) [[22]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L248-R301) [[23]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L257-R326) [[24]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L275-R337) [[25]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L291-R362) [[26]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L306-R376) [[27]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L315-R387) [[28]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L329-R403) [[29]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L343-R419) [[30]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L352-R444) [[31]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L370-R455) [[32]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L395-R483)

**Refactoring and consistency:**

* Refactored several editor store methods to use consistent parameter formatting and improved readability (e.g., multi-line function signatures for complex actions). (`src/store/editor/store.ts`) [[1]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L56-R80) [[2]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L257-R326) [[3]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L291-R362) [[4]](diffhunk://#diff-f154b4fdab3550d7fadcdd43d37516390b5dae6a9a18279b1c06e00cb5fc8596L352-R444)
* Added a custom store name `'carbonio-mails-ui-EDITORS-SLICE'` to the devtools configuration for easier identification in debugging tools. (`src/store/editor/store.ts`)