### PR TITLE
fix: update participant header formatting and add tests for getPartic…

### DIFF
--- a/src/commons/print-conversation/get-participant-header.ts
+++ b/src/commons/print-conversation/get-participant-header.ts
@@ -10,7 +10,8 @@ import { Participant } from 'types/participant';
 export const getParticipantHeader = (participants: Participant[], type: string): string => {
 	const participantsList = map(
 		participants,
-		(f) => `${escape(f.fullName || f.name || f.address)} <${escape(f.address)}> `
+		(f) =>
+			`${escape(f.fullName || f.name || f.address)} ${f.address ? escape(`<${f.address}>`) : ''} `
 	).join(', ');
 
 	if (participants.length === 0) return '';

--- a/src/commons/print-conversation/tests/get-participant-header.test.ts
+++ b/src/commons/print-conversation/tests/get-participant-header.test.ts
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { getParticipantHeader } from 'commons/print-conversation/get-participant-header';
+import { Participant } from 'types/participant';
+
+describe('getParticipantHeader', () => {
+	it('returns an empty string when there are no participants', () => {
+		expect(getParticipantHeader([], 'From')).toBe('');
+	});
+
+	it('renders the provided type label', () => {
+		const participants: Participant[] = [
+			{ type: 'f', address: 'john@example.com', fullName: 'John Doe' }
+		];
+		const result = getParticipantHeader(participants, 'From');
+		expect(result).toContain('From:');
+	});
+
+	it('renders the participant fullName followed by the address in angle brackets', () => {
+		const participants: Participant[] = [
+			{ type: 'f', address: 'john@example.com', fullName: 'John Doe' }
+		];
+		const result = getParticipantHeader(participants, 'From');
+		expect(result).toContain('John Doe');
+		expect(result).toContain('&lt;john@example.com&gt;');
+	});
+
+	it('falls back to name when fullName is missing', () => {
+		const participants: Participant[] = [
+			{ type: 'f', address: 'john@example.com', name: 'Johnny' }
+		];
+		const result = getParticipantHeader(participants, 'To');
+		expect(result).toContain('Johnny');
+		expect(result).toContain('&lt;john@example.com&gt;');
+	});
+
+	it('falls back to the address as display name when fullName and name are missing', () => {
+		const participants: Participant[] = [{ type: 'f', address: 'john@example.com' }];
+		const result = getParticipantHeader(participants, 'To');
+		// display name and the angle-bracketed address are both the address
+		expect(result).toContain('john@example.com');
+		expect(result).toContain('&lt;john@example.com&gt;');
+	});
+
+	it('joins multiple participants with a comma separator', () => {
+		const participants: Participant[] = [
+			{ type: 't', address: 'jane@example.com', fullName: 'Jane Roe' },
+			{ type: 't', address: 'bob@example.com', fullName: 'Bob Smith' }
+		];
+		const result = getParticipantHeader(participants, 'To');
+		expect(result).toContain('Jane Roe');
+		expect(result).toContain('&lt;jane@example.com&gt;');
+		expect(result).toContain('Bob Smith');
+		expect(result).toContain('&lt;bob@example.com&gt;');
+		expect(result).toContain(', ');
+	});
+
+	it('produces a single table row wrapping the participants list', () => {
+		const participants: Participant[] = [
+			{ type: 'c', address: 'cc@example.com', fullName: 'Carbon Copy' }
+		];
+		const result = getParticipantHeader(participants, 'Cc');
+		expect(result).toContain('<tr>');
+		expect(result).toContain('</tr>');
+		expect(result).toContain('<td');
+		expect(result).toContain('<span');
+		// only one row is rendered
+		expect(result.match(/<tr>/g)).toHaveLength(1);
+	});
+
+	it('renders correctly for the typical From / To / Cc usage', () => {
+		const from: Participant[] = [{ type: 'f', address: 'sender@example.com', fullName: 'Sender' }];
+		const to: Participant[] = [
+			{ type: 't', address: 'recipient@example.com', fullName: 'Recipient' }
+		];
+
+		expect(getParticipantHeader(from, 'From')).toContain('From: ');
+		expect(getParticipantHeader(to, 'To')).toContain('To: ');
+	});
+});


### PR DESCRIPTION
This pull request improves the `getParticipantHeader` utility by refining how participant addresses are escaped and adds comprehensive unit tests to ensure correct rendering of participant headers in various scenarios.

**Functionality improvements:**

* Refined the participant address rendering in `getParticipantHeader` to ensure that the angle brackets around email addresses are properly escaped, and that addresses are only shown in angle brackets if present.

**Testing enhancements:**

* Added a new test suite in `get-participant-header.test.ts` to cover edge cases and typical usages, including scenarios with missing names, multiple participants, and correct HTML output structure.…ipantHeader function