### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM backplane/jq:latest AS builder
+FROM --platform=$BUILDPLATFORM docker.io/backplane/jq:latest AS builder
 
 # Define path variables
 ENV IRIS_BASE_PATH="/opt/zextras/web/iris" \
@@ -13,7 +13,7 @@ RUN COMMIT_ID=$(jq -r .commit /tmp/dist/component.json) \
     && mv /tmp/dist/* "${WEB_PATH}/${COMMIT_ID}/"
 
 # Final stage - built for all target platforms
-FROM backplane/jq:latest
+FROM docker.io/backplane/jq:latest
 
 # Re-define path variable for final stage
 ENV IRIS_BASE_PATH="/opt/zextras/web/iris"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-common@v2.8.6',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.