### PR TITLE
fix(CO-3796): prevent duplication of missing tags in tag list

### DIFF
--- a/src/ui-actions/tag-actions.tsx
+++ b/src/ui-actions/tag-actions.tsx
@@ -22,7 +22,7 @@ import {
 	ZIMBRA_STANDARD_COLORS,
 	DeleteTagModal
 } from '@zextras/carbonio-ui-commons';
-import { filter, find, forEach, reduce, some } from 'lodash';
+import { filter, find, map, reduce, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { UIActionDescriptor } from 'types/actions';
@@ -194,7 +194,7 @@ export const useGetTagsList = (msgTags?: string[]): Tag[] => {
 	const [t] = useTranslation();
 	const tagsFromStore = useTagsArrayFromStore();
 
-	return reduce(
+	const tagsInList = reduce(
 		tagsFromStore,
 		(acc: Tag[], tag) => {
 			if (msgTags?.includes(tag.id)) {
@@ -206,26 +206,26 @@ export const useGetTagsList = (msgTags?: string[]): Tag[] => {
 					color: ZIMBRA_STANDARD_COLORS[tag.color ?? 0].hex,
 					label: tag.name
 				});
-			} else {
-				forEach(
-					filter(msgTags, (tagName) => tagName?.includes('nil:')),
-					(tagNotInList: string) => {
-						acc.push({
-							id: tagNotInList,
-							name: t('label.not_in_list', {
-								name: tagNotInList.split(':')[1],
-								defaultValue: '{{name}} - Not in your tag list'
-							}),
-							// TODO: align the use of the property with the type exposed by the shell
-							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-							// @ts-ignore
-							color: ZIMBRA_STANDARD_COLORS[0].hex
-						});
-					}
-				);
 			}
 			return acc;
 		},
 		[]
 	);
+
+	const tagsNotInList = map(
+		filter(msgTags, (tagName) => tagName?.includes('nil:')),
+		(tagNotInList: string): Tag => ({
+			id: tagNotInList,
+			name: t('label.not_in_list', {
+				name: tagNotInList.split(':')[1],
+				defaultValue: '{{name}} - Not in your tag list'
+			}),
+			// TODO: align the use of the property with the type exposed by the shell
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			color: ZIMBRA_STANDARD_COLORS[0].hex
+		})
+	);
+
+	return [...tagsInList, ...tagsNotInList];
 };

--- a/src/ui-actions/tests/tag-actions.test.tsx
+++ b/src/ui-actions/tests/tag-actions.test.tsx
@@ -456,5 +456,23 @@ describe('Tag Actions', () => {
 			const nilTags = result.current.filter((t) => t.id.startsWith('nil:'));
 			expect(nilTags.length).toBeGreaterThanOrEqual(3);
 		});
+
+		it('should not duplicate a not-in-list tag for each tag in the store', () => {
+			const mockTags: Record<string, Tag> = {
+				'tag-1': { id: 'tag-1', name: 'Important', color: 1 },
+				'tag-2': { id: 'tag-2', name: 'Work', color: 2 },
+				'tag-3': { id: 'tag-3', name: 'Personal', color: 3 }
+			};
+
+			populateTagsStore(mockTags);
+			const msgTags = ['nil:missing-tag'];
+
+			const { result } = renderHook(() => useGetTagsList(msgTags), {
+				wrapper: ProvidersWrapper
+			});
+
+			const nilTags = result.current.filter((tag) => tag.id === 'nil:missing-tag');
+			expect(nilTags).toHaveLength(1);
+		});
 	});
 });


### PR DESCRIPTION
In the message preview header, a tag that is missing from the user's tag list (a `nil:` tag) was rendered multiple times — once for every unrelated tag in the user's tag store —
  instead of just once.

  The cause was in `useGetTagsList` (`src/ui-actions/tag-actions.tsx`): the logic that builds the "Not in your tag list" chips lived in the `else` branch of the `reduce` over the
  user's store tags, so it re-emitted all missing tags for each non-matching store tag.

   **Fix**

  Split the two concerns: `reduce` over store tags now only collects matching tags, and the missing (`nil:`) tags are mapped **once**, outside the loop. Each missing tag now appears
  exactly once.
