### PR TITLE
fix: composer keeps plain text format in rich text editor

### DIFF
--- a/src/store/editor-slice-utils.ts
+++ b/src/store/editor-slice-utils.ts
@@ -210,6 +210,7 @@ export const extractBody = (msg: MailMessage): ExtractedBody => {
 	const textArr = findBodyPart(msg.parts, 'text/plain');
 	const htmlArr = findBodyPart(msg.parts, 'text/html');
 	const text = textArr?.[0]?.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+	const textAsHtml = text?.replaceAll('\n', '<br/>');
 	let html = htmlArr.length ? htmlArr[0].replaceAll('dfsrc', 'src') : undefined;
 
 	// Inline CSS styles from <head> <style> tags to preserve formatting
@@ -222,7 +223,7 @@ export const extractBody = (msg: MailMessage): ExtractedBody => {
 		}
 	}
 
-	return { richText: html ?? text ?? '', plainText: text ?? html ?? '' };
+	return { richText: html ?? textAsHtml ?? '', plainText: text ?? html ?? '' };
 };
 
 type Labels = {


### PR DESCRIPTION
refs: CO-3293