### PR TITLE
fix(ci): migrate Jenkinsfile to jenkins-lib-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 
 # SPDX-License-Identifier: CC0-1.0
 
+# Git worktrees
+/.worktrees/
+
 # Node modules
 /node_modules/
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-ui@1.0.13',
+    identifier: 'jenkins-lib-common@v2.4.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        credentialsId: 'jenkins-integration-with-github-account',
-        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+        credentialsId: 'jenkins-integration-with-github-account'
     ])
 )
 
-zappPipeline()
+uiPipeline()


### PR DESCRIPTION
## Summary

`jenkins-lib-ui` has been consolidated into `jenkins-lib-common`. The `uiPipeline()` function is now available directly from `jenkins-lib-common` starting at version `v2.4.3`.

## Changes

- Replaced the `jenkins-lib-ui@1.0.13` library block with `jenkins-lib-common@v2.4.3`
- Renamed the `zappPipeline()` call to `uiPipeline()` (parameters are identical)

No other changes were made to the repository.