### PR TITLE
refactor(CO-3211): remove all .d.ts import and usages

### DIFF
--- a/src/__test__/conversation/api-stub.ts
+++ b/src/__test__/conversation/api-stub.ts
@@ -3,16 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import {
-	GetConvRequest,
-	GetConvResponse,
-	SearchConvRequest,
-	SearchConvResponse,
-	SearchRequest,
-	SearchResponse,
-	SoapConversation
-} from '../../types';
+
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { GetConvRequest, GetConvResponse } from 'types/soap/get-conv';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
+import { SearchConvRequest, SearchConvResponse } from 'types/soap/search-conv';
+import { SoapConversation } from 'types/soap/soap-conversation';
 
 export const stubSearchConversations = ({
 	conversations

--- a/src/__test__/generators/api.ts
+++ b/src/__test__/generators/api.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 /*
  * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
@@ -8,13 +7,13 @@
 import { DefaultBodyType, http, HttpResponse } from 'msw';
 
 import { getSetupServer } from '../vitest-setup';
+import { SoapConversation } from 'types/soap/soap-conversation';
 import {
-	SoapConversation,
 	SoapIncompleteMessage,
 	SoapMailMessage,
-	SoapMailMessagePart,
-	SoapMailParticipant
-} from 'types';
+	SoapMailMessagePart
+} from 'types/soap/soap-mail-message';
+import { SoapMailParticipant } from 'types/soap/soap-mail-participant';
 
 export function generateMessagePartFromAPI(
 	params: Partial<SoapMailMessagePart> = {}
@@ -22,23 +21,6 @@ export function generateMessagePartFromAPI(
 	return {
 		part: 'part',
 		ct: 'ct',
-		...params
-	};
-}
-export const generateConvMessageFromAPI = generateCompleteMessageFromAPI;
-
-export function generateCompleteMessageFromAPI(
-	params: Partial<SoapMailMessage> = {}
-): SoapMailMessage {
-	return {
-		...generateMessageFromAPI({ id: '987', d: 987 }),
-		su: 'Subject',
-		fr: 'Fragment',
-		e: [
-			generateFromParticipantFromAPI({ a: 'from@loc.al' }),
-			generateToParticipantFromAPI({ a: 'to@loc.al' })
-		],
-		mp: [generateMessagePartFromAPI()],
 		...params
 	};
 }
@@ -77,6 +59,24 @@ export function generateMessageFromAPI(
 		...params
 	};
 }
+
+export function generateCompleteMessageFromAPI(
+	params: Partial<SoapMailMessage> = {}
+): SoapMailMessage {
+	return {
+		...generateMessageFromAPI({ id: '987', d: 987 }),
+		su: 'Subject',
+		fr: 'Fragment',
+		e: [
+			generateFromParticipantFromAPI({ a: 'from@loc.al' }),
+			generateToParticipantFromAPI({ a: 'to@loc.al' })
+		],
+		mp: [generateMessagePartFromAPI()],
+		...params
+	};
+}
+
+export const generateConvMessageFromAPI = generateCompleteMessageFromAPI;
 
 type HandlerRequest<T> = DefaultBodyType & {
 	Body: Record<string, T>;

--- a/src/__test__/generators/editors.ts
+++ b/src/__test__/generators/editors.ts
@@ -9,7 +9,7 @@ import { ParticipantRole } from '@zextras/carbonio-ui-commons';
 import { EditViewActions } from '../../constants';
 import { getDefaultIdentity } from '../../helpers/identities';
 import { computeDraftSaveAllowedStatus, computeSendAllowedStatus } from 'store/editor/editor-utils';
-import type { SavedAttachment, UnsavedAttachment } from 'types';
+import { SavedAttachment, UnsavedAttachment } from 'types/attachments';
 import { MailsEditorV2 } from 'types/editor';
 
 const alignState = (editor: MailsEditorV2): void => {

--- a/src/__test__/generators/generateConversation.ts
+++ b/src/__test__/generators/generateConversation.ts
@@ -10,7 +10,9 @@ import { times } from 'lodash';
 
 import { generateMessage, MessageGenerationParams } from '__test__/generators/generateMessage';
 import { updateConversations, updateMessages } from 'store/emails/store';
-import type { MailMessage, NormalizedConversation, Participant } from 'types';
+import { NormalizedConversation } from 'types/conversations';
+import { MailMessage } from 'types/messages';
+import { Participant } from 'types/participant';
 
 /**
  *

--- a/src/__test__/generators/generateMessage.ts
+++ b/src/__test__/generators/generateMessage.ts
@@ -9,7 +9,8 @@ import { FOLDERS, ParticipantRole } from '@zextras/carbonio-ui-commons';
 
 import { convertHtmlToPlainText } from 'commons/utilities';
 import { updateMessages } from 'store/emails/store';
-import { MailMessage, MailMessagePart, Participant, Sensitivity } from 'types';
+import { MailMessage, MailMessagePart, Sensitivity } from 'types/messages';
+import { Participant } from 'types/participant';
 
 export type MessageGenerationParams = {
 	id?: string;

--- a/src/__test__/generators/getMsgResponse.ts
+++ b/src/__test__/generators/getMsgResponse.ts
@@ -8,7 +8,9 @@ import { faker } from '@faker-js/faker';
 import { SoapResponse } from '@zextras/carbonio-shell-ui';
 import { FOLDERS, ParticipantRole } from '@zextras/carbonio-ui-commons';
 
-import type { GetMsgResponse, Participant, SoapMailParticipant } from 'types';
+import { Participant } from 'types/participant';
+import { GetMsgResponse } from 'types/soap/get-msg';
+import { SoapMailParticipant } from 'types/soap/soap-mail-participant';
 
 /**
  *

--- a/src/__test__/message/api-stub.ts
+++ b/src/__test__/message/api-stub.ts
@@ -3,8 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { SearchRequest, SearchResponse, SoapIncompleteMessage } from '../../types';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
+import { SoapIncompleteMessage } from 'types/soap/soap-mail-message';
 
 export const stubSearchMessages = ({
 	messages

--- a/src/api/accept-shared-folder-reply.ts
+++ b/src/api/accept-shared-folder-reply.ts
@@ -8,7 +8,7 @@ import { ErrorSoapBodyResponse, legacySoapFetch } from '@zextras/carbonio-ui-soa
 
 import { generateRequest } from 'store/editor-slice-utils';
 import { MailsEditor } from 'types/editor';
-import type { SaveDraftRequest, SaveDraftResponse } from 'types/index.d';
+import { SaveDraftRequest, SaveDraftResponse } from 'types/soap/save-draft';
 
 // TODO create a generic function to call sendMsg and remove this one
 // TODO probably the owner account should be set also here

--- a/src/api/conv-action-soap-api.ts
+++ b/src/api/conv-action-soap-api.ts
@@ -7,7 +7,8 @@ import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { isNil } from 'lodash';
 
 import { omitBy } from 'commons/utils';
-import type { ConvActionParameters, ConvActionRequest, ConvActionResponse } from 'types/index.d';
+import { ConvActionParameters } from 'types/conversations';
+import { ConvActionRequest, ConvActionResponse } from 'types/soap/conv-action';
 
 export async function convActionSoapApi({
 	ids,

--- a/src/api/create-folder-soap-api.ts
+++ b/src/api/create-folder-soap-api.ts
@@ -6,7 +6,7 @@
 import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
-import { type CreateFolderResponse } from 'types/index.d';
+import { CreateFolderResponse } from 'types/soap/soap';
 
 export function createFolderSoapApi({
 	parentFolderId,

--- a/src/api/delete-all-attachments-soap-api.ts
+++ b/src/api/delete-all-attachments-soap-api.ts
@@ -6,7 +6,7 @@
 
 import { ErrorSoapBodyResponse, legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
-import { SoapMailMessage } from 'types/index.d';
+import { SoapMailMessage } from 'types/soap/soap-mail-message';
 
 type RemoveAttachmentsProps = {
 	id: string;

--- a/src/api/folder-action-soap-api.ts
+++ b/src/api/folder-action-soap-api.ts
@@ -8,7 +8,7 @@ import { DataProps } from '@zextras/carbonio-ui-commons';
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { isEmpty, isNil, omitBy } from 'lodash';
 
-import { FolderActionResponse } from 'types/index.d';
+import { FolderActionResponse } from 'types/soap/soap';
 
 export type FolderActionProps = {
 	folder: Folder | DataProps | Omit<Folder, 'parent'>;

--- a/src/api/get-conv-soap-api.ts
+++ b/src/api/get-conv-soap-api.ts
@@ -9,13 +9,10 @@ import { map } from 'lodash';
 import { MAIL_VERIFICATION_HEADERS } from 'constants/index';
 import { normalizeConversations } from 'normalizations/normalize-conversation';
 import { normalizeMailMessageFromSoap } from 'normalizations/normalize-message';
-import type {
-	GetConvParameters,
-	GetConvRequest,
-	GetConvResponse,
-	IncompleteMessage,
-	NormalizedConversation
-} from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
+import { IncompleteMessage } from 'types/messages';
+import { GetConvRequest, GetConvResponse } from 'types/soap/get-conv';
+import { GetConvParameters } from 'types/soap/soap';
 
 export const getConvSoapApi = async ({
 	conversationId,

--- a/src/api/get-filters.ts
+++ b/src/api/get-filters.ts
@@ -7,7 +7,7 @@
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
 import { normalizeFilterRulesFromSoap } from 'normalizations/normalize-filter-rules';
-import type { FilterRules } from 'types/index.d';
+import { FilterRules } from 'types/filters';
 
 export type FilterRulesAPIResponse = {
 	filterRules: FilterRules;

--- a/src/api/get-incoming-filters-soap-api.ts
+++ b/src/api/get-incoming-filters-soap-api.ts
@@ -7,7 +7,7 @@
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
 import { normalizeFilterRulesFromSoap } from 'normalizations/normalize-filter-rules';
-import { FilterRules } from 'types/index.d';
+import { FilterRules } from 'types/filters';
 
 type GetFilterRulesResponse = {
 	filterRules: FilterRules;

--- a/src/api/get-msg-for-print-soap-api.ts
+++ b/src/api/get-msg-for-print-soap-api.ts
@@ -9,13 +9,13 @@ import { isNull, map, omitBy } from 'lodash';
 
 import { normalizeMailMessageFromSoap } from 'normalizations/normalize-message';
 import { MailMessage } from 'types/messages';
-import { GetMsgForPrintParameter } from 'types/soap/get-msg';
+import { GetMsgForPrintParameter, GetMsgForPrintResponse } from 'types/soap/get-msg';
 
 export const getMsgsForPrintSoapApi = async ({
 	ids,
 	part
 }: GetMsgForPrintParameter): Promise<Array<MailMessage>> => {
-	const { GetMsgResponse } = (await legacySoapFetch('Batch', {
+	const { getMsgResponse } = await legacySoapFetch<unknown, GetMsgForPrintResponse>('Batch', {
 		GetMsgRequest: map(ids, (id) => ({
 			m: omitBy(
 				{
@@ -30,8 +30,8 @@ export const getMsgsForPrintSoapApi = async ({
 			_jsns: 'urn:zimbraMail'
 		})),
 		_jsns: 'urn:zimbra'
-	})) as any; /* as { GetMsgResponse: Array<GetMsgResponseType> } */ // TODO FIX THIS TYPE
-	return map(GetMsgResponse, (re) => {
+	});
+	return map(getMsgResponse, (re) => {
 		const msg = re.m[0];
 		return normalizeMailMessageFromSoap(msg, true) as MailMessage;
 	});

--- a/src/api/get-msg-for-print-soap-api.ts
+++ b/src/api/get-msg-for-print-soap-api.ts
@@ -8,11 +8,8 @@ import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { isNull, map, omitBy } from 'lodash';
 
 import { normalizeMailMessageFromSoap } from 'normalizations/normalize-message';
-import type {
-	GetMsgForPrintParameter,
-	GetMsgResponse as GetMsgResponseType,
-	MailMessage
-} from 'types/index.d';
+import type { GetMsgForPrintParameter, GetMsgResponse as GetMsgResponseType } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 export const getMsgsForPrintSoapApi = async ({
 	ids,

--- a/src/api/get-msg-for-print-soap-api.ts
+++ b/src/api/get-msg-for-print-soap-api.ts
@@ -8,8 +8,8 @@ import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { isNull, map, omitBy } from 'lodash';
 
 import { normalizeMailMessageFromSoap } from 'normalizations/normalize-message';
-import type { GetMsgForPrintParameter, GetMsgResponse as GetMsgResponseType } from 'types/index.d';
 import { MailMessage } from 'types/messages';
+import { GetMsgForPrintParameter } from 'types/soap/get-msg';
 
 export const getMsgsForPrintSoapApi = async ({
 	ids,
@@ -30,7 +30,7 @@ export const getMsgsForPrintSoapApi = async ({
 			_jsns: 'urn:zimbraMail'
 		})),
 		_jsns: 'urn:zimbra'
-	})) as { GetMsgResponse: Array<GetMsgResponseType> };
+	})) as any; /* as { GetMsgResponse: Array<GetMsgResponseType> } */ // TODO FIX THIS TYPE
 	return map(GetMsgResponse, (re) => {
 		const msg = re.m[0];
 		return normalizeMailMessageFromSoap(msg, true) as MailMessage;

--- a/src/api/get-msg-soap-api-decrypt.ts
+++ b/src/api/get-msg-soap-api-decrypt.ts
@@ -7,7 +7,7 @@ import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { map } from 'lodash';
 
 import { MAIL_VERIFICATION_HEADERS } from 'constants/index';
-import type { GetMsgParameters, GetMsgRequest, GetMsgResponse } from 'types/index.d';
+import { GetMsgParameters, GetMsgRequest, GetMsgResponse } from 'types/soap/get-msg';
 
 export async function getMsgDecryptSoapApi({
 	msgId,

--- a/src/api/get-msg-soap-api.ts
+++ b/src/api/get-msg-soap-api.ts
@@ -8,7 +8,7 @@ import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { map } from 'lodash';
 
 import { MAIL_VERIFICATION_HEADERS } from 'constants/index';
-import type { GetMsgParameters, GetMsgRequest, GetMsgResponse } from 'types/index.d';
+import { GetMsgParameters, GetMsgRequest, GetMsgResponse } from 'types/soap/get-msg';
 
 export async function getMsgSoapApi({
 	msgId,

--- a/src/api/get-outgoing-filters-soap-api.ts
+++ b/src/api/get-outgoing-filters-soap-api.ts
@@ -6,7 +6,7 @@
 
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
-import type { FilterRules } from 'types/index.d';
+import { FilterRules } from 'types/filters';
 
 type GetFilterRulesResponse = {
 	filterRules: FilterRules;

--- a/src/api/mount-shared-folder-soap-api.ts
+++ b/src/api/mount-shared-folder-soap-api.ts
@@ -8,7 +8,7 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { ErrorSoapBodyResponse, legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
 import { CreateMountpointError } from 'api/errors/create-mountpoint-error';
-import { ISoapFolderObj } from 'types/index.d';
+import { ISoapFolderObj } from 'types/soap/soap';
 
 type MountpointSpecType = {
 	l?: string;

--- a/src/api/msg-action-soap-api.ts
+++ b/src/api/msg-action-soap-api.ts
@@ -7,7 +7,7 @@
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { omitBy, isNil } from 'lodash';
 
-import { MsgActionParameters, MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionParameters, MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 export const msgActionSoapApi = async ({
 	ids,

--- a/src/api/redirect-message-soap-api.ts
+++ b/src/api/redirect-message-soap-api.ts
@@ -6,7 +6,10 @@
 
 import { ErrorSoapBodyResponse, legacySoapFetch, SoapBody } from '@zextras/carbonio-ui-soap-lib';
 
-import type { RedirectMessageActionRequest, MessageSpecification } from 'types/index.d';
+import {
+	MessageSpecification,
+	RedirectMessageActionRequest
+} from 'types/soap/redirect-message-action';
 
 export const redirectMessageSoapApi = ({
 	id,

--- a/src/api/save-draft-soap-api.ts
+++ b/src/api/save-draft-soap-api.ts
@@ -6,7 +6,8 @@
 
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
-import type { SaveDraftParameters, SaveDraftRequest, SaveDraftResponse } from 'types/index.d';
+import { SaveDraftRequest, SaveDraftResponse } from 'types/soap/save-draft';
+import { SaveDraftParameters } from 'types/soap/soap';
 
 export const saveDraftSoapApi = ({
 	soapDraftMessageObj,

--- a/src/api/search-backup-deleted-messages-api.ts
+++ b/src/api/search-backup-deleted-messages-api.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type {
-	SearchBackupDeletedMessagesResponse,
-	SearchBackupDeletedMessagesAPIProps
-} from 'types/index.d';
+import {
+	SearchBackupDeletedMessagesAPIProps,
+	SearchBackupDeletedMessagesResponse
+} from 'types/api';
 
 export async function searchBackupDeletedMessagesApi({
 	startDate,

--- a/src/api/search-conv-soap-api.ts
+++ b/src/api/search-conv-soap-api.ts
@@ -8,7 +8,11 @@ import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { map } from 'lodash';
 
 import { MAIL_VERIFICATION_HEADERS } from 'constants/index';
-import type { SearchConvRequest, SearchConvResponse, SearchConvParameters } from 'types/index.d';
+import {
+	SearchConvParameters,
+	SearchConvRequest,
+	SearchConvResponse
+} from 'types/soap/search-conv';
 
 export async function searchConvSoapApi({
 	conversationId,

--- a/src/api/search-soap-api.ts
+++ b/src/api/search-soap-api.ts
@@ -7,7 +7,8 @@
 
 import { ErrorSoapBodyResponse, legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 
-import type { SearchSoapApiParams, SearchRequest, SearchResponse } from 'types/index.d';
+import { SearchSoapApiParams } from 'types/conversations';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
 
 export async function searchSoapApi({
 	folderId,

--- a/src/api/send-msg.ts
+++ b/src/api/send-msg.ts
@@ -16,7 +16,8 @@ import { getConvEmailStoreAction } from 'store/emails/actions/get-conv-action';
 import { getMessageEmailStoreAction } from 'store/emails/actions/get-message';
 import { getMessageWithExistingParticipantsEmailStoreAction } from 'store/emails/actions/get-message-with-existing-participants';
 import { MailsEditorV2 } from 'types/editor';
-import { MailMessage, SaveDraftRequest, SaveDraftResponse } from 'types/index.d';
+import { MailMessage } from 'types/messages';
+import { SaveDraftRequest, SaveDraftResponse } from 'types/soap/save-draft';
 
 export const sendMsg = async ({
 	msg

--- a/src/api/share-folder-soap-api.ts
+++ b/src/api/share-folder-soap-api.ts
@@ -8,7 +8,7 @@ import { Folder } from '@zextras/carbonio-ui-commons';
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { trim } from 'lodash';
 
-import { FolderActionGrant, FolderActionRequest } from 'types/index.d';
+import { FolderActionGrant, FolderActionRequest } from 'types/soap/soap';
 
 export type ShareFolderDataType = {
 	sendNotification?: boolean;

--- a/src/api/tests/get-conv-soap-api.test.ts
+++ b/src/api/tests/get-conv-soap-api.test.ts
@@ -7,9 +7,9 @@
 import { waitFor } from '@testing-library/react';
 
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
-import { getConvSoapApi } from 'api/get-conv-soap-api';
 import { generateConversationFromAPI, generateConvMessageFromAPI } from '__test__/generators/api';
-import { GetConvResponse } from 'types/index.d';
+import { getConvSoapApi } from 'api/get-conv-soap-api';
+import { GetConvResponse } from 'types/soap/get-conv';
 
 describe('getConvSoapApi', () => {
 	it('should fetch with the correct parameters', async () => {

--- a/src/api/tests/get-msg-decrypt.test.ts
+++ b/src/api/tests/get-msg-decrypt.test.ts
@@ -6,7 +6,7 @@
 
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { getMsgDecryptSoapApi } from 'api/get-msg-soap-api-decrypt';
-import { GetMsgRequest } from 'types/index.d';
+import { GetMsgRequest } from 'types/soap/get-msg';
 
 describe('GetMsg', () => {
 	it('should send max parameter if present', async () => {

--- a/src/api/tests/get-msg.test.ts
+++ b/src/api/tests/get-msg.test.ts
@@ -6,7 +6,7 @@
 
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { getMsgSoapApi } from 'api/get-msg-soap-api';
-import { GetMsgRequest } from 'types/index.d';
+import { GetMsgRequest } from 'types/soap/get-msg';
 
 describe('GetMsg', () => {
 	it('should send max parameter if present', async () => {

--- a/src/api/tests/mount-shared-folder.test.ts
+++ b/src/api/tests/mount-shared-folder.test.ts
@@ -15,7 +15,7 @@ import {
 	MountSharedFolderParams,
 	mountSharedFolderSoapApi
 } from 'api/mount-shared-folder-soap-api';
-import { ISoapFolderObj } from 'types/index.d';
+import { ISoapFolderObj } from 'types/soap/soap';
 
 describe('mountShareCalendar', () => {
 	it('raise an error if the response is an error', async () => {

--- a/src/api/tests/search-conv.test.ts
+++ b/src/api/tests/search-conv.test.ts
@@ -8,7 +8,7 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { searchConvSoapApi } from 'api/search-conv-soap-api';
-import { SearchConvRequest } from 'types/index.d';
+import { SearchConvRequest } from 'types/soap/search-conv';
 
 describe('searchConvSoapApi', () => {
 	test('the max property is set to 250_000', async () => {

--- a/src/api/tests/search.test.ts
+++ b/src/api/tests/search.test.ts
@@ -5,7 +5,7 @@
  */
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { searchSoapApi } from 'api/search-soap-api';
-import { SearchRequest } from 'types/index.d';
+import { SearchRequest } from 'types/soap/search';
 
 describe('Search', () => {
 	it('should send dateDesc filter if readDesc', async () => {

--- a/src/api/tests/share-folder.test.ts
+++ b/src/api/tests/share-folder.test.ts
@@ -11,7 +11,7 @@ import { http, HttpResponse } from 'msw';
 import { getSetupServer } from '../../__test__/vitest-setup';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { ShareFolderDataType, shareFolderSoapApi } from 'api/share-folder-soap-api';
-import { FolderActionGrant } from 'types/index.d';
+import { FolderActionGrant } from 'types/soap/soap';
 
 const setupInterceptor = (): Promise<Array<{ action: FolderActionGrant }>> =>
 	new Promise<Array<{ action: FolderActionGrant }>>((resolve, reject) => {

--- a/src/commons/mail-message-renderer/html-message-renderer/html-message-renderer.tsx
+++ b/src/commons/mail-message-renderer/html-message-renderer/html-message-renderer.tsx
@@ -12,7 +12,7 @@ import { BannerViewExternalImages } from './banner-view-external-images';
 import { ShadowDomWrapper } from './shadow-dom-wrapper';
 import { ShowQuotedTextButton } from './show-quoted-text-button';
 import { useHtmlMessageRenderer } from './use-html-message-renderer';
-import { MailMessage } from '../../../types';
+import { MailMessage } from 'types/messages';
 
 type HtmlMessageRendererProps = {
 	message: MailMessage;

--- a/src/commons/mail-message-renderer/html-message-renderer/tests/html-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/html-message-renderer/tests/html-message-renderer.test.tsx
@@ -10,12 +10,13 @@ import React from 'react';
 import { act, screen, waitFor, within } from '@testing-library/react';
 
 import { updateMessages } from '../../../../store/emails/store';
-import { GetMsgRequest, GetMsgResponse, MailMessage } from '../../../../types';
+import { GetMsgRequest, GetMsgResponse } from '../../../../types';
 import { HtmlMessageRenderer } from '../html-message-renderer';
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { generateCompleteMessageFromAPI } from '__test__/generators/api';
 import { generateMessage } from '__test__/generators/generateMessage';
+import { MailMessage } from 'types/messages';
 
 // Helper function to access shadow DOM elements
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/src/commons/mail-message-renderer/html-message-renderer/tests/html-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/html-message-renderer/tests/html-message-renderer.test.tsx
@@ -10,13 +10,13 @@ import React from 'react';
 import { act, screen, waitFor, within } from '@testing-library/react';
 
 import { updateMessages } from '../../../../store/emails/store';
-import { GetMsgRequest, GetMsgResponse } from '../../../../types';
 import { HtmlMessageRenderer } from '../html-message-renderer';
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { generateCompleteMessageFromAPI } from '__test__/generators/api';
 import { generateMessage } from '__test__/generators/generateMessage';
 import { MailMessage } from 'types/messages';
+import { GetMsgRequest, GetMsgResponse } from 'types/soap/get-msg';
 
 // Helper function to access shadow DOM elements
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/src/commons/mail-message-renderer/html-message-renderer/use-html-message-renderer.ts
+++ b/src/commons/mail-message-renderer/html-message-renderer/use-html-message-renderer.ts
@@ -13,7 +13,6 @@ import { filter, forEach, isArray, some } from 'lodash';
 import { getFlattenedAttachmentParts } from '../../../helpers/attachments';
 import { getNoIdentityPlaceholder } from '../../../helpers/identities';
 import { getFullMessageEmailStoreAction } from '../../../store/emails/actions/get-message';
-import { BodyPart, MailMessage, MailMessagePartWithDisposition } from '../../../types';
 import {
 	getOriginalHtmlContent,
 	getQuotedTextFromOriginalContent
@@ -24,6 +23,7 @@ import {
 	isAvailableInTrusteeList,
 	updateImageSrc
 } from '../../utils';
+import { BodyPart, MailMessage, MailMessagePartWithDisposition } from 'types/messages';
 
 export type ExternalImageState = {
 	showExternalImages: boolean;

--- a/src/commons/mail-message-renderer/mail-message-renderer.tsx
+++ b/src/commons/mail-message-renderer/mail-message-renderer.tsx
@@ -8,7 +8,7 @@ import React, { memo } from 'react';
 import { HtmlMessageRenderer } from './html-message-renderer/html-message-renderer';
 import { TextMessageRenderer } from './text-message-renderer/text-message-renderer';
 import { EmptyBody, EncryptedMsg } from 'commons/mail-message-renderer/empty-body';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 type MailMessageRendererProps = {
 	message: MailMessage;

--- a/src/commons/print-conversation/get-attachments.ts
+++ b/src/commons/print-conversation/get-attachments.ts
@@ -7,7 +7,7 @@
 import { t } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 export const getAttachments = ({ msg }: { msg: MailMessage }): string =>
 	`

--- a/src/commons/print-conversation/get-header.ts
+++ b/src/commons/print-conversation/get-header.ts
@@ -12,7 +12,7 @@ import { getUserLocale } from '../utils';
 import { getAttachments } from 'commons/print-conversation/get-attachments';
 import { getParticipantHeader } from 'commons/print-conversation/get-participant-header';
 import { getSubject } from 'commons/print-conversation/get-subject';
-import { type MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 export function getHeader(msg: MailMessage, content: string): string {
 	const { participants, subject } = msg;

--- a/src/commons/print-conversation/get-participant-header.ts
+++ b/src/commons/print-conversation/get-participant-header.ts
@@ -5,7 +5,7 @@
  */
 import { map } from 'lodash';
 
-import type { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 
 export const getParticipantHeader = (participants: Participant[], type: string): string => {
 	const participantsList = map(

--- a/src/commons/print-conversation/print-conversation.ts
+++ b/src/commons/print-conversation/print-conversation.ts
@@ -11,7 +11,8 @@ import { getCompleteHTML } from 'commons/print-conversation/get-complete-html';
 import { getHeader } from 'commons/print-conversation/get-header';
 import { _CI_REGEX, _CI_SRC_REGEX, plainTextToHTML } from 'commons/utils';
 import { findAttachments } from 'helpers/attachments';
-import { NormalizedConversation, type MailMessage } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
+import { MailMessage } from 'types/messages';
 
 function getSs(conversationMessage: Array<MailMessage>): Array<string> {
 	return map(conversationMessage, (msg) => {

--- a/src/commons/tests/utils.test.tsx
+++ b/src/commons/tests/utils.test.tsx
@@ -16,7 +16,7 @@ import {
 	participantToString,
 	updateImageSrc
 } from 'commons/utils';
-import { MailMessagePart } from 'types/index.d';
+import { MailMessagePart } from 'types/messages';
 
 describe('getTimeLabel', () => {
 	describe('the date is formatted using local', () => {

--- a/src/commons/utils.ts
+++ b/src/commons/utils.ts
@@ -7,7 +7,7 @@ import { Account, getUserSettings, t } from '@zextras/carbonio-shell-ui';
 import { find, isArray } from 'lodash';
 import moment from 'moment';
 
-import type { MailMessagePart } from 'types/index.d';
+import { MailMessagePart } from 'types/messages';
 
 // retrieves locale from preferences, fallbacks to "en" if no locale found.
 export const getUserLocale = (): string => {

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -5,7 +5,7 @@
  */
 import { DropdownItem } from '@zextras/carbonio-design-system';
 
-import { UIActionDescriptor } from 'types/index.d';
+import { UIActionDescriptor } from 'types/actions';
 
 export const normalizeDropdownActionItem = (item: UIActionDescriptor): DropdownItem => ({
 	id: item.id,

--- a/src/helpers/appointmemt.ts
+++ b/src/helpers/appointmemt.ts
@@ -14,7 +14,7 @@ import {
 } from 'helpers/identities';
 import { retrieveALL, retrieveCC } from 'store/editor-slice-utils';
 import { Attendee, MatchingReplyIdentity, SenderType } from 'types/calendar';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 /**
  * Analyze the message and return the identity that should be used as organizer.

--- a/src/helpers/attachments.ts
+++ b/src/helpers/attachments.ts
@@ -15,15 +15,9 @@ import {
 	removeAngleBrackets
 } from 'commons/content-id-utils';
 import { calcColor } from 'commons/utilities';
-import {
-	AbstractAttachment,
-	MailMessage,
-	MailMessagePart,
-	MailMessagePartWithDisposition,
-	SavedAttachment,
-	UnsavedAttachment
-} from 'types/index.d';
+import { AbstractAttachment, SavedAttachment, UnsavedAttachment } from 'types/attachments';
 import { EditorAttachmentFiles } from 'types/editor';
+import { MailMessage, MailMessagePart, MailMessagePartWithDisposition } from 'types/messages';
 
 /**
  * Content disposition types for email attachments

--- a/src/helpers/folders.ts
+++ b/src/helpers/folders.ts
@@ -9,7 +9,7 @@ import { FOLDERS, useFolderStore } from '@zextras/carbonio-ui-commons';
 import { find } from 'lodash';
 
 import { NO_ACCOUNT_NAME } from 'constants/index';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 /*
  * Describe the folder id syntax

--- a/src/helpers/identities.ts
+++ b/src/helpers/identities.ts
@@ -12,7 +12,8 @@ import { filter, findIndex, flatten, map, remove } from 'lodash';
 import { NO_ACCOUNT_NAME } from 'constants/index';
 import { getFolderIdParts, getMessageOwnerAccountName } from 'helpers/folders';
 import { getAvailableAddresses } from 'helpers/get-available-addresses';
-import type { MailMessage, Participant } from 'types/index.d';
+import { MailMessage } from 'types/messages';
+import { Participant } from 'types/participant';
 
 /**
  * The name of the primary identity

--- a/src/helpers/messages.ts
+++ b/src/helpers/messages.ts
@@ -5,7 +5,9 @@
  */
 import { ParticipantRole, ParticipantRoleType } from '@zextras/carbonio-ui-commons';
 
-import type { MailMessage, NormalizedConversation, Participant } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
+import { MailMessage } from 'types/messages';
+import { Participant } from 'types/participant';
 
 /**
  * Collect all the participants of the given type (or any type if the type params is not set)

--- a/src/helpers/participants.ts
+++ b/src/helpers/participants.ts
@@ -3,7 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { Participant } from 'types/index.d';
+
+import { Participant } from 'types/participant';
 
 /**
  * Compares the mandatory fields and then, if set, the optional fields

--- a/src/helpers/tests/attachments.test.ts
+++ b/src/helpers/tests/attachments.test.ts
@@ -16,7 +16,7 @@ import {
 	getReferredContentIds
 } from 'helpers/attachments';
 import { normalizeMailMessageFromSoap } from 'normalizations/normalize-message';
-import type { MailMessagePart } from 'types';
+import { MailMessagePart } from 'types/messages';
 
 describe('attachments', () => {
 	describe('getFlattenedAttachmentParts', () => {

--- a/src/hooks/actions/tests/use-conv-apply-tag.test.ts
+++ b/src/hooks/actions/tests/use-conv-apply-tag.test.ts
@@ -9,13 +9,13 @@ import { find, forEach } from 'lodash';
 
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { generateConversation } from '__test__/generators/generateConversation';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import {
 	useConvApplyTagDescriptor,
 	useConvApplyTagSubDescriptors
 } from 'hooks/actions/use-conv-apply-tag';
-import { generateConversation } from '__test__/generators/generateConversation';
-import { ConvActionRequest } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
 
 const tagA = { id: '1', name: 'a', label: 'a', color: 3 };
 const tagB = { id: '2', name: 'b', label: 'b', color: 3 };

--- a/src/hooks/actions/tests/use-conv-archive.test.ts
+++ b/src/hooks/actions/tests/use-conv-archive.test.ts
@@ -17,7 +17,7 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { TIMERS } from '__test__/constants';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
-import { ConvActionRequest, ConvActionResponse } from 'types';
+import { ConvActionRequest, ConvActionResponse } from 'types/soap/conv-action';
 
 describe('useConvArchive', () => {
 	const conversationsId = times(faker.number.int({ max: 42 }), () =>

--- a/src/hooks/actions/tests/use-conv-delete-permanently.test.ts
+++ b/src/hooks/actions/tests/use-conv-delete-permanently.test.ts
@@ -20,7 +20,7 @@ import {
 	useConvDeletePermanentlyDescriptor,
 	useConvDeletePermanentlyFn
 } from 'hooks/actions/use-conv-delete-permanently';
-import { ConvActionRequest } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
 
 describe('useConvDeletePermanently', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-conv-move-to-trash.test.ts
+++ b/src/hooks/actions/tests/use-conv-move-to-trash.test.ts
@@ -19,7 +19,8 @@ import {
 	useConvMoveToTrashDescriptor,
 	useConvMoveToTrashFn
 } from 'hooks/actions/use-conv-move-to-trash';
-import { ConvActionRequest, MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useConMoveToTrash', () => {
 	populateFoldersStore({ view: FOLDER_VIEW.message });

--- a/src/hooks/actions/tests/use-conv-print.test.ts
+++ b/src/hooks/actions/tests/use-conv-print.test.ts
@@ -12,7 +12,7 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { generateConversation } from '__test__/generators/generateConversation';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useConvPrintDescriptor, useConvPrintFn } from 'hooks/actions/use-conv-print';
-import { NormalizedConversation } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
 
 describe('useConvPrint', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-conv-set-flag.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-flag.test.ts
@@ -11,7 +11,7 @@ import { times } from 'lodash';
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { useConvSetFlagDescriptor, useConvSetFlagFn } from 'hooks/actions/use-conv-set-flag';
-import { ConvActionRequest } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
 
 describe('useConvSetFlag', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-conv-set-not-spam.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-not-spam.test.ts
@@ -10,12 +10,12 @@ import { times } from 'lodash';
 
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
-import { FOLDERS_DESCRIPTORS, TIMEOUTS } from 'constants/index';
+import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import {
 	useConvSetNotSpamDescriptor,
 	useConvSetNotSpamFn
 } from 'hooks/actions/use-conv-set-not-spam';
-import { ConvActionRequest, ConvActionResponse } from 'types/index.d';
+import { ConvActionRequest, ConvActionResponse } from 'types/soap/conv-action';
 
 describe('useConvSetNotSpam', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-conv-set-read.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-read.test.ts
@@ -13,7 +13,7 @@ import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useConvSetReadDescriptor, useConvSetReadFn } from 'hooks/actions/use-conv-set-read';
-import { ConvActionRequest } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
 
 describe('useConvSetRead', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-conv-set-spam.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-spam.test.ts
@@ -10,9 +10,9 @@ import { times } from 'lodash';
 
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
-import { FOLDERS_DESCRIPTORS, TIMEOUTS } from 'constants/index';
+import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useConvSetSpamDescriptor, useConvSetSpamFn } from 'hooks/actions/use-conv-set-spam';
-import { ConvActionRequest, ConvActionResponse } from 'types/index.d';
+import { ConvActionRequest, ConvActionResponse } from 'types/soap/conv-action';
 
 describe('useConvSetSpam', () => {
 	describe('descriptor', () => {

--- a/src/hooks/actions/tests/use-conv-set-unflag.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-unflag.test.ts
@@ -11,7 +11,7 @@ import { times } from 'lodash';
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { useConvSetUnflagDescriptor, useConvSetUnflagFn } from 'hooks/actions/use-conv-set-unflag';
-import { ConvActionRequest } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
 
 describe('useConvSetUnflag', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-conv-set-unread.test.ts
+++ b/src/hooks/actions/tests/use-conv-set-unread.test.ts
@@ -13,7 +13,7 @@ import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useConvSetUnreadDescriptor, useConvSetUnreadFn } from 'hooks/actions/use-conv-set-unread';
-import { ConvActionRequest } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
 
 describe('useConvSetUnread', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-msg-apply-tag.test.ts
+++ b/src/hooks/actions/tests/use-msg-apply-tag.test.ts
@@ -10,13 +10,13 @@ import { find, forEach } from 'lodash';
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { tags as mockTags } from '@test-utils/tags/tags';
+import { generateMessage } from '__test__/generators/generateMessage';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import {
 	useMsgApplyTagDescriptor,
 	useMsgApplyTagSubDescriptors
 } from 'hooks/actions/use-msg-apply-tag';
-import { generateMessage } from '__test__/generators/generateMessage';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgApplyTag', () => {
 	const msg = generateMessage();

--- a/src/hooks/actions/tests/use-msg-archive.test.tsx
+++ b/src/hooks/actions/tests/use-msg-archive.test.tsx
@@ -15,7 +15,7 @@ import { generateFolder } from '@test-utils/folders/folders-generator';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgArchive', () => {
 	const messagesId = times(faker.number.int({ max: 42 }), () =>

--- a/src/hooks/actions/tests/use-msg-create-appointment.test.ts
+++ b/src/hooks/actions/tests/use-msg-create-appointment.test.ts
@@ -17,7 +17,7 @@ import {
 	useMsgCreateAppointmentDescriptor,
 	useMsgCreateAppointmentFn
 } from 'hooks/actions/use-msg-create-appointment';
-import { GetMsgRequest } from 'types/index.d';
+import { GetMsgRequest } from 'types/soap/get-msg';
 
 describe('useMsgCreateAppointment', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-msg-move-to-trash.test.ts
+++ b/src/hooks/actions/tests/use-msg-move-to-trash.test.ts
@@ -17,7 +17,7 @@ import {
 	useMsgMoveToTrashDescriptor,
 	useMsgMoveToTrashFn
 } from 'hooks/actions/use-msg-move-to-trash';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgMoveToTrash', () => {
 	populateFoldersStore();

--- a/src/hooks/actions/tests/use-msg-print.test.ts
+++ b/src/hooks/actions/tests/use-msg-print.test.ts
@@ -9,10 +9,10 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { generateMessage } from '__test__/generators/generateMessage';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useMsgPrintDescriptor, useMsgPrintFn } from 'hooks/actions/use-msg-print';
-import { generateMessage } from '__test__/generators/generateMessage';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 describe('useMsgPrintDescripto', () => {
 	const msg = generateMessage({ isComplete: true });

--- a/src/hooks/actions/tests/use-msg-set-flag.test.ts
+++ b/src/hooks/actions/tests/use-msg-set-flag.test.ts
@@ -11,7 +11,7 @@ import { times } from 'lodash';
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { useMsgSetFlagDescriptor, useMsgSetFlagFn } from 'hooks/actions/use-msg-set-flag';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgSetFlag', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-msg-set-not-spam.test.ts
+++ b/src/hooks/actions/tests/use-msg-set-not-spam.test.ts
@@ -12,7 +12,7 @@ import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { FOLDERS_DESCRIPTORS, TIMEOUTS } from 'constants/index';
 import { useMsgSetNotSpamDescriptor, useMsgSetNotSpamFn } from 'hooks/actions/use-msg-set-not-spam';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgSetNotSpam', () => {
 	const ids = times(faker.number.int({ max: 42 }), () =>

--- a/src/hooks/actions/tests/use-msg-set-read.test.ts
+++ b/src/hooks/actions/tests/use-msg-set-read.test.ts
@@ -13,7 +13,7 @@ import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useMsgSetReadDescriptor, useMsgSetReadFn } from 'hooks/actions/use-msg-set-read';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgSetRead', () => {
 	const ids = times(faker.number.int({ max: 42 }), () =>

--- a/src/hooks/actions/tests/use-msg-set-spam.test.ts
+++ b/src/hooks/actions/tests/use-msg-set-spam.test.ts
@@ -12,7 +12,7 @@ import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { FOLDERS_DESCRIPTORS, TIMEOUTS } from 'constants/index';
 import { useMsgSetSpamDescriptor, useMsgSetSpamFn } from 'hooks/actions/use-msg-set-spam';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgSetSpam', () => {
 	const ids = times(faker.number.int({ max: 42 }), () =>

--- a/src/hooks/actions/tests/use-msg-set-unflag.test.ts
+++ b/src/hooks/actions/tests/use-msg-set-unflag.test.ts
@@ -11,7 +11,7 @@ import { times } from 'lodash';
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { useMsgSetUnflagDescriptor, useMsgSetUnflagFn } from 'hooks/actions/use-msg-set-unflag';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 describe('useMsgSetUnflag', () => {
 	describe('Descriptor', () => {

--- a/src/hooks/actions/tests/use-msg-set-unread.test.ts
+++ b/src/hooks/actions/tests/use-msg-set-unread.test.ts
@@ -14,7 +14,7 @@ import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useMsgSetUnreadDescriptor, useMsgSetUnreadFn } from 'hooks/actions/use-msg-set-unread';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 const mockNavigate = vi.fn();
 

--- a/src/hooks/actions/tests/use-msg-show-original.test.ts
+++ b/src/hooks/actions/tests/use-msg-show-original.test.ts
@@ -9,13 +9,13 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 
 import { setupHook } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { generateMessage } from '__test__/generators/generateMessage';
 import { FOLDERS_DESCRIPTORS } from 'constants/index';
 import {
 	useMsgShowOriginalDescriptor,
 	useMsgShowOriginalFn
 } from 'hooks/actions/use-msg-show-original';
-import { generateMessage } from '__test__/generators/generateMessage';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 describe('useMsgShowOriginal', () => {
 	const msg = generateMessage();

--- a/src/hooks/actions/use-conv-actions.ts
+++ b/src/hooks/actions/use-conv-actions.ts
@@ -29,7 +29,8 @@ import { useConvSetUnflagDescriptor } from 'hooks/actions/use-conv-set-unflag';
 import { useConvSetUnreadDescriptor } from 'hooks/actions/use-conv-set-unread';
 import { useConvShowOriginalDescriptor } from 'hooks/actions/use-conv-show-original';
 import { useConversationMessages } from 'store/emails/store';
-import { NormalizedConversation, UIActionAggregator, UIActionDescriptor } from 'types/index.d';
+import { UIActionDescriptor, UIActionAggregator } from 'types/actions';
+import { NormalizedConversation } from 'types/conversations';
 
 export type ConversationActionsArgumentType = {
 	conversation: NormalizedConversation;

--- a/src/hooks/actions/use-conv-apply-tag.tsx
+++ b/src/hooks/actions/use-conv-apply-tag.tsx
@@ -15,12 +15,9 @@ import { ConversationActionsDescriptors, TIMEOUTS } from 'constants/index';
 import { isSpam } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import {
-	ConvActionParameters,
-	ConvActionResponse,
-	UIActionAggregator,
-	UIActionDescriptor
-} from 'types/index.d';
+import { UIActionAggregator, UIActionDescriptor } from 'types/actions';
+import { ConvActionParameters } from 'types/conversations';
+import { ConvActionResponse } from 'types/soap/conv-action';
 
 const createSnackbarMessage = (
 	createSnackbar: CreateSnackbarFn,

--- a/src/hooks/actions/use-conv-delete-permanently.tsx
+++ b/src/hooks/actions/use-conv-delete-permanently.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isSpam, isTrash } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { PermanentlyDeleteModal } from 'ui-actions/permanently-delete-modal';
 
 type ConvDeletePermanentlyFunctionsParameter = {

--- a/src/hooks/actions/use-conv-forward-as-attachment.ts
+++ b/src/hooks/actions/use-conv-forward-as-attachment.ts
@@ -11,7 +11,8 @@ import { useTranslation } from 'react-i18next';
 import { ConversationActionsDescriptors, EditViewActions } from 'constants/index';
 import { MIMETYPE_EML } from 'helpers/attachments';
 import { useMsgForwardAsAttachmentFn } from 'hooks/actions/use-msg-forward-as-attachment';
-import { ActionFn, UIActionDescriptor, UnsavedAttachment } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
+import { UnsavedAttachment } from 'types/attachments';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 type ConvForwardAsAttachmentAction = {

--- a/src/hooks/actions/use-conv-forward.ts
+++ b/src/hooks/actions/use-conv-forward.ts
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors, EditViewActions } from 'constants/index';
 import { useMsgForwardFn } from 'hooks/actions/use-msg-forward';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 type ConvForwardAction = {

--- a/src/hooks/actions/use-conv-move-to-folder.tsx
+++ b/src/hooks/actions/use-conv-move-to-folder.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isTrash } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { MoveConversation } from 'ui-actions/move-conv';
 
 export const useConvMoveToFolderFn = ({

--- a/src/hooks/actions/use-conv-move-to-trash.ts
+++ b/src/hooks/actions/use-conv-move-to-trash.ts
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useConversationDetailPanelControls } from '../../views/app/detail-panel/detail-panel-controls-hooks';
 import { ConversationActionsDescriptors } from 'constants/index';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import type { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { useInSearchModule } from 'ui-actions/utils';
 
 type ConvRestoreFunctionsParameter = {

--- a/src/hooks/actions/use-conv-preview-on-separated-window.tsx
+++ b/src/hooks/actions/use-conv-preview-on-separated-window.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isFocusModeMailView, openConversationStandalonePreview } from 'helpers/external-tabs';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useConvPreviewOnSeparatedWindowFn = ({
 	conversationId,

--- a/src/hooks/actions/use-conv-print.tsx
+++ b/src/hooks/actions/use-conv-print.tsx
@@ -12,7 +12,8 @@ import { getMsgsForPrintSoapApi } from 'api/index';
 import { getContentForPrint } from 'commons/print-conversation/print-conversation';
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isDraft, isTrash } from 'helpers/folders';
-import { ActionFn, NormalizedConversation, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
+import { NormalizedConversation } from 'types/conversations';
 import { errorPage } from 'ui-actions/error-page';
 
 export const useConvPrintFn = (

--- a/src/hooks/actions/use-conv-reply-all.tsx
+++ b/src/hooks/actions/use-conv-reply-all.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors, EditViewActions } from 'constants/index';
 import { useMsgReplyAllFn } from 'hooks/actions/use-msg-reply-all';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 type ConvReplyAllFunctionsParameter = {

--- a/src/hooks/actions/use-conv-reply.tsx
+++ b/src/hooks/actions/use-conv-reply.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
 import { useMsgReplyFn } from 'hooks/actions/use-msg-reply';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type ConvReplyFunctionsParameter = {
 	firstMessageId: string;

--- a/src/hooks/actions/use-conv-restore.tsx
+++ b/src/hooks/actions/use-conv-restore.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isTrash } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { MoveConversation } from 'ui-actions/move-conv';
 
 export const useConvRestoreFn = ({

--- a/src/hooks/actions/use-conv-set-flag.tsx
+++ b/src/hooks/actions/use-conv-set-flag.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useConvSetFlagFn = (ids: Array<string>, isFlagged: boolean): ActionFn => {
 	const canExecute = useCallback((): boolean => !isFlagged, [isFlagged]);

--- a/src/hooks/actions/use-conv-set-not-spam.tsx
+++ b/src/hooks/actions/use-conv-set-not-spam.tsx
@@ -12,7 +12,7 @@ import { useConversationDetailPanelControls } from '../../views/app/detail-panel
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isSpam } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type ConvSetNotSpamFunctionsParameter = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-conv-set-read.tsx
+++ b/src/hooks/actions/use-conv-set-read.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isDraft } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type ConvSetMsgReadFunctionsParameter = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-conv-set-spam.tsx
+++ b/src/hooks/actions/use-conv-set-spam.tsx
@@ -12,7 +12,7 @@ import { useConversationDetailPanelControls } from '../../views/app/detail-panel
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isDraft, isSpam } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type ConvSetSpamFunctionsParameter = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-conv-set-unflag.tsx
+++ b/src/hooks/actions/use-conv-set-unflag.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useConvSetUnflagFn = (ids: Array<string>, isFlagged: boolean): ActionFn => {
 	const canExecute = useCallback((): boolean => isFlagged, [isFlagged]);

--- a/src/hooks/actions/use-conv-set-unread.tsx
+++ b/src/hooks/actions/use-conv-set-unread.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isDraft } from 'helpers/folders';
 import { convActionEmailStoreAction } from 'store/emails/actions/conv-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type ConvSetUnreadFunctionsParameter = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-conv-show-original.tsx
+++ b/src/hooks/actions/use-conv-show-original.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ConversationActionsDescriptors } from 'constants/index';
 import { isDraft, isTrash } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useConvShowOriginalFn = (firstMessageId: string, folderId: string): ActionFn => {
 	const canExecute = useCallback(

--- a/src/hooks/actions/use-hover-conversation-actions.tsx
+++ b/src/hooks/actions/use-hover-conversation-actions.tsx
@@ -7,7 +7,7 @@ import { useMemo } from 'react';
 
 import { getParentFolderId } from 'helpers/folders';
 import { useConvReplyDescriptor } from 'hooks/actions/use-conv-reply';
-import { UIActionDescriptor } from 'types/index.d';
+import { UIActionDescriptor } from 'types/actions';
 
 export type HoverMessageActionsType = {
 	firstMessageId: string;

--- a/src/hooks/actions/use-msg-actions.ts
+++ b/src/hooks/actions/use-msg-actions.ts
@@ -32,7 +32,8 @@ import { useMsgSetSpamDescriptor } from 'hooks/actions/use-msg-set-spam';
 import { useMsgSetUnflagDescriptor } from 'hooks/actions/use-msg-set-unflag';
 import { useMsgSetUnreadDescriptor } from 'hooks/actions/use-msg-set-unread';
 import { useMsgShowOriginalDescriptor } from 'hooks/actions/use-msg-show-original';
-import { MailMessage, UIActionAggregator, UIActionDescriptor } from 'types/index.d';
+import { UIActionAggregator, UIActionDescriptor } from 'types/actions';
+import { MailMessage } from 'types/messages';
 
 export type MessageActionsArgumentType = {
 	message: MailMessage;

--- a/src/hooks/actions/use-msg-apply-tag.tsx
+++ b/src/hooks/actions/use-msg-apply-tag.tsx
@@ -13,12 +13,8 @@ import { MessageActionsDescriptors, TIMEOUTS } from 'constants/index';
 import { isSpam } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import {
-	MsgActionOperation,
-	MsgActionResponse,
-	UIActionAggregator,
-	UIActionDescriptor
-} from 'types/index.d';
+import { UIActionAggregator, UIActionDescriptor } from 'types/actions';
+import { MsgActionOperation, MsgActionResponse } from 'types/soap/msg-action';
 
 export const useMsgApplyTagSubDescriptors = ({
 	ids,

--- a/src/hooks/actions/use-msg-create-appointment.tsx
+++ b/src/hooks/actions/use-msg-create-appointment.tsx
@@ -16,8 +16,9 @@ import { isDraft, isSpam } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
 import { extractBody } from 'store/editor-slice-utils';
 import { getMessageEmailStoreAction } from 'store/emails/actions/get-message';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { CalendarType, SenderType } from 'types/calendar';
-import type { ActionFn, MailMessage, UIActionDescriptor } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 export const useMsgCreateAppointmentFn = (item: MailMessage, folderId: string): ActionFn => {
 	const { createSnackbar } = useUiUtilities();

--- a/src/hooks/actions/use-msg-delete-permanently.tsx
+++ b/src/hooks/actions/use-msg-delete-permanently.tsx
@@ -13,7 +13,7 @@ import { isFocusModeMailView } from 'helpers/external-tabs';
 import { isSpam, isTrash } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { PermanentlyDeleteModal } from 'ui-actions/permanently-delete-modal';
 
 type MsgDeletePermanentlyFunctionsParameter = {

--- a/src/hooks/actions/use-msg-download-eml.tsx
+++ b/src/hooks/actions/use-msg-download-eml.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
 import { isDraft } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { getLocationOrigin } from 'views/app/detail-panel/preview/utils/index';
 
 export const useMsgDownloadEmlFn = (messageId: string, folderId: string): ActionFn => {

--- a/src/hooks/actions/use-msg-edit-as-new.tsx
+++ b/src/hooks/actions/use-msg-edit-as-new.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { EditViewActions, MessageActionsDescriptors } from 'constants/index';
 import { isDraft, isTrash } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 export const useMsgEditAsNewFn = (messageId: string, folderId: string): ActionFn => {

--- a/src/hooks/actions/use-msg-edit-draft.tsx
+++ b/src/hooks/actions/use-msg-edit-draft.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { EditViewActions, MessageActionsDescriptors } from 'constants/index';
 import { isDraft } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 export const useMsgEditDraftFn = (

--- a/src/hooks/actions/use-msg-forward-as-attachment.tsx
+++ b/src/hooks/actions/use-msg-forward-as-attachment.tsx
@@ -11,7 +11,8 @@ import { EditViewActions, MessageActionsDescriptors } from 'constants/index';
 import { MIMETYPE_EML } from 'helpers/attachments';
 import { isFocusModeMailView } from 'helpers/external-tabs';
 import { isDraft, isSpam } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor, UnsavedAttachment } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
+import { UnsavedAttachment } from 'types/attachments';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 export const useMsgForwardAsAttachmentFn = (

--- a/src/hooks/actions/use-msg-forward.tsx
+++ b/src/hooks/actions/use-msg-forward.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { EditViewActions, MessageActionsDescriptors } from 'constants/index';
 import { isDraft, isSpam } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 export const useMsgForwardFn = (messageId: string, folderId: string): ActionFn => {

--- a/src/hooks/actions/use-msg-move-to-folder.tsx
+++ b/src/hooks/actions/use-msg-move-to-folder.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { MessageActionsDescriptors } from 'constants/index';
 import { isTrash } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { MoveMessage } from 'ui-actions/move-msg';
 
 export const useMsgMoveToFolderFn = ({

--- a/src/hooks/actions/use-msg-move-to-trash.tsx
+++ b/src/hooks/actions/use-msg-move-to-trash.tsx
@@ -17,7 +17,7 @@ import { MAILS_ROUTE, MessageActionsDescriptors } from 'constants/index';
 import { isFocusModeMailView } from 'helpers/external-tabs';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import type { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { useInSearchModule } from 'ui-actions/utils';
 
 const useRestoreMessage = (): ((

--- a/src/hooks/actions/use-msg-preview-on-separated-window.tsx
+++ b/src/hooks/actions/use-msg-preview-on-separated-window.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
 import { isFocusModeMailView, openMessageStandalonePreview } from 'helpers/external-tabs';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useMsgPreviewOnSeparatedWindowFn = ({
 	messageId,

--- a/src/hooks/actions/use-msg-print.tsx
+++ b/src/hooks/actions/use-msg-print.tsx
@@ -11,7 +11,8 @@ import { getMsgsForPrintSoapApi } from 'api/index';
 import { getContentForPrint } from 'commons/print-conversation/print-conversation';
 import { MessageActionsDescriptors } from 'constants/index';
 import { isDraft, isTrash } from 'helpers/folders';
-import type { ActionFn, MailMessage, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
+import { MailMessage } from 'types/messages';
 import { errorPage } from 'ui-actions/error-page';
 
 export const useMsgPrintFn = (message: MailMessage, folderId: string): ActionFn => {

--- a/src/hooks/actions/use-msg-redirect.tsx
+++ b/src/hooks/actions/use-msg-redirect.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { MessageActionsDescriptors } from 'constants/index';
 import { isDraft, isTrash } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import RedirectAction from 'ui-actions/redirect-message-action';
 
 export const useMsgRedirectFn = (messageId: string, folderId: string): ActionFn => {

--- a/src/hooks/actions/use-msg-reply-all.tsx
+++ b/src/hooks/actions/use-msg-reply-all.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { EditViewActions, MessageActionsDescriptors } from 'constants/index';
 import { isDraft, isSpam } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 export const useMsgReplyAllFn = (messageId: string, folderId: string): ActionFn => {

--- a/src/hooks/actions/use-msg-reply.tsx
+++ b/src/hooks/actions/use-msg-reply.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { EditViewActions, MessageActionsDescriptors } from 'constants/index';
 import { isDraft, isSpam } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 export const useMsgReplyFn = (messageId: string, folderId: string): ActionFn => {

--- a/src/hooks/actions/use-msg-restore.tsx
+++ b/src/hooks/actions/use-msg-restore.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { MessageActionsDescriptors } from 'constants/index';
 import { isTrash } from 'helpers/folders';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 import { MoveMessage } from 'ui-actions/move-msg';
 
 export const useMsgRestoreFn = ({

--- a/src/hooks/actions/use-msg-set-flag.tsx
+++ b/src/hooks/actions/use-msg-set-flag.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useMsgSetFlagFn = (ids: Array<string>, isFlagged: boolean): ActionFn => {
 	const canExecute = useCallback((): boolean => !isFlagged, [isFlagged]);

--- a/src/hooks/actions/use-msg-set-not-spam.tsx
+++ b/src/hooks/actions/use-msg-set-not-spam.tsx
@@ -12,7 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { MAILS_ROUTE, MessageActionsDescriptors, TIMEOUTS } from 'constants/index';
 import { isSpam } from 'helpers/folders';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type MsgSetNotSpam = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-msg-set-read.tsx
+++ b/src/hooks/actions/use-msg-set-read.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { MAILS_ROUTE, MessageActionsDescriptors } from 'constants/index';
 import { isDraft } from 'helpers/folders';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type MsgSetReadFunctionsParameter = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-msg-set-spam.tsx
+++ b/src/hooks/actions/use-msg-set-spam.tsx
@@ -13,7 +13,7 @@ import { useNavigate } from 'react-router-dom';
 import { MAILS_ROUTE, MessageActionsDescriptors, TIMEOUTS } from 'constants/index';
 import { isDraft, isSpam } from 'helpers/folders';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type MsgSetSpam = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-msg-set-unflag.tsx
+++ b/src/hooks/actions/use-msg-set-unflag.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useMsgSetUnflagFn = (ids: Array<string>, isFlagged: boolean): ActionFn => {
 	const canExecute = useCallback((): boolean => isFlagged, [isFlagged]);

--- a/src/hooks/actions/use-msg-set-unread.tsx
+++ b/src/hooks/actions/use-msg-set-unread.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { MAILS_ROUTE, MessageActionsDescriptors } from 'constants/index';
 import { isDraft } from 'helpers/folders';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 type MsgSetUnreadFunctionsParameter = {
 	ids: Array<string>;

--- a/src/hooks/actions/use-msg-show-original.tsx
+++ b/src/hooks/actions/use-msg-show-original.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { MessageActionsDescriptors } from 'constants/index';
 import { isDraft, isTrash } from 'helpers/folders';
-import { ActionFn, UIActionDescriptor } from 'types/index.d';
+import { ActionFn, UIActionDescriptor } from 'types/actions';
 
 export const useMsgShowOriginalFn = (messageId: string, folderId: string): ActionFn => {
 	const canExecute = useCallback(

--- a/src/hooks/tests/use-fetch-messages-by-folder.test.ts
+++ b/src/hooks/tests/use-fetch-messages-by-folder.test.ts
@@ -20,7 +20,7 @@ import {
 	resetMessagesAndPopulatedItems,
 	updateMessagesResultsLoadingStatus
 } from 'store/emails/store';
-import { SearchRequest, SearchResponse } from 'types/index.d';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
 
 const folder = generateFolder({ id: '2' });
 vi.mock('../../store/emails/store', async () => ({

--- a/src/hooks/use-get-tags-accordions.tsx
+++ b/src/hooks/use-get-tags-accordions.tsx
@@ -25,7 +25,7 @@ import {
 } from '@zextras/carbonio-ui-commons';
 import { reduce } from 'lodash';
 
-import type { ItemType } from 'types/index.d';
+import { ItemType } from 'types/tags';
 import { createTag, useGetTagsActions } from 'ui-actions/tag-actions';
 
 type ItemProps = {

--- a/src/hooks/use-mark-as-read-on-click.ts
+++ b/src/hooks/use-mark-as-read-on-click.ts
@@ -7,7 +7,7 @@ import { useCallback } from 'react';
 
 import { useUserSettings } from '@zextras/carbonio-shell-ui';
 
-import { ActionFn } from 'types/index.d';
+import { ActionFn } from 'types/actions';
 
 /**
  * Hook to encapsulate the logic used across components to mark a message/conversation as read

--- a/src/hooks/use-should-replace-history.ts
+++ b/src/hooks/use-should-replace-history.ts
@@ -11,7 +11,6 @@ import { filter } from 'lodash';
 import { useParams } from 'react-router-dom';
 
 import { useConversationMessages } from '../store/emails/store';
-import type { MailMessage, NormalizedConversation } from '../types';
 import type {
 	DetailPanelRoutesParams,
 	FolderPanelRouteParams,
@@ -21,6 +20,8 @@ import type {
 	SearchListPanelRouteParams,
 	SearchRoutesParams
 } from '../types/routes';
+import { NormalizedConversation } from 'types/conversations';
+import { MailMessage } from 'types/messages';
 
 const isItemAMessage = (item: MailMessage | NormalizedConversation): item is MailMessage =>
 	!!(item as MailMessage)?.conversation;

--- a/src/hooks/use-tag-dropdown-item.tsx
+++ b/src/hooks/use-tag-dropdown-item.tsx
@@ -8,7 +8,7 @@ import React, { useMemo } from 'react';
 import { DropdownItem } from '@zextras/carbonio-design-system';
 import { includes, reduce } from 'lodash';
 
-import { UIActionAggregator } from 'types/index.d';
+import { UIActionAggregator } from 'types/actions';
 import { TagsDropdownItem } from 'ui-actions/tag-actions';
 
 export const useTagDropdownItem = (

--- a/src/integrations/shared-functions.ts
+++ b/src/integrations/shared-functions.ts
@@ -6,7 +6,7 @@
 
 import { EditViewActions } from 'constants/index';
 import { EditorPrefillData } from 'types/editor';
-import type { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 
 export const mailToSharedFunction: (recipients: Array<Participant>, subject?: string) => void = (

--- a/src/integrations/shared-invite-reply/index.tsx
+++ b/src/integrations/shared-invite-reply/index.tsx
@@ -22,7 +22,7 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import LabelRow from 'integrations/shared-invite-reply/parts/label-row';
 import ResponseActions from 'integrations/shared-invite-reply/parts/response-actions';
 import { ShareCalendarRoleOptions, findLabel } from 'integrations/shared-invite-reply/parts/utils';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 const InviteContainer = styled(Container)`
 	border: 0.0625rem solid ${({ theme }): string => theme.palette.gray2.regular};

--- a/src/integrations/shared-invite-reply/parts/share-folder-actions.ts
+++ b/src/integrations/shared-invite-reply/parts/share-folder-actions.ts
@@ -14,7 +14,8 @@ import { acceptSharedFolderReply } from 'api/accept-shared-folder-reply';
 import { mountSharedFolderSoapApi } from 'api/mount-shared-folder-soap-api';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import type { Participant, SaveDraftResponse } from 'types/index.d';
+import { Participant } from 'types/participant';
+import { SaveDraftResponse } from 'types/soap/save-draft';
 
 type Accept = {
 	zid: string;

--- a/src/integrations/shared-invite-reply/parts/tests/share-folder-actions.test.ts
+++ b/src/integrations/shared-invite-reply/parts/tests/share-folder-actions.test.ts
@@ -13,7 +13,7 @@ import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
 import { CreateMountpointError } from 'api/errors/create-mountpoint-error';
 import { CreateMountpointResponse } from 'api/mount-shared-folder-soap-api';
 import { useAccept } from 'integrations/shared-invite-reply/parts/share-folder-actions';
-import { ISoapFolderObj } from 'types/index.d';
+import { ISoapFolderObj } from 'types/soap/soap';
 
 describe('share folder actions', () => {
 	it('should mount shared folder on accept', async () => {

--- a/src/normalizations/normalize-conversation.ts
+++ b/src/normalizations/normalize-conversation.ts
@@ -7,11 +7,9 @@ import { filter, isNil, map, omitBy } from 'lodash';
 
 import { normalizeParticipantsFromSoap } from 'normalizations/normalize-message';
 import { getTagIds } from 'normalizations/utils';
-import type {
-	NormalizedConversation,
-	SoapConversation,
-	SoapIncompleteMessage
-} from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
+import { SoapConversation } from 'types/soap/soap-conversation';
+import { SoapIncompleteMessage } from 'types/soap/soap-mail-message';
 import { OptionalExcept, SoapPartialConversation } from 'views/sidebar/commons/types';
 
 export type NormalizeConversationProps = {

--- a/src/normalizations/normalize-filter-rules.ts
+++ b/src/normalizations/normalize-filter-rules.ts
@@ -5,7 +5,7 @@
  */
 import { map, omit } from 'lodash';
 
-import { AllFiltersTest, FilterRules } from 'types/index.d';
+import { AllFiltersTest, FilterRules } from 'types/filters';
 
 const normalizeFilterTests = (filterTests: AllFiltersTest): AllFiltersTest => {
 	const result: AllFiltersTest = { condition: filterTests.condition };

--- a/src/normalizations/normalize-message.ts
+++ b/src/normalizations/normalize-message.ts
@@ -28,14 +28,15 @@ import {
 	IncompleteMessage,
 	MailHeaders,
 	MailMessage,
-	MailMessagePart,
-	SoapEmailParticipantRole,
+	MailMessagePart
+} from 'types/messages';
+import { Participant } from 'types/participant';
+import {
 	SoapIncompleteMessage,
 	SoapMailMessage,
-	SoapMailMessagePart,
-	SoapMailParticipant
-} from 'types/index.d';
-import { Participant } from 'types/participant';
+	SoapMailMessagePart
+} from 'types/soap/soap-mail-message';
+import { SoapEmailParticipantRole, SoapMailParticipant } from 'types/soap/soap-mail-participant';
 import {
 	PartialIncompleteMessage,
 	SoapPartialIncompleteMessage

--- a/src/normalizations/normalize-message.ts
+++ b/src/normalizations/normalize-message.ts
@@ -29,13 +29,13 @@ import {
 	MailHeaders,
 	MailMessage,
 	MailMessagePart,
-	Participant,
 	SoapEmailParticipantRole,
 	SoapIncompleteMessage,
 	SoapMailMessage,
 	SoapMailMessagePart,
 	SoapMailParticipant
 } from 'types/index.d';
+import { Participant } from 'types/participant';
 import {
 	PartialIncompleteMessage,
 	SoapPartialIncompleteMessage

--- a/src/normalizations/tests/normalize-conversation.test.ts
+++ b/src/normalizations/tests/normalize-conversation.test.ts
@@ -6,16 +6,17 @@
 import { ParticipantRole } from '@zextras/carbonio-ui-commons';
 
 import {
-	mapToNormalizedConversation,
-	normalizeConversations,
-	normalizePartialConversations
-} from 'normalizations/normalize-conversation';
-import {
 	generateCompleteMessageFromAPI,
 	generateConversationFromAPI,
 	generateSoapConversationMessage
 } from '__test__/generators/api';
-import { Participant, SoapConversation } from 'types/index.d';
+import {
+	mapToNormalizedConversation,
+	normalizeConversations,
+	normalizePartialConversations
+} from 'normalizations/normalize-conversation';
+import { Participant } from 'types/participant';
+import { SoapConversation } from 'types/soap/soap-conversation';
 
 describe('Normalize conversation', () => {
 	it('returns normalized conversation with all fields', () => {

--- a/src/normalizations/tests/normalize-message.test.ts
+++ b/src/normalizations/tests/normalize-message.test.ts
@@ -1,17 +1,15 @@
-/* eslint-disable sonarjs/no-duplicate-string */
-// noinspection HtmlRequiredLangAttribute
-
 /*
  * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { generateMessageFromAPI } from '../../__test__/generators/api';
-import { MailMessagePart, SoapMailMessagePart } from '../../types';
 import {
 	normalizeMailMessageFromSoap,
 	normalizePartialIncompleteMessageFromSoapNotify
 } from '../normalize-message';
+import { MailMessagePart } from 'types/messages';
+import { SoapMailMessagePart } from 'types/soap/soap-mail-message';
 
 describe('normalize-message.ts', () => {
 	describe('Normalize message', () => {

--- a/src/store/backup-search/store.ts
+++ b/src/store/backup-search/store.ts
@@ -9,7 +9,8 @@ import produce from 'immer';
 import { omit, reduce } from 'lodash';
 import { create } from 'zustand';
 
-import type { BackupSearchStore, DeletedMessageFromAPI } from 'types/index.d';
+import { DeletedMessageFromAPI } from 'types/api';
+import { BackupSearchStore } from 'types/backup-search';
 
 export const useBackupSearchStore = create<BackupSearchStore>()((set) => ({
 	messages: {},

--- a/src/store/editor-slice-utils.ts
+++ b/src/store/editor-slice-utils.ts
@@ -15,14 +15,9 @@ import { getAddressOwnerAccount, getIdentityDescriptor } from 'helpers/identitie
 import { extractBodyWithInlinedStyles } from 'helpers/inline-styles';
 import { applyUserPreferenceStyles } from 'helpers/user-preference-styles';
 import { InlineAttachments, MailsEditor } from 'types/editor';
-import type {
-	MailAttachmentParts,
-	MailMessage,
-	MailMessagePart,
-	Participant,
-	SharedParticipant,
-	SoapDraftMessageObj
-} from 'types/index.d';
+import { MailMessage, MailMessagePart } from 'types/messages';
+import { Participant, SharedParticipant } from 'types/participant';
+import { MailAttachmentParts, SoapDraftMessageObj } from 'types/soap/save-draft';
 
 export const retrieveAttachmentsType = (
 	original: MailMessage,

--- a/src/store/editor/editor-generators.ts
+++ b/src/store/editor/editor-generators.ts
@@ -35,6 +35,7 @@ import {
 	retrieveReplyTo,
 	retrieveTO
 } from 'store/editor-slice-utils';
+import { UnsavedAttachment } from 'types/attachments';
 import {
 	EditorPrefillData,
 	EditorRecipients,
@@ -42,7 +43,8 @@ import {
 	EditViewActionsType,
 	MailsEditorV2
 } from 'types/editor';
-import { MailMessage, Participant, UnsavedAttachment } from 'types/index.d';
+import { MailMessage } from 'types/messages';
+import { Participant } from 'types/participant';
 
 // Regex reply msg title
 const REPLY_REGEX = /(^(re:\s)+)/i;

--- a/src/store/editor/editor-transformations.ts
+++ b/src/store/editor/editor-transformations.ts
@@ -24,17 +24,16 @@ import {
 	filterUnsavedStandardAttachment
 } from 'store/editor/editor-utils';
 import { getCompleteMessageId } from 'store/utils';
+import { SavedAttachment, UnsavedAttachment } from 'types/attachments';
 import { MailsEditorV2 } from 'types/editor';
+import { Participant } from 'types/participant';
 import {
 	MailAttachment,
 	MailAttachmentParts,
 	MsgAttach,
-	Participant,
-	SavedAttachment,
 	SoapDraftMessageObj,
-	SoapEmailMessagePartObj,
-	UnsavedAttachment
-} from 'types/index.d';
+	SoapEmailMessagePartObj
+} from 'types/soap/save-draft';
 
 export const composeCidUrlFromContentId = (contentId: string): string | null => {
 	const contentIdInnerPart = removeAngleBrackets(contentId);

--- a/src/store/editor/editor-utils.ts
+++ b/src/store/editor/editor-utils.ts
@@ -8,8 +8,8 @@ import { concat, filter, reduce, reject, some } from 'lodash';
 
 import { areContentIdsEqual } from '../../commons/content-id-utils';
 import { PROCESS_STATUS } from 'constants/index';
+import { SavedAttachment, UnsavedAttachment } from 'types/attachments';
 import { EditorOperationAllowedStatus, MailsEditorV2 } from 'types/editor';
-import type { SavedAttachment, UnsavedAttachment } from 'types/index.d';
 
 /**
  *

--- a/src/store/editor/hooks/send.ts
+++ b/src/store/editor/hooks/send.ts
@@ -14,7 +14,7 @@ import { getEditor } from 'store/editor/hooks/editors';
 import { computeAndUpdateEditorStatus } from 'store/editor/hooks/statuses';
 import { useEditorsStore } from 'store/editor/store';
 import { MailsEditorV2 } from 'types/editor';
-import { SaveDraftResponse } from 'types/index.d';
+import { SaveDraftResponse } from 'types/soap/save-draft';
 
 export type SendMessageOptions = {
 	cancelable?: boolean;

--- a/src/store/editor/hooks/tests/useEditorAttachments.test.tsx
+++ b/src/store/editor/hooks/tests/useEditorAttachments.test.tsx
@@ -7,12 +7,6 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 
 import { generateCompleteMessageFromAPI } from '../../../../__test__/generators/api';
 import { generateNewEditor } from '../../../../__test__/generators/editors';
-import {
-	SavedAttachment,
-	SaveDraftRequest,
-	SaveDraftResponse,
-	UnsavedAttachment
-} from '../../../../types';
 import { generateNewMessageEditor } from '../../editor-generators';
 import { useEditorsStore } from '../../store';
 import { useEditorAttachments } from '../attachments';
@@ -22,6 +16,8 @@ import {
 	createSoapAPIInterceptorV2
 } from '@test-utils/network/msw/create-api-interceptor';
 import { getEditor } from 'store/editor/hooks/editors';
+import { SavedAttachment, UnsavedAttachment } from 'types/attachments';
+import { SaveDraftRequest, SaveDraftResponse } from 'types/soap/save-draft';
 
 const extractContentIdFromRequest = (request: SaveDraftRequest): string | undefined => {
 	// Magic, trust me

--- a/src/store/emails/actions/get-message-with-existing-participants.ts
+++ b/src/store/emails/actions/get-message-with-existing-participants.ts
@@ -12,7 +12,9 @@ import {
 	normalizeMailMessageFromSoap
 } from 'normalizations/normalize-message';
 import { updateMessages, updateMessageStatus } from 'store/emails/store';
-import { GetMsgResponse, MailMessage, Participant } from 'types/index.d';
+import { MailMessage } from 'types/messages';
+import { Participant } from 'types/participant';
+import { GetMsgResponse } from 'types/soap/get-msg';
 
 async function handleRetrieveMessageWithParticipants(
 	messageId: string,

--- a/src/store/emails/actions/get-message.ts
+++ b/src/store/emails/actions/get-message.ts
@@ -14,7 +14,8 @@ import {
 	normalizeMailMessageFromSoap
 } from 'normalizations/normalize-message';
 import { updateMessages, updateMessageStatus } from 'store/emails/store';
-import { GetMsgResponse, MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
+import { GetMsgResponse } from 'types/soap/get-msg';
 
 function handleGetMsgResponse(response: GetMsgResponse): void {
 	const messages = map(response?.m ?? [], (msg) => normalizeCompleteMailMessageFromSoap(msg));

--- a/src/store/emails/actions/search-action.ts
+++ b/src/store/emails/actions/search-action.ts
@@ -23,7 +23,8 @@ import {
 	resetMessagesAndPopulatedItems,
 	updateConversationsResultsLoadingStatus
 } from 'store/emails/store';
-import { SearchResponse, SearchSoapApiParams } from 'types/index.d';
+import { SearchSoapApiParams } from 'types/conversations';
+import { SearchResponse } from 'types/soap/search';
 import { extractConvMessage } from 'views/sidebar/commons/use-sync-data-handler';
 
 const handleSearchSoapApiResults = ({

--- a/src/store/emails/actions/search-conv-action.ts
+++ b/src/store/emails/actions/search-conv-action.ts
@@ -15,7 +15,8 @@ import {
 	updateConversations,
 	updateConversationStatus
 } from 'store/emails/store';
-import { NormalizedConversation, SearchConvResponse } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
+import { SearchConvResponse } from 'types/soap/search-conv';
 
 function handleSearchConvResponse(conversationId: string, response: SearchConvResponse): void {
 	const messages = map(response?.m ?? [], (msg) => normalizeCompleteMailMessageFromSoap(msg));

--- a/src/store/emails/actions/tests/get-message-with-existing-participants.test.ts
+++ b/src/store/emails/actions/tests/get-message-with-existing-participants.test.ts
@@ -1,14 +1,16 @@
-import { ParticipantRole } from '@zextras/carbonio-ui-commons';
 /*
  * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { ParticipantRole } from '@zextras/carbonio-ui-commons';
+
 import { generateCompleteMessageFromAPI } from '../../../../__test__/generators/api';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { getMessageWithExistingParticipantsEmailStoreAction } from 'store/emails/actions/get-message-with-existing-participants';
-import { GetMsgRequest, GetMsgResponse, MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
+import { GetMsgRequest, GetMsgResponse } from 'types/soap/get-msg';
 
 const stubGetMsgApi = (response: any): Promise<GetMsgRequest> =>
 	createSoapAPIInterceptor<GetMsgRequest, GetMsgResponse>('GetMsg', response);

--- a/src/store/emails/actions/tests/get-message.test.ts
+++ b/src/store/emails/actions/tests/get-message.test.ts
@@ -12,7 +12,7 @@ import {
 	getMessageDecryptEmailStoreAction
 } from 'store/emails/actions/get-message';
 import { getSoapMailMessage } from 'store/emails/actions/tests/test-utils';
-import { GetMsgRequest, GetMsgResponse } from 'types/index.d';
+import { GetMsgRequest, GetMsgResponse } from 'types/soap/get-msg';
 
 const stubGetMsgApi = (response: any): Promise<GetMsgRequest> =>
 	createSoapAPIInterceptor<GetMsgRequest, GetMsgResponse>('GetMsg', response);
@@ -54,10 +54,6 @@ describe('get-message', () => {
 				})
 			]
 		};
-
-		// beforeEach(() => {
-		// 	vi.clearAllMocks();
-		// });
 
 		it('handles successful message retrieval', async () => {
 			const getMsgApi = stubGetMsgApi(getMsgResponse);

--- a/src/store/emails/actions/tests/test-utils.ts
+++ b/src/store/emails/actions/tests/test-utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { SoapIncompleteMessage, SoapMailMessage } from 'types/index.d';
+import { SoapIncompleteMessage, SoapMailMessage } from 'types/soap/soap-mail-message';
 
 export function getSoapMailMessage(
 	messageId: string,

--- a/src/store/emails/slices/populated-items/tests/populated-items-slice.test.ts
+++ b/src/store/emails/slices/populated-items/tests/populated-items-slice.test.ts
@@ -1,28 +1,26 @@
-/* eslint-disable */
 /*
  * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { populateFoldersStore } from '@test-utils/store/folders';
-import { tags as mockTags } from '@test-utils/tags/tags';
-import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
-
 import { FOLDERS, useTags } from '@zextras/carbonio-ui-commons';
 import { omit } from 'lodash';
 import type { Mock } from 'vitest';
-import { CONVACTIONS } from 'commons/utilities';
-import { API_REQUEST_STATUS } from 'constants/index';
+
+import { populateFoldersStore } from '@test-utils/store/folders';
+import { tags as mockTags } from '@test-utils/tags/tags';
+import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
 import { generateCompleteMessageFromAPI } from '__test__/generators/api';
 import {
 	generateConversation,
 	populateConversationInEmailStore
 } from '__test__/generators/generateConversation';
 import { generateMessage, populateMessagesInEmailStore } from '__test__/generators/generateMessage';
-import { ConvActionResponse, MailMessage } from 'types/index.d';
+import { CONVACTIONS } from 'commons/utilities';
+import { API_REQUEST_STATUS } from 'constants/index';
 import {
 	appendConversations,
 	getConversationMessages,
@@ -51,6 +49,8 @@ import {
 	useMessagesByIds,
 	useMessageStatus
 } from 'store/emails/store';
+import { MailMessage } from 'types/messages';
+import { ConvActionResponse } from 'types/soap/conv-action';
 
 const { setMessagesInSearchSlice } = getUseEmailStoreAndHooksForTesting();
 
@@ -81,6 +81,7 @@ describe('store-populated-items-slice', () => {
 			const updatedMessage = { ...initialMessage, isComplete: true, subject: undefined };
 			act(() => {
 				// passing undefined to subject to make sure it is not updated
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				updateMessages([updatedMessage]);
 			});
@@ -95,6 +96,7 @@ describe('store-populated-items-slice', () => {
 			const updatedMessage = { ...initialMessage, isComplete: false, subject: undefined };
 			act(() => {
 				// passing undefined to subject to make sure it is not updated
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				updateMessages([updatedMessage]);
 			});
@@ -181,6 +183,7 @@ describe('store-populated-items-slice', () => {
 				updateMessages(messages);
 			});
 
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
 			const { result: messageWithoutId } = renderHook(() => useMessageById(undefined));
 			const { result: message2 } = renderHook(() => useMessageById('2'));

--- a/src/store/emails/sync-data-handler/trigger-notification.tsx
+++ b/src/store/emails/sync-data-handler/trigger-notification.tsx
@@ -15,7 +15,7 @@ import { filter, find, reject, reverse, sortBy } from 'lodash';
 import { NavigateFunction } from 'react-router-dom';
 
 import { MAILS_ROUTE } from 'constants/index';
-import { IncompleteMessage, MailMessage } from 'types/index.d';
+import { IncompleteMessage, MailMessage } from 'types/messages';
 
 export const triggerNotification = (
 	messages: Array<IncompleteMessage | MailMessage>,

--- a/src/store/tests/editor-slice-utils.test.ts
+++ b/src/store/tests/editor-slice-utils.test.ts
@@ -10,7 +10,6 @@ import { AvailableAddress, FOLDERS, ParticipantRole } from '@zextras/carbonio-ui
 import type { Mock } from 'vitest';
 
 import { LineType } from '../../commons/utils';
-import { MailMessage } from '../../types';
 import { generateAccount } from '@test-utils/accounts/account-generator';
 import { generateMessage } from '__test__/generators/generateMessage';
 import { getAvailableAddresses } from 'helpers/get-available-addresses';
@@ -21,6 +20,7 @@ import {
 	retrieveCC,
 	retrieveReplyTo
 } from 'store/editor-slice-utils';
+import { MailMessage } from 'types/messages';
 
 vi.mock('../../helpers/get-available-addresses', () => ({
 	getAvailableAddresses: vi.fn()

--- a/src/store/tests/extract-body-styles.test.ts
+++ b/src/store/tests/extract-body-styles.test.ts
@@ -5,8 +5,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import type { MailMessage } from '../../types';
 import { extractBody } from '../editor-slice-utils';
+import { MailMessage } from 'types/messages';
 
 describe('extractBody - style preservation', () => {
 	it('should preserve styles from head when extracting body for reply/forward', () => {

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -6,7 +6,8 @@
 import { getUserAccount } from '@zextras/carbonio-shell-ui';
 import { includes, map } from 'lodash';
 
-import type { FetchConversationsReturn, MailMessage, NormalizedConversation } from 'types/index.d';
+import { FetchConversationsReturn, NormalizedConversation } from 'types/conversations';
+import { MailMessage } from 'types/messages';
 
 /**
  * Extracts all ids from conversations and messages

--- a/src/tests/app.test.tsx
+++ b/src/tests/app.test.tsx
@@ -23,24 +23,7 @@ import * as registerShellIntegrations from 'app-utils/register-shell-integration
 import * as useSearchRegisterer from 'app-utils/use-search-registerer';
 import { BACKUP_SEARCH_ROUTE } from 'constants/index';
 import { useBackupSearchStore } from 'store/backup-search/store';
-import { DeletedMessageFromAPI } from 'types';
-
-// Mocking the worker. In commons jest-setup the worker is already mocked, but is improperly defined with wrong types and
-// is causing a call to "onMessage", which tries to alter the folders store and overrides the folders, breaking the test.
-// It also causes warning/errors due the fact it tries to set an "undefined" in the folders.
-// I think we should consider removing that mock or redefine it or make it configurable
-// vi.mock('@zextras/carbonio-ui-commons', async () => ({
-// 	...(await vi.importActual('@zextras/carbonio-ui-commons')),
-// 	folderWorker: {
-// 		postMessage: vi.fn()
-// 	},
-// 	tagsWorker: {
-// 		postMessage: vi.fn()
-// 	}
-// }));
-// vi.mock('@zextras/carbonio-shell-ui', async () => ({
-// 	...(await vi.importActual('@zextras/carbonio-shell-ui'))
-// }));
+import { DeletedMessageFromAPI } from 'types/api';
 
 function aDeletedMessage(): DeletedMessageFromAPI {
 	return {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -5,4 +5,3 @@
  */
 
 export * from '@zextras/carbonio-ui-commons';
-export * from './api';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,0 @@
-/*
- * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
-export * from '@zextras/carbonio-ui-commons';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -5,7 +5,6 @@
  */
 
 export * from '@zextras/carbonio-ui-commons';
-export * from './actions';
 export * from './api';
 export * from './attachments';
 export * from './backup-search';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,7 +6,6 @@
 
 export * from '@zextras/carbonio-ui-commons';
 export * from './api';
-export * from './attachments';
 export * from './conversations';
 export * from './messages';
 export * from './soap';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,5 +7,4 @@
 export * from '@zextras/carbonio-ui-commons';
 export * from './api';
 export * from './conversations';
-export * from './messages';
 export * from './soap';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -10,7 +10,6 @@ export * from './api';
 export * from './attachments';
 export * from './backup-search';
 export * from './conversations';
-export * from './filters';
 export * from './messages';
 export * from './participant';
 export * from './soap';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,5 +6,4 @@
 
 export * from '@zextras/carbonio-ui-commons';
 export * from './api';
-export * from './conversations';
 export * from './soap';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,7 +7,6 @@
 export * from '@zextras/carbonio-ui-commons';
 export * from './api';
 export * from './attachments';
-export * from './backup-search';
 export * from './conversations';
 export * from './messages';
 export * from './participant';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,4 +6,3 @@
 
 export * from '@zextras/carbonio-ui-commons';
 export * from './api';
-export * from './soap';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -9,5 +9,4 @@ export * from './api';
 export * from './attachments';
 export * from './conversations';
 export * from './messages';
-export * from './participant';
 export * from './soap';

--- a/src/types/soap/get-msg.ts
+++ b/src/types/soap/get-msg.ts
@@ -40,6 +40,5 @@ export type GetMsgForPrintParameter = {
 };
 
 export type GetMsgForPrintResponse = {
-	GetMsgResponse: Array<GetMsgResponse>;
-	_jsns: 'urn:zimbra';
+	getMsgResponse: Array<GetMsgResponse>;
 };

--- a/src/ui-actions/modals/tests/select-folder-modal.test.tsx
+++ b/src/ui-actions/modals/tests/select-folder-modal.test.tsx
@@ -9,14 +9,14 @@ import React from 'react';
 import { faker } from '@faker-js/faker';
 import { screen } from '@testing-library/react';
 import { t } from '@zextras/carbonio-shell-ui';
-import { Folder, RootFolder } from '@zextras/carbonio-ui-commons';
+import { Folder, RootFolder, SoapFolderAction } from '@zextras/carbonio-ui-commons';
 
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { folderActionSoapApi } from 'api/folder-action-soap-api';
 import { FOLDER_ACTIONS } from 'commons/utilities';
-import { FolderActionResponse, SoapFolderAction } from 'types/index.d';
+import { FolderActionResponse } from 'types/soap/soap';
 import { SelectFolderModal } from 'ui-actions/modals/select-folder-modal';
 
 const folderToMove: Folder = {

--- a/src/ui-actions/participant-displayer-actions.ts
+++ b/src/ui-actions/participant-displayer-actions.ts
@@ -7,7 +7,7 @@ import { CreateSnackbarFn } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
 
 import { mailToSharedFunction } from 'integrations/shared-functions';
-import { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 
 export const copyEmailToClipboard = (email: string, createSnackbar: CreateSnackbarFn): void => {
 	navigator.clipboard.writeText(email).then(() => {

--- a/src/ui-actions/tag-actions.tsx
+++ b/src/ui-actions/tag-actions.tsx
@@ -25,8 +25,8 @@ import {
 import { filter, find, forEach, reduce, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import type { ItemType, UIActionDescriptor } from 'types/index.d';
-import { ArgumentType, TagActionsReturnType } from 'types/tags';
+import { UIActionDescriptor } from 'types/actions';
+import { ArgumentType, ItemType, TagActionsReturnType } from 'types/tags';
 import CreateUpdateTagModal from 'views/sidebar/parts/tags/create-update-tag-modal';
 
 export const createTag = ({ createModal, closeModal }: ArgumentType): DropdownItem => ({

--- a/src/ui-actions/tests/move-conv.test.tsx
+++ b/src/ui-actions/tests/move-conv.test.tsx
@@ -17,7 +17,8 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
 import { generateConversation } from '__test__/generators/generateConversation';
-import { ConvActionRequest, ConvActionResponse, NormalizedConversation } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
+import { ConvActionRequest, ConvActionResponse } from 'types/soap/conv-action';
 import { MoveConversation } from 'ui-actions/move-conv';
 
 vi.mock('react-router-dom', async () => ({

--- a/src/ui-actions/tests/move-msg.test.tsx
+++ b/src/ui-actions/tests/move-msg.test.tsx
@@ -16,7 +16,8 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
 import { generateMessage } from '__test__/generators/generateMessage';
-import { MailMessage, MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MailMessage } from 'types/messages';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 import { MoveMessage } from 'ui-actions/move-msg';
 
 describe('MoveMsg', () => {

--- a/src/ui-actions/tests/multi-sel-msg-primary-actions.test.tsx
+++ b/src/ui-actions/tests/multi-sel-msg-primary-actions.test.tsx
@@ -13,7 +13,7 @@ import { setupTest } from '@test-setup';
 import { ASSERTIONS, MSG_CONV_STATUS_DESCRIPTORS } from '__test__/constants';
 import { generateMessage } from '__test__/generators/generateMessage';
 import { FOLDERS_DESCRIPTORS, MessageActionsDescriptors } from 'constants/index';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { MessagesMultipleSelectionActions } from 'views/app/folder-panel/messages/messages-multiple-selection-actions';
 import { MultipleSelectionActionsPanel } from 'views/app/folder-panel/parts/multiple-selection-actions-panel';
 
@@ -290,17 +290,3 @@ test.todo(
 test.todo(
 	'secondary actions don’t contain the mark as unread action if the selection involve a trashed, junk or draft message'
 );
-// test.todo('secondary actions contain the flag action');
-// test.todo(
-// 	'secondary actions don’t contain the move action if the selection involve a trashed or draft message'
-// );
-// test.todo('secondary actions contain the tag submenu');
-// test.todo(
-// 	'secondary actions don’t contain the mark as spam action if the selection involve a trashed, junk or draft message'
-// );
-// test.todo(
-// 	'secondary actions contain the restore action if the selection involve trashed messages only'
-// );
-// test.todo(
-// 	'secondary actions contain the delete permanently action if the selection involve trashed messages only'
-// );

--- a/src/ui-actions/tests/multi-sel-msg-secondary-actions.test.tsx
+++ b/src/ui-actions/tests/multi-sel-msg-secondary-actions.test.tsx
@@ -13,7 +13,7 @@ import { setupTest } from '@test-setup';
 import { ASSERTIONS, MSG_CONV_STATUS_DESCRIPTORS } from '__test__/constants';
 import { generateMessage } from '__test__/generators/generateMessage';
 import { FOLDERS_DESCRIPTORS, MessageActionsDescriptors } from 'constants/index';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { MessagesMultipleSelectionActions } from 'views/app/folder-panel/messages/messages-multiple-selection-actions';
 import { MultipleSelectionActionsPanel } from 'views/app/folder-panel/parts/multiple-selection-actions-panel';
 
@@ -345,17 +345,3 @@ test.todo(
 test.todo(
 	'secondary actions don’t contain the mark as unread action if the selection involve a trashed, junk or draft message'
 );
-// test.todo('secondary actions contain the flag action');
-// test.todo(
-// 	'secondary actions don’t contain the move action if the selection involve a trashed or draft message'
-// );
-// test.todo('secondary actions contain the tag submenu');
-// test.todo(
-// 	'secondary actions don’t contain the mark as spam action if the selection involve a trashed, junk or draft message'
-// );
-// test.todo(
-// 	'secondary actions contain the restore action if the selection involve trashed messages only'
-// );
-// test.todo(
-// 	'secondary actions contain the delete permanently action if the selection involve trashed messages only'
-// );

--- a/src/ui-actions/tests/redirect-message-action.test.tsx
+++ b/src/ui-actions/tests/redirect-message-action.test.tsx
@@ -15,7 +15,7 @@ import { createFakeIdentity } from '@test-utils/accounts/fakeAccounts';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { generateMessage } from '__test__/generators/generateMessage';
-import { RedirectMessageActionRequest } from 'types/index.d';
+import { RedirectMessageActionRequest } from 'types/soap/redirect-message-action';
 import RedirectMessageAction from 'ui-actions/redirect-message-action';
 
 describe('RedirectMessageAction', () => {

--- a/src/ui-actions/tests/utils.test.ts
+++ b/src/ui-actions/tests/utils.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { parseTextToHTMLDocument } from 'helpers/text';
-import { MessageAction } from 'types/index.d';
+import { MessageAction } from 'types/actions';
 import {
 	findMessageActionById,
 	generateSmartLinkHtml,

--- a/src/views/app/detail-panel/conversation-message-preview.tsx
+++ b/src/views/app/detail-panel/conversation-message-preview.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { Padding } from '@zextras/carbonio-design-system';
 
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import MailPreview from 'views/app/detail-panel/preview/mail-preview';
 
 export type ConversationMessagePreviewProps = {

--- a/src/views/app/detail-panel/conversation-preview-panel.tsx
+++ b/src/views/app/detail-panel/conversation-preview-panel.tsx
@@ -10,7 +10,7 @@ import { useUserSettings } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 
 import { Spinner } from 'assets/spinner';
-import { NormalizedConversation } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
 import { ConversationMessagePreviewWrapper } from 'views/app/detail-panel/conversation-message-preview-wrapper';
 
 export const ConversationPreviewPanel = ({

--- a/src/views/app/detail-panel/edit/attachment-upload-status.tsx
+++ b/src/views/app/detail-panel/edit/attachment-upload-status.tsx
@@ -11,7 +11,7 @@ import { Button, Container, Icon, Padding, Row, Text } from '@zextras/carbonio-d
 import { t } from '@zextras/carbonio-shell-ui';
 
 import { TIMEOUTS } from 'constants/index';
-import { AttachmentUploadProcessStatus } from 'types/index.d';
+import { AttachmentUploadProcessStatus } from 'types/attachments';
 
 export const UploadingRow = styled(Row)`
 	display: flex;

--- a/src/views/app/detail-panel/edit/edit-utils-hooks/use-error-handler.ts
+++ b/src/views/app/detail-panel/edit/edit-utils-hooks/use-error-handler.ts
@@ -7,7 +7,7 @@
 import { ErrorSoapBodyResponse, t } from '@zextras/carbonio-shell-ui';
 
 import { TIMEOUTS } from 'constants/index';
-import { SaveDraftResponse } from 'types';
+import { SaveDraftResponse } from 'types/soap/save-draft';
 
 function isErrorAboutInvalidRecipient(error: SaveDraftResponse | ErrorSoapBodyResponse): boolean {
 	return error?.Fault?.Detail?.Error?.Code === 'mail.SEND_ABORTED_ADDRESS_FAILURE';

--- a/src/views/app/detail-panel/edit/parts/recipients-row.tsx
+++ b/src/views/app/detail-panel/edit/parts/recipients-row.tsx
@@ -13,8 +13,8 @@ import {
 } from '@zextras/carbonio-ui-commons';
 import { map, some } from 'lodash';
 
-import { Participant } from 'types';
 import { isValidEmail } from 'views/search/parts/utils';
+import { Participant } from 'types/participant';
 
 /**
  * Get the name for a contact based on available fields

--- a/src/views/app/detail-panel/edit/parts/tests/recipients-row.test.tsx
+++ b/src/views/app/detail-panel/edit/parts/tests/recipients-row.test.tsx
@@ -21,7 +21,7 @@ import {
 	generateMockedContactInput,
 	mockContactInput
 } from '@test-utils/integrations/mock-contact-input';
-import { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 import { RecipientsRow } from 'views/app/detail-panel/edit/parts/recipients-row';
 
 const triggerOnAdd = async (user: UserEvent): Promise<void> => {

--- a/src/views/app/detail-panel/edit/tests/edit-view-controller.test.tsx
+++ b/src/views/app/detail-panel/edit/tests/edit-view-controller.test.tsx
@@ -29,7 +29,7 @@ import { populateMessagesInEmailStore } from '__test__/generators/generateMessag
 import { EditViewActions } from 'constants/index';
 import { generateNewMessageEditor } from 'store/editor/editor-generators';
 import { getSoapMailMessage } from 'store/emails/actions/tests/test-utils';
-import { GetMsgRequest, GetMsgResponse } from 'types/index.d';
+import { GetMsgRequest, GetMsgResponse } from 'types/soap/get-msg';
 import { EditViewBoardContext } from 'views/app/detail-panel/edit/edit-view-board';
 import EditViewController from 'views/app/detail-panel/edit/edit-view-controller';
 

--- a/src/views/app/detail-panel/edit/tests/utils/utils.ts
+++ b/src/views/app/detail-panel/edit/tests/utils/utils.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
-import { SaveDraftRequest, SaveDraftResponse, SoapMailMessage } from 'types/index.d';
+import { SaveDraftRequest, SaveDraftResponse } from 'types/soap/save-draft';
+import { SoapMailMessage } from 'types/soap/soap-mail-message';
 
 export function aSuccessfullSaveDraft(): Promise<SaveDraftRequest> {
 	const msg: SoapMailMessage = {

--- a/src/views/app/detail-panel/eml-preview-panel-container.tsx
+++ b/src/views/app/detail-panel/eml-preview-panel-container.tsx
@@ -12,7 +12,7 @@ import type { EmlRouteParams } from '../../../types/routes';
 import { getMsgSoapApi } from 'api/get-msg-soap-api';
 import { isFocusModeMailView } from 'helpers/external-tabs';
 import { normalizeMailMessageFromSoap } from 'normalizations/normalize-message';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { MessagePreviewPanel } from 'views/app/detail-panel/message-preview-panel';
 
 export const EmlPreviewPanelContainer = (): React.JSX.Element => {

--- a/src/views/app/detail-panel/message-preview-panel.tsx
+++ b/src/views/app/detail-panel/message-preview-panel.tsx
@@ -9,7 +9,7 @@ import { Container, Padding } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 
 import { Spinner } from 'assets/spinner';
-import { IncompleteMessage, MailMessage } from 'types/index.d';
+import { IncompleteMessage, MailMessage } from 'types/messages';
 import MailPreview from 'views/app/detail-panel/preview/mail-preview';
 import { PreviewPanelHeader } from 'views/app/detail-panel/preview/preview-panel-header';
 

--- a/src/views/app/detail-panel/preview/mail-preview.tsx
+++ b/src/views/app/detail-panel/preview/mail-preview.tsx
@@ -8,7 +8,7 @@ import React, { FC, useCallback, useMemo, useState } from 'react';
 import { Container } from '@zextras/carbonio-design-system';
 
 import { isFocusModeMailView } from 'helpers/external-tabs';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { MailPreviewBlock } from 'views/app/detail-panel/preview/parts/mail-preview-block';
 import { MailPreviewContent } from 'views/app/detail-panel/preview/parts/mail-preview-content';
 

--- a/src/views/app/detail-panel/preview/parts/contact-names-chips.tsx
+++ b/src/views/app/detail-panel/preview/parts/contact-names-chips.tsx
@@ -22,7 +22,7 @@ import { map, noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import type { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 import { copyEmailToClipboard, sendMsg } from 'ui-actions/participant-displayer-actions';
 
 const BadgeButton = styled(Button)`

--- a/src/views/app/detail-panel/preview/parts/contact-names.tsx
+++ b/src/views/app/detail-panel/preview/parts/contact-names.tsx
@@ -12,7 +12,7 @@ import { useUserAccounts } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 
 import { participantToString } from 'commons/utils';
-import type { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 
 const ContactSubText = styled(Text)`
 	padding: 0 0.125rem;

--- a/src/views/app/detail-panel/preview/parts/info-block/mail-info-block.tsx
+++ b/src/views/app/detail-panel/preview/parts/info-block/mail-info-block.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { checkExistEncryptionPassword } from 'api/check-exist-password-api';
 import { useSmimeFeatureStore, useSmimePasswordStore } from 'store/certificates/store';
 import { getMessageDecryptEmailStoreAction } from 'store/emails/actions/get-message';
-import { IncompleteMessage } from 'types/index.d';
+import { IncompleteMessage } from 'types/messages';
 import { DistributionListIcon } from 'views/app/detail-panel/preview/parts/info-block/distribution-list-icon';
 import { ExternalDomainIcon } from 'views/app/detail-panel/preview/parts/info-block/external-domain-icon';
 import { MailSensitivityIcon } from 'views/app/detail-panel/preview/parts/info-block/mail-sensitivity-icon';

--- a/src/views/app/detail-panel/preview/parts/info-block/mail-sensitivity-icon.tsx
+++ b/src/views/app/detail-panel/preview/parts/info-block/mail-sensitivity-icon.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { Icon, Row, Tooltip } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 
-import { Sensitivity } from 'types/index.d';
+import { Sensitivity } from 'types/messages';
 import {
 	getMailSensitivityIconColor,
 	getMailSensitivityLabel

--- a/src/views/app/detail-panel/preview/parts/info-block/smime-icon.tsx
+++ b/src/views/app/detail-panel/preview/parts/info-block/smime-icon.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { Icon, Row, Tooltip } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 
-import { MessageSignature } from 'types/index.d';
+import { MessageSignature } from 'types/soap/soap-mail-message';
 import { getSignedIconColor } from 'views/app/detail-panel/preview/utils/index';
 
 export const SmimeIcon = ({ signature }: { signature: MessageSignature }): React.JSX.Element => {

--- a/src/views/app/detail-panel/preview/parts/info-block/tests/mail-info-block.test.tsx
+++ b/src/views/app/detail-panel/preview/parts/info-block/tests/mail-info-block.test.tsx
@@ -12,7 +12,7 @@ import { HttpResponse } from 'msw';
 import { setupTest } from '@test-setup';
 import { createAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { useSmimeFeatureStore, useSmimePasswordStore } from 'store/certificates/store';
-import { IncompleteMessage } from 'types/index.d';
+import { IncompleteMessage } from 'types/messages';
 import { MailInfoBlock } from 'views/app/detail-panel/preview/parts/info-block/mail-info-block';
 
 const validSignature = {

--- a/src/views/app/detail-panel/preview/parts/info-details-modal/mail-info-detail-modal.tsx
+++ b/src/views/app/detail-panel/preview/parts/info-details-modal/mail-info-detail-modal.tsx
@@ -9,7 +9,8 @@ import { Container } from '@zextras/carbonio-design-system';
 import { ModalFooter, ModalHeader } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
-import { IncompleteMessage, MessageSignature } from 'types/index.d';
+import { IncompleteMessage } from 'types/messages';
+import { MessageSignature } from 'types/soap/soap-mail-message';
 import { MailGeneralInfoSubsection } from 'views/app/detail-panel/preview/parts/info-details-modal/subsections/mail-general-info-subsection';
 import { SmimeSubsection } from 'views/app/detail-panel/preview/parts/info-details-modal/subsections/smime-subsection';
 

--- a/src/views/app/detail-panel/preview/parts/info-details-modal/subsections/smime-subsection.tsx
+++ b/src/views/app/detail-panel/preview/parts/info-details-modal/subsections/smime-subsection.tsx
@@ -10,7 +10,7 @@ import { Container, Divider, Icon, Padding, Row, Text } from '@zextras/carbonio-
 import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 
-import { MessageSignature } from 'types/index.d';
+import { MessageSignature } from 'types/soap/soap-mail-message';
 import { ErrorMessageCode } from 'views/app/detail-panel/preview/utils/index';
 
 type SmimeDetailsModalProps = {

--- a/src/views/app/detail-panel/preview/parts/info-details-modal/subsections/tests/smime-subsection.test.tsx
+++ b/src/views/app/detail-panel/preview/parts/info-details-modal/subsections/tests/smime-subsection.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { setupTest } from '@test-setup';
-import { MessageSignature } from 'types/index.d';
+import { MessageSignature } from 'types/soap/soap-mail-message';
 import { SmimeSubsection } from 'views/app/detail-panel/preview/parts/info-details-modal/subsections/smime-subsection';
 
 describe('SmimeSubsection', () => {

--- a/src/views/app/detail-panel/preview/parts/mail-message-preview-actions.tsx
+++ b/src/views/app/detail-panel/preview/parts/mail-message-preview-actions.tsx
@@ -13,7 +13,7 @@ import { useShouldReplaceHistory } from '../../../../../hooks/use-should-replace
 import { normalizeDropdownActionItem } from 'helpers/actions';
 import { useMsgActions } from 'hooks/actions/use-msg-actions';
 import { useTagDropdownItem } from 'hooks/use-tag-dropdown-item';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 type MailMsgPreviewActionsType = {
 	message: MailMessage;

--- a/src/views/app/detail-panel/preview/parts/mail-preview-block.tsx
+++ b/src/views/app/detail-panel/preview/parts/mail-preview-block.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useShouldReplaceHistory } from '../../../../../hooks/use-should-replace-history';
 import { useMsgSetNotSpamFn } from 'hooks/actions/use-msg-set-not-spam';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { PreviewHeader } from 'views/app/detail-panel/preview/parts/preview-header';
 
 type MailPreviewBlockType = {

--- a/src/views/app/detail-panel/preview/parts/mail-preview-content.tsx
+++ b/src/views/app/detail-panel/preview/parts/mail-preview-content.tsx
@@ -13,7 +13,7 @@ import { MailMessageRenderer } from 'commons/mail-message-renderer/mail-message-
 import { isFocusModeMailView } from 'helpers/external-tabs';
 import SharedInviteReply from 'integrations/shared-invite-reply/index';
 import { msgActionEmailStoreAction } from 'store/emails/actions/msg-action-action';
-import type { IncompleteMessage, MailMessage } from 'types/index.d';
+import { MailMessage, IncompleteMessage } from 'types/messages';
 import AttachmentsBlock from 'views/app/detail-panel/preview/attachments-block';
 import { ReadReceiptModal } from 'views/app/detail-panel/preview/read-receipt-modal';
 

--- a/src/views/app/detail-panel/preview/parts/on-behalf-of-displayer.tsx
+++ b/src/views/app/detail-panel/preview/parts/on-behalf-of-displayer.tsx
@@ -8,9 +8,10 @@ import React, { FC, ReactElement, useMemo } from 'react';
 import styled from '@emotion/styled';
 import { getColor, Tooltip, Text } from '@zextras/carbonio-design-system';
 import { capitalize } from 'lodash';
-
-import type { Participant, MailMessage } from 'types/index.d';
 import { useTranslation } from 'react-i18next';
+
+import { MailMessage } from 'types/messages';
+import { Participant } from 'types/participant';
 
 const StyledText = styled.span<{ $isRead?: string | boolean; $color?: string }>`
 	padding: 0 0.125rem;

--- a/src/views/app/detail-panel/preview/parts/preview-header-actions.tsx
+++ b/src/views/app/detail-panel/preview/parts/preview-header-actions.tsx
@@ -14,13 +14,13 @@ import {
 	Tooltip,
 	Text
 } from '@zextras/carbonio-design-system';
+import { Tag } from '@zextras/carbonio-ui-soap-lib';
 import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 
 import { MailMsgPreviewActions } from './mail-message-preview-actions';
 import { getCompactDateLabel, getTimeLabel } from 'commons/utils';
 import { retrieveAttachmentsType } from 'store/editor-slice-utils';
-import { Tag } from 'types';
 import { MailMessage } from 'types/messages';
 
 type PreviewHeaderActions = {

--- a/src/views/app/detail-panel/preview/parts/preview-header.tsx
+++ b/src/views/app/detail-panel/preview/parts/preview-header.tsx
@@ -18,7 +18,7 @@ import { useContainerWidth } from './utils';
 import type { DetailPanelRoutesParams } from '../../../../../types/routes';
 import { participantToString } from 'commons/utils';
 import { getNoIdentityPlaceholder } from 'helpers/identities';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { useGetTagsList } from 'ui-actions/tag-actions';
 import { ContactChip } from 'views/app/detail-panel/preview/parts/contact-names-chips';
 import { MailInfoBlock } from 'views/app/detail-panel/preview/parts/info-block/mail-info-block';

--- a/src/views/app/detail-panel/preview/parts/tests/contact-names-chips.test.tsx
+++ b/src/views/app/detail-panel/preview/parts/tests/contact-names-chips.test.tsx
@@ -11,7 +11,7 @@ import { ParticipantRoleType } from '@zextras/carbonio-ui-commons';
 import { omit } from 'lodash';
 
 import { screen, setupTest } from '@test-setup';
-import { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 import { copyEmailToClipboard, sendMsg } from 'ui-actions/participant-displayer-actions';
 import {
 	ContactNameChip,

--- a/src/views/app/detail-panel/preview/parts/tests/contact-names.test.tsx
+++ b/src/views/app/detail-panel/preview/parts/tests/contact-names.test.tsx
@@ -11,7 +11,7 @@ import { useUserAccounts } from '@zextras/carbonio-shell-ui';
 import type { Mock } from 'vitest';
 
 import { setupTest } from '@test-setup';
-import { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 import ContactName from 'views/app/detail-panel/preview/parts/contact-names';
 
 describe('ContactName component', () => {

--- a/src/views/app/detail-panel/preview/preview-panel-header.tsx
+++ b/src/views/app/detail-panel/preview/preview-panel-header.tsx
@@ -20,7 +20,7 @@ import { useNavigate } from 'react-router-dom';
 import { MAILS_ROUTE } from 'constants/index';
 import { isFocusModeMailView } from 'helpers/external-tabs';
 import { useViewLayout } from 'hooks/use-view-layout';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { ConversationPreviewHeaderNavigation } from 'views/app/detail-panel/preview/conversation-preview-header-navigation';
 import { MessagePreviewHeaderNavigation } from 'views/app/detail-panel/preview/message-preview-header-navigation';
 import { LayoutComponent } from 'views/app/folder-panel/parts/layout-component';

--- a/src/views/app/detail-panel/preview/read-receipt-modal.tsx
+++ b/src/views/app/detail-panel/preview/read-receipt-modal.tsx
@@ -13,7 +13,7 @@ import { msgActionEmailStoreAction } from '../../../../store/emails/actions/msg-
 import { updateMessages } from '../../../../store/emails/store';
 import { sendDeliveryReportSoapApi } from 'api/send-delivery-request-soap-api';
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import type { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 
 type ReadReceiptModalProps = {
 	open: boolean;

--- a/src/views/app/detail-panel/preview/tests/read-receipt-modal.test.tsx
+++ b/src/views/app/detail-panel/preview/tests/read-receipt-modal.test.tsx
@@ -14,7 +14,7 @@ import { ReadReceiptModal } from '../read-receipt-modal';
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { generateMessage } from '__test__/generators/generateMessage';
-import type { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 
 const baseMessageWithReadReadReceiptRequested = generateMessage({
 	id: '12345',

--- a/src/views/app/folder-panel/conversations/conversation-list-hooks.ts
+++ b/src/views/app/folder-panel/conversations/conversation-list-hooks.ts
@@ -16,7 +16,7 @@ import {
 	updateConversationsResultsLoadingStatus,
 	updateMessages
 } from 'store/emails/store';
-import { SearchResponse } from 'types/index.d';
+import { SearchResponse } from 'types/soap/search';
 import { SortBy } from 'types/sorting';
 import { extractConvMessage } from 'views/sidebar/commons/use-sync-data-handler';
 

--- a/src/views/app/folder-panel/conversations/conversation-list-item-wrapper.tsx
+++ b/src/views/app/folder-panel/conversations/conversation-list-item-wrapper.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { normalizeDropdownActionItem } from 'helpers/actions';
 import { useConvActions } from 'hooks/actions/use-conv-actions';
 import { useTagDropdownItem } from 'hooks/use-tag-dropdown-item';
-import { NormalizedConversation } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
 import { HoverBarContainer } from 'views/app/folder-panel/parts/hover-bar-container';
 import { HoverContainer } from 'views/app/folder-panel/parts/hover-container';
 import { ListItemHoverActions } from 'views/app/folder-panel/parts/list-item-hover-actions';

--- a/src/views/app/folder-panel/conversations/tests/conversation-list-data-sync.test.tsx
+++ b/src/views/app/folder-panel/conversations/tests/conversation-list-data-sync.test.tsx
@@ -15,7 +15,7 @@ import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { generateConversationFromAPI, generateConvMessageFromAPI } from '__test__/generators/api';
-import { SearchRequest, SearchResponse } from 'types/index.d';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
 import { ConversationList } from 'views/app/folder-panel/conversations/conversation-list';
 import { simulateReplyToSingleMessageConversation } from 'views/app/folder-panel/tests/utils';
 import { useSyncDataHandler } from 'views/sidebar/commons/use-sync-data-handler';

--- a/src/views/app/folder-panel/conversations/tests/conversation-list-item.test.tsx
+++ b/src/views/app/folder-panel/conversations/tests/conversation-list-item.test.tsx
@@ -21,7 +21,7 @@ import { populateConversationInEmailStore } from '__test__/generators/generateCo
 import { API_REQUEST_STATUS, FOLDERS_DESCRIPTORS } from 'constants/index';
 import { useConvPreviewOnSeparatedWindowFn } from 'hooks/actions/use-conv-preview-on-separated-window';
 import { setConversationsInEmailStore, updateConversationStatus } from 'store/emails/store';
-import type { ConvActionRequest } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
 import {
 	ConversationListItem,
 	ConversationListItemProps

--- a/src/views/app/folder-panel/conversations/tests/conversation-list.test.tsx
+++ b/src/views/app/folder-panel/conversations/tests/conversation-list.test.tsx
@@ -19,7 +19,8 @@ import { tags } from '@test-utils/tags/tags';
 import { TESTID_SELECTORS } from '__test__/constants';
 import { generateConversationFromAPI, generateConvMessageFromAPI } from '__test__/generators/api';
 import { updateConversationsResultsLoadingStatus } from 'store/emails/store';
-import { ConvActionRequest, SearchRequest, SearchResponse } from 'types/index.d';
+import { ConvActionRequest } from 'types/soap/conv-action';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
 import { ConversationList } from 'views/app/folder-panel/conversations/conversation-list';
 import { makeAllItemsVisible } from 'views/settings/filters/tests/test-utils';
 

--- a/src/views/app/folder-panel/messages/message-list-hooks.ts
+++ b/src/views/app/folder-panel/messages/message-list-hooks.ts
@@ -15,7 +15,7 @@ import {
 	appendMessagesToMessagesSlice,
 	updateMessagesResultsLoadingStatus
 } from 'store/emails/store';
-import { SearchResponse } from 'types/index.d';
+import { SearchResponse } from 'types/soap/search';
 import { SortBy } from 'types/sorting';
 
 function handleLoadMoreResults({

--- a/src/views/app/folder-panel/messages/message-list-item-action-wrapper.tsx
+++ b/src/views/app/folder-panel/messages/message-list-item-action-wrapper.tsx
@@ -12,7 +12,7 @@ import { normalizeDropdownActionItem } from 'helpers/actions';
 import { isDraft } from 'helpers/folders';
 import { useMsgActions } from 'hooks/actions/use-msg-actions';
 import { useTagDropdownItem } from 'hooks/use-tag-dropdown-item';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { HoverBarContainer } from 'views/app/folder-panel/parts/hover-bar-container';
 import { HoverContainer } from 'views/app/folder-panel/parts/hover-container';
 import { ListItemDropdownAction } from 'views/app/folder-panel/parts/list-item-dropdown-action';

--- a/src/views/app/folder-panel/messages/tests/message-list-data-sync.test.tsx
+++ b/src/views/app/folder-panel/messages/tests/message-list-data-sync.test.tsx
@@ -15,7 +15,7 @@ import { makeListItemsVisible, setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { generateMessageFromAPI } from '__test__/generators/api';
-import { SearchRequest, SearchResponse } from 'types/index.d';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
 import { MessageList } from 'views/app/folder-panel/messages/message-list';
 import { simulateReplyToSingleMessageConversation } from 'views/app/folder-panel/tests/utils';
 import { useSyncDataHandler } from 'views/sidebar/commons/use-sync-data-handler';

--- a/src/views/app/folder-panel/messages/tests/message-list.test.tsx
+++ b/src/views/app/folder-panel/messages/tests/message-list.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import {
 	FOLDERS,
+	FolderState,
 	ParticipantRole,
 	useFolderStore,
 	useTagStore
@@ -23,7 +24,7 @@ import { populateFoldersStore } from '@test-utils/store/folders';
 import { tags } from '@test-utils/tags/tags';
 import { TESTID_SELECTORS } from '__test__/constants';
 import { generateCompleteMessageFromAPI } from '__test__/generators/api';
-import { FolderState, MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 import { MessageList } from 'views/app/folder-panel/messages/message-list';
 import { makeAllItemsVisible } from 'views/settings/filters/tests/test-utils';
 

--- a/src/views/app/folder-panel/parts/item-avatar.tsx
+++ b/src/views/app/folder-panel/parts/item-avatar.tsx
@@ -11,7 +11,7 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { FOLDERS, ParticipantRole } from '@zextras/carbonio-ui-commons';
 
 import { getFolderIdParts } from 'helpers/folders';
-import type { Participant } from 'types/index.d';
+import { Participant } from 'types/participant';
 import { TooltipWrapper } from 'views/app/folder-panel/parts/tooltip-wrapper';
 
 const AvatarElement = styled(Avatar)`

--- a/src/views/app/folder-panel/parts/list-item-hover-actions.tsx
+++ b/src/views/app/folder-panel/parts/list-item-hover-actions.tsx
@@ -7,7 +7,7 @@ import React, { ReactElement, useCallback } from 'react';
 
 import { Button, Tooltip } from '@zextras/carbonio-design-system';
 
-import { UIActionDescriptor } from 'types/index.d';
+import { UIActionDescriptor } from 'types/actions';
 
 const ListItemHoverAction = ({ action }: { action: UIActionDescriptor }): ReactElement => {
 	const onClick = useCallback(

--- a/src/views/app/folder-panel/parts/multiple-selection-actions-component.tsx
+++ b/src/views/app/folder-panel/parts/multiple-selection-actions-component.tsx
@@ -15,7 +15,7 @@ import {
 } from '@zextras/carbonio-design-system';
 import { isNil, noop } from 'lodash';
 
-import { UIActionDescriptor } from 'types/index.d';
+import { UIActionDescriptor } from 'types/actions';
 
 export const MultipleSelectionActionsComponent = ({
 	actions

--- a/src/views/app/folder-panel/parts/participants-string.tsx
+++ b/src/views/app/folder-panel/parts/participants-string.tsx
@@ -17,7 +17,8 @@ import { getFolderOwnerAccountName, isDraft, isInbox, isSent } from '../../../..
 import { isConversation } from '../../../../helpers/messages';
 import { getConversationMessagesParents } from '../../../../store/emails/store';
 import { DetailPanelMessageRouteParams, DetailPanelRoutesParams } from '../../../../types/routes';
-import { MailMessage, NormalizedConversation } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
+import { MailMessage } from 'types/messages';
 
 const getUserAddress = (
 	item: NormalizedConversation | MailMessage,

--- a/src/views/app/folder-panel/parts/row-info.tsx
+++ b/src/views/app/folder-panel/parts/row-info.tsx
@@ -10,7 +10,7 @@ import { Icon, Padding, Row, Text } from '@zextras/carbonio-design-system';
 import { Tag } from '@zextras/carbonio-ui-commons';
 
 import { getTimeLabel } from 'commons/utils';
-import { NormalizedConversation } from 'types/index.d';
+import { NormalizedConversation } from 'types/conversations';
 import { useTagExist } from 'ui-actions/tag-actions';
 
 type RowInfoProps = {

--- a/src/views/app/folder-panel/parts/utils/utils.ts
+++ b/src/views/app/folder-panel/parts/utils/utils.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { Folder } from '@zextras/carbonio-ui-commons';
 import { isEmpty } from 'lodash';
 
 import { INJECTED_DESCRIPTION_DECORATOR } from '../../../../../constants';
-import { Folder } from 'types/index.d';
 import { getFolderTranslatedName } from 'views/sidebar/utils';
 
 export const getFolderPath = (

--- a/src/views/backup-search/parts/backup-search-message-list-item.tsx
+++ b/src/views/backup-search/parts/backup-search-message-list-item.tsx
@@ -12,7 +12,7 @@ import { find } from 'lodash';
 import { useNavigate } from 'react-router-dom';
 
 import { BACKUP_SEARCH_ROUTE } from 'constants/index';
-import { BackupSearchMessage } from 'types/index.d';
+import { BackupSearchMessage } from 'types/backup-search';
 import { HoverContainer } from 'views/app/folder-panel/parts/hover-container';
 
 type BackupSearchMessageListmessageProps = {

--- a/src/views/backup-search/test/backup-search-panel.test.tsx
+++ b/src/views/backup-search/test/backup-search-panel.test.tsx
@@ -14,7 +14,7 @@ import type { Mock } from 'vitest';
 import { setupTest } from '@test-setup';
 import { generateFolder } from '@test-utils/folders/folders-generator';
 import { useBackupSearchStore } from 'store/backup-search/store';
-import { DeletedMessageFromAPI } from 'types/index.d';
+import { DeletedMessageFromAPI } from 'types/api';
 import { BackupSearchPanel } from 'views/backup-search/parts/backup-search-panel';
 
 vi.mock('react-router-dom', async () => ({

--- a/src/views/search/list/conversation/tests/search-conversation-list-item.test.tsx
+++ b/src/views/search/list/conversation/tests/search-conversation-list-item.test.tsx
@@ -18,7 +18,7 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { generateSettings } from '@test-utils/settings/settings-generator';
 import { populateConversationInEmailStore } from '__test__/generators/generateConversation';
 import { CONVACTIONS } from 'commons/utilities';
-import { ConvActionRequest, ConvActionResponse } from 'types/index.d';
+import { ConvActionRequest, ConvActionResponse } from 'types/soap/conv-action';
 import { SearchConversationListItem } from 'views/search/list/conversation/search-conversation-list-item';
 
 const conversationId = '-123';

--- a/src/views/search/list/message/search-message-list-item.tsx
+++ b/src/views/search/list/message/search-message-list-item.tsx
@@ -14,7 +14,7 @@ import { useMsgPreviewOnSeparatedWindowFn } from 'hooks/actions/use-msg-preview-
 import { useMsgSetReadFn } from 'hooks/actions/use-msg-set-read';
 import { useMarkAsReadOnClick } from 'hooks/use-mark-as-read-on-click';
 import { useOnMouseHover } from 'hooks/use-on-mouse-hover';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { MessageListItemActionWrapper } from 'views/app/folder-panel/messages/message-list-item-action-wrapper';
 import { SearchMessageListItemCore } from 'views/search/list/message/search-message-list-item-core';
 

--- a/src/views/search/list/message/tests/search-message-list-item-wrapper.test.tsx
+++ b/src/views/search/list/message/tests/search-message-list-item-wrapper.test.tsx
@@ -11,7 +11,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { setupTest } from '@test-setup';
 import { populateMessagesInEmailStore } from '__test__/generators/generateMessage';
 import * as storeModule from 'store/emails/store';
-import { MailMessage } from 'types/index.d';
+import { MailMessage } from 'types/messages';
 import { SearchMessageListItemWrapper } from 'views/search/list/message/search-message-list-item-wrapper';
 
 describe('SearchMessageListItemWrapper', () => {

--- a/src/views/search/list/message/tests/search-message-list-item.test.tsx
+++ b/src/views/search/list/message/tests/search-message-list-item.test.tsx
@@ -17,7 +17,7 @@ import { generateSettings } from '@test-utils/settings/settings-generator';
 import { populateMessagesInEmailStore } from '__test__/generators/generateMessage';
 import { CONVACTIONS } from 'commons/utilities';
 import { openMessageStandalonePreview } from 'helpers/external-tabs';
-import { MsgActionRequest, MsgActionResponse } from 'types/index.d';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
 import { createEditBoard } from 'views/app/detail-panel/edit/edit-view-board';
 import { SearchMessageListItem } from 'views/search/list/message/search-message-list-item';
 

--- a/src/views/search/parts/search-panel-header.tsx
+++ b/src/views/search/parts/search-panel-header.tsx
@@ -18,7 +18,8 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { useNavigate } from 'react-router-dom';
 
 import { SEARCH_ROUTE } from '../../../constants';
-import type { MailMessage, NormalizedConversation } from '../../../types';
+import { NormalizedConversation } from 'types/conversations';
+import { MailMessage } from 'types/messages';
 
 export const SearchPanelHeader: FC<{
 	item: NormalizedConversation | (Partial<MailMessage> & Pick<MailMessage, 'id'>);

--- a/src/views/search/test/search-view-hooks.test.ts
+++ b/src/views/search/test/search-view-hooks.test.ts
@@ -12,6 +12,8 @@ import { noop } from 'lodash';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { generateSettings } from '@test-utils/settings/settings-generator';
 import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
+import { generateConversationFromAPI, generateConvMessageFromAPI } from '__test__/generators/api';
+import { generateConversation } from '__test__/generators/generateConversation';
 import * as searchSoapApi from 'api/search-soap-api';
 import { API_REQUEST_STATUS } from 'constants/index';
 import {
@@ -20,9 +22,7 @@ import {
 	useMessageById,
 	useSearchResults
 } from 'store/emails/store';
-import { generateConversationFromAPI, generateConvMessageFromAPI } from '__test__/generators/api';
-import { generateConversation } from '__test__/generators/generateConversation';
-import { SearchRequest, SearchResponse } from 'types/index.d';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
 import { useLoadMoreForSearchSlice, useRunSearch } from 'views/search/search-view-hooks';
 
 describe('search view hooks', () => {

--- a/src/views/search/test/search-view.test.tsx
+++ b/src/views/search/test/search-view.test.tsx
@@ -22,22 +22,15 @@ import { tags } from '@test-utils/tags/tags';
 import { TESTID_SELECTORS } from '__test__/constants';
 import { generateSoapConversationMessage } from '__test__/generators/api';
 import * as searchSoapApi from 'api/search-soap-api';
-import {
-	ConvActionRequest,
-	ConvActionResponse,
-	GetMsgRequest,
-	GetMsgResponse,
-	MsgActionRequest,
-	MsgActionResponse,
-	SearchConvRequest,
-	SearchConvResponse,
-	SearchRequest,
-	SearchResponse,
-	SoapConversation,
-	SoapIncompleteMessage,
-	SoapMailMessage
-} from 'types/index.d';
+
 import SearchView from 'views/search/search-view';
+import { MsgActionRequest, MsgActionResponse } from 'types/soap/msg-action';
+import { SoapIncompleteMessage, SoapMailMessage } from 'types/soap/soap-mail-message';
+import { SoapConversation } from 'types/soap/soap-conversation';
+import { SearchRequest, SearchResponse } from 'types/soap/search';
+import { ConvActionRequest, ConvActionResponse } from 'types/soap/conv-action';
+import { SearchConvRequest, SearchConvResponse } from 'types/soap/search-conv';
+import { GetMsgRequest, GetMsgResponse } from 'types/soap/get-msg';
 
 vi.mock('react-router-dom', async () => ({
 	...(await vi.importActual('react-router-dom')),

--- a/src/views/search/test/utils.test.ts
+++ b/src/views/search/test/utils.test.ts
@@ -5,11 +5,10 @@
  */
 
 import type { QueryChip } from '@zextras/carbonio-search-ui';
-import { CONTACT_TYPES } from '@zextras/carbonio-ui-commons';
+import { CONTACT_TYPES, ContactInputItem } from '@zextras/carbonio-ui-commons';
 import { keyBy } from 'lodash';
 import moment from 'moment';
 
-import { ContactInputItem } from '../../../types';
 import { createFakeIdentity } from '@test-utils/accounts/fakeAccounts';
 import { generateFolder, generateFolderLink } from '@test-utils/folders/folders-generator';
 import { Query } from 'views/search/types/types';

--- a/src/views/settings/filters/parts/actions.ts
+++ b/src/views/settings/filters/parts/actions.ts
@@ -10,7 +10,7 @@ import { concat, filter, findIndex } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useUiUtilities } from 'hooks/use-ui-utilities';
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 
 export type ListType = {
 	isSelecting: boolean;

--- a/src/views/settings/filters/parts/create-filter-modal.tsx
+++ b/src/views/settings/filters/parts/create-filter-modal.tsx
@@ -12,7 +12,7 @@ import { map, omit, reduce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { Filter, FilterActions } from 'types/index.d';
+import { Filter, FilterActions } from 'types/filters';
 import { CreateFilterContext } from 'views/settings/filters/parts/create-filter-context';
 import ModalFooter from 'views/settings/filters/parts/create-filter-modal-footer';
 import DefaultCondition from 'views/settings/filters/parts/create-filters-conditions/default';

--- a/src/views/settings/filters/parts/filter-actions-panel.tsx
+++ b/src/views/settings/filters/parts/filter-actions-panel.tsx
@@ -9,7 +9,7 @@ import { Container, Text } from '@zextras/carbonio-design-system';
 import { map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { FilterAction } from 'types/index.d';
+import { FilterAction } from 'types/filters';
 import Heading from 'views/settings/components/settings-heading';
 import { FilterActionRow } from 'views/settings/filters/parts/filter-action-row';
 import { getActionTranslations } from 'views/settings/filters/parts/utils';

--- a/src/views/settings/filters/parts/filter-actions/action-move-to-folder-component.tsx
+++ b/src/views/settings/filters/parts/filter-actions/action-move-to-folder-component.tsx
@@ -6,12 +6,12 @@
 
 import React, { useCallback } from 'react';
 
+import { Folder } from '@zextras/carbonio-ui-commons';
 import { noop } from 'lodash';
 
+import { FilterFileInto } from 'types/filters';
 import { MovetoFolder } from 'views/settings/filters/parts/filter-actions/move-to-folder';
 import { ActionComponentProps } from 'views/settings/filters/types';
-import { FilterFileInto } from 'types/filters';
-import { Folder } from 'types';
 
 export const ActionMoveToFolderComponent = ({
 	value,

--- a/src/views/settings/filters/parts/filter-actions/mark-as-utils.ts
+++ b/src/views/settings/filters/parts/filter-actions/mark-as-utils.ts
@@ -6,7 +6,7 @@
 
 import { TFunction } from 'i18next';
 
-import { MarkAsOption } from 'types/index.d';
+import { MarkAsOption } from 'types/filters';
 
 export const getMarkAsOptions = (t: TFunction): Array<MarkAsOption> => [
 	{

--- a/src/views/settings/filters/parts/filter-actions/mark-as.tsx
+++ b/src/views/settings/filters/parts/filter-actions/mark-as.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { Row } from '@zextras/carbonio-design-system';
 
-import { MarkAsOption } from 'types/index.d';
+import { MarkAsOption } from 'types/filters';
 import CustomSelect from 'views/settings/filters/parts/custom-select';
 
 type MarkAsProps = {

--- a/src/views/settings/filters/parts/filter-actions/show-tag.tsx
+++ b/src/views/settings/filters/parts/filter-actions/show-tag.tsx
@@ -18,7 +18,7 @@ import { ZIMBRA_STANDARD_COLORS } from '@zextras/carbonio-ui-commons';
 import { find } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { MailFilterTag } from 'types/index.d';
+import { MailFilterTag } from 'types/filters';
 
 type ShowTagProps = {
 	value: MailFilterTag[];

--- a/src/views/settings/filters/parts/filter-item.tsx
+++ b/src/views/settings/filters/parts/filter-item.tsx
@@ -8,7 +8,7 @@ import React, { FC, ReactElement, useCallback, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import { Container, Text, Row, Icon, Padding } from '@zextras/carbonio-design-system';
 
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 
 const StyledFilterRow = styled(Row)`
 	border-bottom: 0.0625rem solid ${({ theme }): string => theme.palette.gray2.regular};

--- a/src/views/settings/filters/parts/filter-list.tsx
+++ b/src/views/settings/filters/parts/filter-list.tsx
@@ -9,7 +9,7 @@ import React, { useCallback } from 'react';
 import { List, ListItem } from '@zextras/carbonio-design-system';
 import { map } from 'lodash';
 
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 import { FilterItem } from 'views/settings/filters/parts/filter-item';
 
 type FilterListProps = {

--- a/src/views/settings/filters/parts/filter-manager.tsx
+++ b/src/views/settings/filters/parts/filter-manager.tsx
@@ -9,7 +9,7 @@ import { Button, Padding, useModal, useSnackbar } from '@zextras/carbonio-design
 import { find, findIndex } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 import {
 	ApplyFilterUIActionExecutionParams,
 	getApplyFilterUIAction

--- a/src/views/settings/filters/parts/message-filter-tab.tsx
+++ b/src/views/settings/filters/parts/message-filter-tab.tsx
@@ -10,7 +10,7 @@ import { filter, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { FilterRulesAPIResponse } from 'api/get-filters';
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 import Heading from 'views/settings/components/settings-heading';
 import { FilterList } from 'views/settings/filters/parts/filter-list';
 import { FilterManagerProps } from 'views/settings/filters/parts/filter-manager';

--- a/src/views/settings/filters/parts/tests/filter-action-row.test.tsx
+++ b/src/views/settings/filters/parts/tests/filter-action-row.test.tsx
@@ -12,7 +12,7 @@ import { FOLDER_VIEW, FOLDERS, useTagStore } from '@zextras/carbonio-ui-commons'
 import { makeListItemsVisible, setupTest } from '@test-setup';
 import { generateFolder } from '@test-utils/folders/folders-generator';
 import { populateFoldersStore } from '@test-utils/store/folders';
-import { FilterAction } from 'types/index.d';
+import { FilterAction } from 'types/filters';
 import {
 	FilterActionRow,
 	FilterActionRowProps

--- a/src/views/settings/filters/parts/tests/filter-actions-panel.test.tsx
+++ b/src/views/settings/filters/parts/tests/filter-actions-panel.test.tsx
@@ -9,8 +9,10 @@ import React from 'react';
 import { screen, within } from '@testing-library/react';
 
 import { setupTest } from '@test-setup';
-import { FilterActionsProps } from 'types/index.d';
-import { FilterActionsPanel } from 'views/settings/filters/parts/filter-actions-panel';
+import {
+	FilterActionsPanel,
+	FilterActionsProps
+} from 'views/settings/filters/parts/filter-actions-panel';
 
 describe('FilterActionsPanel', () => {
 	it('should update actions when switching an existing action for another one', async () => {

--- a/src/views/settings/filters/parts/tests/filter-actions/mark-as.test.tsx
+++ b/src/views/settings/filters/parts/tests/filter-actions/mark-as.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { setupTest } from '@test-setup';
-import { MarkAsOption } from 'types/index.d';
+import { MarkAsOption } from 'types/filters';
 import { MarkAs } from 'views/settings/filters/parts/filter-actions/mark-as';
 
 describe('Mark As', () => {

--- a/src/views/settings/filters/parts/tests/filter-manager.test.tsx
+++ b/src/views/settings/filters/parts/tests/filter-manager.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { act, screen, within } from '@testing-library/react';
 
 import { makeListItemsVisible, setupTest } from '@test-setup';
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 import { ListType } from 'views/settings/filters/parts/actions';
 import { getFiltermanager } from 'views/settings/filters/parts/filter-manager';
 

--- a/src/views/settings/filters/parts/tests/message-filter-tab.test.tsx
+++ b/src/views/settings/filters/parts/tests/message-filter-tab.test.tsx
@@ -11,7 +11,7 @@ import userEvent, { UserEvent } from '@testing-library/user-event';
 
 import { setupTest } from '@test-setup';
 import { FilterRulesAPIResponse } from 'api/get-filters';
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 import { getFiltermanager } from 'views/settings/filters/parts/filter-manager';
 import { MessageFilterTab } from 'views/settings/filters/parts/message-filter-tab';
 import { makeAllItemsVisible, mockFilter } from 'views/settings/filters/tests/test-utils';

--- a/src/views/settings/filters/parts/tests/modify-filter-modal.test.tsx
+++ b/src/views/settings/filters/parts/tests/modify-filter-modal.test.tsx
@@ -10,7 +10,7 @@ import React, { act } from 'react';
 import { screen } from '@testing-library/react';
 
 import { setupTest } from '@test-setup';
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 import { ModifyFilterModal } from 'views/settings/filters/parts/modify-filter/modify-filter-modal';
 
 describe('modify filter modal', () => {

--- a/src/views/settings/filters/parts/use-filter-selection.tsx
+++ b/src/views/settings/filters/parts/use-filter-selection.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { cloneDeep, concat, isEmpty, map, omit } from 'lodash';
 
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 import { FiltersListType } from 'views/settings/filters/types';
 
 export const useFilterSelection = (
@@ -49,7 +49,7 @@ export const useFilterSelection = (
 				map(tmp, (t) => omit(t, 'id')),
 				secondList
 			);
-			modifyFunc(toSend).then(() => {});
+			modifyFunc(toSend);
 		},
 		[list, secondList, modifyFunc]
 	);
@@ -68,7 +68,7 @@ export const useFilterSelection = (
 				secondList
 			);
 
-			modifyFunc(toSend).then(() => {});
+			modifyFunc(toSend);
 		},
 		[list, secondList, modifyFunc]
 	);

--- a/src/views/settings/filters/tests/incoming-filters-tab.test.tsx
+++ b/src/views/settings/filters/tests/incoming-filters-tab.test.tsx
@@ -7,13 +7,13 @@
 import React from 'react';
 
 import { act, screen, waitFor, within } from '@testing-library/react';
-import { useRootsArray } from '@zextras/carbonio-ui-commons';
+import { Folder, useRootsArray } from '@zextras/carbonio-ui-commons';
 import type { Mock } from 'vitest';
 
 import { setupTest } from '@test-setup';
 import { generateFolder } from '@test-utils/folders/folders-generator';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
-import { Filter, type Folder } from 'types/index.d';
+import { Filter } from 'types/filters';
 import { IncomingFiltersTab } from 'views/settings/filters/incoming-filters-tab';
 import { makeAllItemsVisible, mockFilter } from 'views/settings/filters/tests/test-utils';
 

--- a/src/views/settings/filters/tests/test-utils.tsx
+++ b/src/views/settings/filters/tests/test-utils.tsx
@@ -7,7 +7,7 @@
 import { act } from '@testing-library/react';
 
 import { makeListItemsVisible } from '@test-setup';
-import { Filter } from 'types/index.d';
+import { Filter } from 'types/filters';
 
 export function mockFilter({
 	name,

--- a/src/views/settings/filters/types.ts
+++ b/src/views/settings/filters/types.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Filter, FilterAction } from 'types/index.d';
+import { Filter, FilterAction } from 'types/filters';
 
 export type OnFilterActionChange = (filterActionValue: FilterAction) => void;
 

--- a/src/views/sidebar/commons/flatten-folders/tests/utils.test.ts
+++ b/src/views/sidebar/commons/flatten-folders/tests/utils.test.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { Folder } from '@zextras/carbonio-ui-commons';
+
 import { generateFolder } from '@test-utils/folders/folders-generator';
-import { Folder } from 'types/index.d';
 import { flattenAndFilterFoldersWithCap } from 'views/sidebar/commons/flatten-folders/utils';
 
 function generateFolderFunction(name: string, n: number, depth: number): Folder {

--- a/src/views/sidebar/commons/tests/use-sync-data-handler.test.tsx
+++ b/src/views/sidebar/commons/tests/use-sync-data-handler.test.tsx
@@ -51,7 +51,8 @@ import {
 	useMessageById
 } from 'store/emails/store';
 import * as triggerNotification from 'store/emails/sync-data-handler/trigger-notification';
-import { SoapConversation, SoapIncompleteMessage, SoapMailMessage } from 'types/index.d';
+import { SoapConversation } from 'types/soap/soap-conversation';
+import { SoapIncompleteMessage, SoapMailMessage } from 'types/soap/soap-mail-message';
 import { useSyncDataHandler } from 'views/sidebar/commons/use-sync-data-handler';
 
 const UNREAD = 'u';

--- a/src/views/sidebar/commons/types.ts
+++ b/src/views/sidebar/commons/types.ts
@@ -5,15 +5,12 @@
  */
 
 import { SoapNotify } from '@zextras/carbonio-shell-ui';
-import { TagState } from '@zextras/carbonio-ui-commons';
+import { FolderState, TagState } from '@zextras/carbonio-ui-commons';
 import { StoreApi, UseBoundStore } from 'zustand';
 
-import {
-	FolderState,
-	IncompleteMessage,
-	SoapConversation,
-	SoapIncompleteMessage
-} from 'types/index.d';
+import { IncompleteMessage } from 'types/messages';
+import { SoapConversation } from 'types/soap/soap-conversation';
+import { SoapIncompleteMessage } from 'types/soap/soap-mail-message';
 
 export type OptionalExcept<T, K extends keyof T> = {
 	[P in keyof T as P extends K ? P : never]: T[P];

--- a/src/views/sidebar/commons/use-sync-data-handler.ts
+++ b/src/views/sidebar/commons/use-sync-data-handler.ts
@@ -35,7 +35,9 @@ import {
 	updateMessages
 } from 'store/emails/store';
 import { triggerNotification } from 'store/emails/sync-data-handler/trigger-notification';
-import { IncompleteMessage, SoapConversation, SoapIncompleteMessage } from 'types/index.d';
+import { IncompleteMessage } from 'types/messages';
+import { SoapConversation } from 'types/soap/soap-conversation';
+import { SoapIncompleteMessage } from 'types/soap/soap-mail-message';
 import {
 	HandleFoldersNotifyProps,
 	HandleTagsNotifyProps,

--- a/src/views/sidebar/tests/delete-modal.test.tsx
+++ b/src/views/sidebar/tests/delete-modal.test.tsx
@@ -8,14 +8,19 @@ import React from 'react';
 
 import { faker } from '@faker-js/faker';
 import { act, screen } from '@testing-library/react';
-import { Folder, FOLDERS, FolderView, getFolder } from '@zextras/carbonio-ui-commons';
+import {
+	Folder,
+	FOLDERS,
+	FolderView,
+	getFolder,
+	SoapFolderAction
+} from '@zextras/carbonio-ui-commons';
 
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { FOLDER_ACTIONS } from 'commons/utilities';
 import { getFolders } from 'hooks/use-folders';
-import { SoapFolderAction } from 'types/index.d';
 import { DeleteModal } from 'views/sidebar/delete-modal';
 
 describe('delete-modal', () => {

--- a/src/views/sidebar/tests/edit-modal.test.tsx
+++ b/src/views/sidebar/tests/edit-modal.test.tsx
@@ -13,6 +13,7 @@ import {
 	FOLDERS,
 	FolderView,
 	getFolder,
+	SoapFolderAction,
 	ZIMBRA_STANDARD_COLORS
 } from '@zextras/carbonio-ui-commons';
 import { http } from 'msw';
@@ -24,7 +25,7 @@ import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-int
 import { handleGetFolderRequest } from '@test-utils/network/msw/handle-get-folder';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
-import { BatchRequest, SoapFolderAction } from 'types/index.d';
+import { BatchRequest } from 'types/soap/soap';
 import { makeAllItemsVisible } from 'views/settings/filters/tests/test-utils';
 import { EditModal } from 'views/sidebar/edit-modal';
 

--- a/src/views/sidebar/tests/empty-modal.test.tsx
+++ b/src/views/sidebar/tests/empty-modal.test.tsx
@@ -9,13 +9,12 @@ import React from 'react';
 import { faker } from '@faker-js/faker';
 import { act, screen } from '@testing-library/react';
 import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
-import { Folder, FOLDERS, getFolder } from '@zextras/carbonio-ui-commons';
+import { Folder, FOLDERS, getFolder, SoapFolderAction } from '@zextras/carbonio-ui-commons';
 
 import { setupTest } from '@test-setup';
 import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { populateFoldersStore } from '@test-utils/store/folders';
 import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
-import { SoapFolderAction } from 'types/index.d';
 import { EmptyModal } from 'views/sidebar/empty-modal';
 
 describe('empty-modal', () => {

--- a/src/views/sidebar/tests/sidebar.test.tsx
+++ b/src/views/sidebar/tests/sidebar.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
 import * as hooks from '@zextras/carbonio-shell-ui';
-import { FolderActionsType, FOLDERS } from '@zextras/carbonio-ui-commons';
+import { FolderActionsType, FOLDERS, SoapFolderAction } from '@zextras/carbonio-ui-commons';
 
 import { makeListItemsVisible, setupTest } from '@test-setup';
 import { getCurrentRoute, useLocalStorage } from '@test-utils/carbonio-shell-ui/carbonio-shell-ui';
@@ -18,7 +18,7 @@ import { populateFoldersStore } from '@test-utils/store/folders';
 import { generateMessage } from '__test__/generators/generateMessage';
 import { MAIL_APP_ID, MAILS_ROUTE } from 'constants/index';
 import { setMessagesInEmailStore } from 'store/emails/store';
-import { MsgActionRequest, SoapFolderAction } from 'types/index.d';
+import { MsgActionRequest } from 'types/soap/msg-action';
 import Sidebar from 'views/sidebar/sidebar';
 
 function fakeCounter(): { count: number; setCount: (value: number) => void } {

--- a/src/views/sidebar/tests/test-helpers.ts
+++ b/src/views/sidebar/tests/test-helpers.ts
@@ -7,7 +7,8 @@
 import { SoapNotify } from '@zextras/carbonio-shell-ui';
 import { useInfoRefresh, useSync } from '@zextras/carbonio-ui-soap-lib';
 
-import { SoapIncompleteMessage, SoapConversation } from 'types/index.d';
+import { SoapConversation } from 'types/soap/soap-conversation';
+import { SoapIncompleteMessage } from 'types/soap/soap-mail-message';
 
 export function mockSoapRefresh(mailbox: number): void {
 	const result = {


### PR DESCRIPTION
This pull request refactors type imports throughout the codebase to improve modularity and clarity. Types that were previously imported from broad modules like `types` or `types/index.d` are now imported from more specific submodules, such as `types/soap`, `types/messages`, `types/conversations`, and others. This change helps ensure that each file only imports the types it actually needs, from their most relevant location, making the code easier to maintain and understand.

**Type import refactoring:**

* Test files now import types from specific submodules instead of the generic `types` module, improving clarity and modularity. [[1]](diffhunk://#diff-87df04acf65869867ea93fc0a05ca833c7f68dcfb368aefaaab737b148a6c10eL6-R11) [[2]](diffhunk://#diff-8a4072e1a1baa23929ca15f0207027b67ff03cae4289edd43631702fc298efadR10-R16) [[3]](diffhunk://#diff-f9b9e3047219237762ed401f157a31a51d4dc333b6bc8467ca9b30a7f8ef9968L12-R12) [[4]](diffhunk://#diff-2fdbf366d877d0c24bf5b18e6050743f9e2ff5116426ce2d09b8d19fc0fd6e95L13-R15) [[5]](diffhunk://#diff-c6fb38829c8b21617a66679f4cc8001bfe79fe3c5e5d6afffb8a13181c7d27c8L12-R13) [[6]](diffhunk://#diff-b416853710f0e6ff6e586cf98fcb1b70254ee4ad6ac5fccc89ae4a55f30a2c71L11-R13) [[7]](diffhunk://#diff-b0ec1779fe3f98ad16b626bd589be64cd4be97f97972e6ccc9b3bbfa3df5d437L6-R8)
* API files have updated type imports to use specific submodules such as `types/soap`, `types/messages`, `types/conversations`, and `types/filters`. This reduces reliance on the catch-all `types/index.d` and makes the codebase more modular. [[1]](diffhunk://#diff-31f3963b9bbaf3caa0cfd305891892cc6aea20db8d9d6293894d11213efcf791L11-R11) [[2]](diffhunk://#diff-baaac72e465a607208d70474baf2faee7790dabc8883d221c7b6dedb447f8ca8L10-R11) [[3]](diffhunk://#diff-42d45c10f0ee78b1be950a97729380d9f956ba2d48d1fb87f372f92f9785cc11L9-R9) [[4]](diffhunk://#diff-8b4026639a5aef0f8619b25a0ba2fda704f48f4c52232ee90d345c032d22d749L9-R9) [[5]](diffhunk://#diff-e78f3e12fdc3ee885d2bd3c459d462a90aef65fcbe0a09f2d98c5b8e5be8b9d1L11-R11) [[6]](diffhunk://#diff-79b97d444e8525150b348d17ff62938199214c02a242544dd43d59ad110441b3L12-R15) [[7]](diffhunk://#diff-ed117fe7a61f36a3e7018ad19849295f637c6e6df0139ea0ac9bf1922e35db72L10-R10) [[8]](diffhunk://#diff-053528c2b2b9468670964ac14183eaec9b90b3071d94b6b1f2a45c2d3a3e3ba9L10-R10) [[9]](diffhunk://#diff-41cee5358d513ab00bd9a7807353806627fefeca38547842ed6216f4e31f7bf2L11-R12) [[10]](diffhunk://#diff-560862033f6e1d44a120383fd8e0737323e93c46a46ffbed9bf17c715e265109L10-R10) [[11]](diffhunk://#diff-1c5736de800007845a2f16b2fa17e8433a2dcba2f336e755639577283a0a04fcL11-R11) [[12]](diffhunk://#diff-1c743c7fe56cfcb8c1a322ae3e4b8e8421895d3377fe85cd2c37a91dd9b62a19L9-R9) [[13]](diffhunk://#diff-cfa9a6072280231d84843c76b42245860168abe708a42f7977861ce999f9890cL11-R11)

**Code cleanup and organization:**

* Functions and constants in `src/__test__/generators/api.ts` have been reorganized for improved readability, including moving the definition of `generateCompleteMessageFromAPI` and its alias. [[1]](diffhunk://#diff-8a4072e1a1baa23929ca15f0207027b67ff03cae4289edd43631702fc298efadL28-L44) [[2]](diffhunk://#diff-8a4072e1a1baa23929ca15f0207027b67ff03cae4289edd43631702fc298efadR63-R80)
* Minor cleanup such as removing unnecessary ESLint comments.

**Type safety improvements:**

* Some API functions now include TODOs or cast responses to `any` where type definitions need to be fixed, highlighting areas for future improvement in type safety.

These changes collectively make the codebase more maintainable, modular, and easier to navigate.