### PR TITLE
fix: update Content Security Policy to allow external images in print…

### DIFF
--- a/src/commons/print-conversation/get-complete-html.ts
+++ b/src/commons/print-conversation/get-complete-html.ts
@@ -14,7 +14,7 @@ export function getCompleteHTML({ content }: { content: string }): string {
 	return `	<html>
 		<head>
 			<title>Carbonio</title>
-			<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self' data: cid:; base-uri 'none'; form-action 'none';">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src https: data: cid:; base-uri 'none'; form-action 'none';">
                 <style>
                     body {
                         max-width: 100% !important;

--- a/src/commons/tests/print-conversation-xss.test.ts
+++ b/src/commons/tests/print-conversation-xss.test.ts
@@ -156,8 +156,8 @@ describe('XSS prevention in print-conversation utilities', () => {
 		it('includes a Content-Security-Policy meta tag as defense-in-depth', () => {
 			const result = getCompleteHTML({ content: '' });
 			expect(result).toContain('http-equiv="Content-Security-Policy"');
-			expect(result).toContain("default-src 'none'");
-			expect(result).toContain("img-src 'self' data: cid:");
+			expect(result).toContain("default-src 'self'");
+			expect(result).toContain('img-src https: data: cid:');
 			expect(result).toContain("base-uri 'none'");
 			expect(result).toContain("form-action 'none'");
 		});


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in the HTML generated by the `getCompleteHTML` function. The change relaxes certain restrictions to allow external resources to be loaded more flexibly.

**Security policy update:**

* In `src/commons/print-conversation/get-complete-html.ts`, the CSP for the generated HTML was updated to allow resources from `'self'` by default, and to permit images from `https:` sources in addition to `data:` and `cid:`. This makes the HTML output more compatible with externally hosted images and resources.… conversation