### PR TITLE
fix: correct casing for GetMsgResponse in API and tests

### DIFF
--- a/src/api/get-msg-for-print-soap-api.ts
+++ b/src/api/get-msg-for-print-soap-api.ts
@@ -15,7 +15,7 @@ export const getMsgsForPrintSoapApi = async ({
 	ids,
 	part
 }: GetMsgForPrintParameter): Promise<Array<MailMessage>> => {
-	const { getMsgResponse } = await legacySoapFetch<unknown, GetMsgForPrintResponse>('Batch', {
+	const { GetMsgResponse } = await legacySoapFetch<unknown, GetMsgForPrintResponse>('Batch', {
 		GetMsgRequest: map(ids, (id) => ({
 			m: omitBy(
 				{
@@ -31,7 +31,7 @@ export const getMsgsForPrintSoapApi = async ({
 		})),
 		_jsns: 'urn:zimbra'
 	});
-	return map(getMsgResponse, (re) => {
+	return map(GetMsgResponse, (re) => {
 		const msg = re.m[0];
 		return normalizeMailMessageFromSoap({ m: msg, isComplete: true });
 	});

--- a/src/api/tests/get-msg-for-print-soap-api.test.ts
+++ b/src/api/tests/get-msg-for-print-soap-api.test.ts
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { generateCompleteMessageFromAPI } from '__test__/generators/api';
+import { getMsgsForPrintSoapApi } from 'api/get-msg-for-print-soap-api';
+import { SoapMailMessage } from 'types/soap';
+import { GetMsgForPrintResponse } from 'types/soap/get-msg';
+
+describe('getMsgsForPrintSoapApi', () => {
+	it('should send a BatchRequest with one GetMsgRequest per id', async () => {
+		const interceptor = createSoapAPIInterceptor('Batch');
+		getMsgsForPrintSoapApi({ ids: ['1', '2'] });
+		const request = await interceptor;
+
+		expect((request as { GetMsgRequest: [] }).GetMsgRequest).toHaveLength(2);
+	});
+
+	it('should include html, needExp and read fields in each GetMsgRequest entry', async () => {
+		const interceptor = createSoapAPIInterceptor('Batch');
+		getMsgsForPrintSoapApi({ ids: ['42'] });
+		const request = await interceptor;
+
+		expect(
+			(request as { GetMsgRequest: Array<{ m: Array<SoapMailMessage>; _jsns: string }> })
+				.GetMsgRequest[0]
+		).toMatchObject({
+			_jsns: 'urn:zimbraMail',
+			m: { id: '42', html: 1, needExp: 1, read: 1 }
+		});
+	});
+
+	it('should return a normalized message for each id', async () => {
+		const soapMessage = generateCompleteMessageFromAPI({ id: '7', cid: '7', l: '2' });
+		const response: GetMsgForPrintResponse = {
+			GetMsgResponse: [{ m: [soapMessage] }]
+		};
+		createSoapAPIInterceptor('Batch', response);
+
+		const result = await getMsgsForPrintSoapApi({ ids: ['7'] });
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ id: '7' });
+	});
+
+	it('should return messages with a visible body when html content is present', async () => {
+		const htmlContent = '<p>Hello, print world!</p>';
+		const soapMessage = generateCompleteMessageFromAPI({
+			id: '10',
+			mp: [{ part: '1', ct: 'text/html', s: htmlContent.length, body: true, content: htmlContent }]
+		});
+		const response: GetMsgForPrintResponse = {
+			GetMsgResponse: [{ m: [soapMessage] }]
+		};
+		createSoapAPIInterceptor('Batch', response);
+
+		const result = await getMsgsForPrintSoapApi({ ids: ['10'] });
+
+		expect(result[0].body.content).toBe(htmlContent);
+	});
+
+	it('should return all messages when multiple ids are requested', async () => {
+		const msg1 = generateCompleteMessageFromAPI({ id: '1' });
+		const msg2 = generateCompleteMessageFromAPI({ id: '2' });
+		const response: GetMsgForPrintResponse = {
+			GetMsgResponse: [{ m: [msg1] }, { m: [msg2] }]
+		};
+		createSoapAPIInterceptor('Batch', response);
+
+		const result = await getMsgsForPrintSoapApi({ ids: ['1', '2'] });
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toMatchObject({ id: '1' });
+		expect(result[1]).toMatchObject({ id: '2' });
+	});
+});

--- a/src/types/soap/get-msg.ts
+++ b/src/types/soap/get-msg.ts
@@ -40,5 +40,5 @@ export type GetMsgForPrintParameter = {
 };
 
 export type GetMsgForPrintResponse = {
-	getMsgResponse: Array<GetMsgResponse>;
+	GetMsgResponse: Array<GetMsgResponse>;
 };


### PR DESCRIPTION
This pull request updates the `getMsgsForPrintSoapApi` function to align with the correct SOAP response casing and adds comprehensive tests to ensure its correctness. The most significant changes are the renaming of the response property for consistency and the addition of a new test suite.

**API Response Consistency:**

* Changed the property name in `GetMsgForPrintResponse` from `getMsgResponse` to `GetMsgResponse` in both the type definition and function implementation to match the actual SOAP API response casing. [[1]](diffhunk://#diff-ce43e9f6fe1ea7a7bfa994133bd7fd8068527bb99ea82f9dd949702608659fe1L43-R43) [[2]](diffhunk://#diff-41cee5358d513ab00bd9a7807353806627fefeca38547842ed6216f4e31f7bf2L18-R18) [[3]](diffhunk://#diff-41cee5358d513ab00bd9a7807353806627fefeca38547842ed6216f4e31f7bf2L34-R34)

**Testing Improvements:**

* Added a new test file `get-msg-for-print-soap-api.test.ts` that thoroughly tests the `getMsgsForPrintSoapApi` function, covering request structure, field inclusion, normalization, HTML content handling, and multi-message scenarios.