### PR TITLE
fix(CO-3793): preserve author-defined styles in elements

### DIFF
--- a/src/constants/tinymce-content-styles.ts
+++ b/src/constants/tinymce-content-styles.ts
@@ -33,28 +33,34 @@ export const TINYMCE_BASE_CONTENT_STYLES = `
 	h5 { font-size: 14px; }
 	h6 { font-size: 12px; }
 	
-	/* Tables */
-	table {
+	/*
+	 * Tables - defaults only. Each rule is guarded so it applies only when the
+	 * author hasn't already set that property via an inline style or the matching
+	 * presentational attribute. No width is forced (CO-3793).
+	 */
+	table:not([cellspacing]):not([style*="border-spacing"]) {
 		border-collapse: collapse;
 		border-spacing: 0;
-		width: 100%;
-		max-width: 100%;
-		background-color: transparent;
 	}
-	table td,
-	table th {
+	table:not([cellpadding]) td:not([style*="padding"]),
+	table:not([cellpadding]) th:not([style*="padding"]) {
 		padding: 8px;
+	}
+	table td:not([valign]):not([style*="vertical-align"]),
+	table th:not([valign]):not([style*="vertical-align"]) {
 		vertical-align: top;
 	}
 	table td:not([style*="border"]),
 	table th:not([style*="border"]) {
 		border: 1px solid #cccccc;
 	}
-	table th {
+	table th:not([style*="font-weight"]) {
 		font-weight: bold;
+	}
+	table th:not([align]):not([style*="text-align"]) {
 		text-align: left;
 	}
-	table th:not([style*="background"]) {
+	table th:not([bgcolor]):not([style*="background"]) {
 		background-color: #f5f5f5;
 	}
 	table[border="1"] td:not([style*="border"]),
@@ -65,10 +71,12 @@ export const TINYMCE_BASE_CONTENT_STYLES = `
 	table[border="0"] th {
 		border: none;
 	}
-	
+
 	/* Table captions */
-	caption {
+	caption:not([style*="padding"]) {
 		padding: 8px;
+	}
+	caption {
 		caption-side: top;
 		margin-bottom: 8px;
 	}
@@ -100,20 +108,26 @@ export const TINYMCE_BASE_CONTENT_STYLES = `
 		color: #1e5092;
 	}
 	
-	/* Images */
-	img {
+	/* Images - "border: 0" must not override an author border attribute/style */
+	img:not([border]):not([style*="border"]) {
 		border: 0;
+	}
+	img {
 		outline: none;
 		text-decoration: none;
 		display: block;
 	}
-	
-	/* Horizontal rules */
-	hr {
+
+	/* Horizontal rules - respect author thickness via size/noshade attributes */
+	hr:not([size]):not([noshade]):not([style*="border"]) {
 		border: 0;
 		border-top: 1px solid #cccccc;
-		margin: 16px 0;
+	}
+	hr:not([size]):not([style*="height"]) {
 		height: 0;
+	}
+	hr {
+		margin: 16px 0;
 	}
 	
 	/* Code blocks */

--- a/src/helpers/tests/user-preference-styles.test.ts
+++ b/src/helpers/tests/user-preference-styles.test.ts
@@ -529,16 +529,16 @@ describe('user-preference-styles', () => {
 			expect(result).toMatch(/<p style="[^"]*color: #ff0000/);
 		});
 
-		it('should not shrink a heading when the author colors part of it', () => {
-			// TinyMCE wraps the coloured selection in a <span> inside the heading.
+		it('should not change size or font when the author colors part of a heading', () => {
+			// TinyMCE wraps the coloured selection in a <span> inside the heading;
+			// only the author's colour should change - size/font are inherited.
 			const content = `<h1>Title <span style="color: blue;">colored</span></h1>`;
 
 			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
 
-			// the heading keeps its size and the span must NOT be forced to the
-			// preference font-size (it inherits the heading size instead)
 			expect(result).toMatch(/<h1 style="[^"]*font-size: 24px/);
 			expect(result).not.toMatch(/<span[^>]*font-size: 14pt/);
+			expect(result).not.toMatch(/<span[^>]*font-family/);
 			expect(result).toContain('color: blue');
 		});
 
@@ -550,6 +550,24 @@ describe('user-preference-styles', () => {
 			// sub keeps its relative 75% size rather than the absolute preference size
 			expect(result).toMatch(/<sub[^>]*font-size: 75%/);
 			expect(result).not.toMatch(/<sub[^>]*font-size: 14pt/);
+		});
+
+		it('should not override the monospace font of code content', () => {
+			const content = `<pre><code>fn <span>x</span></code></pre>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			// the span inside code must not be re-fonted to the preference family
+			expect(result).not.toMatch(/<span[^>]*font-family: Arial/);
+		});
+
+		it('should still apply the preference to nested ordinary content via inheritance', () => {
+			const content = `<div><p>nested</p></div>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			// the top-level div carries the preference; the nested <p> inherits it
+			expect(result).toMatch(/<div style="[^"]*color: #ff0000[^"]*font-size: 14pt/);
 		});
 	});
 

--- a/src/helpers/tests/user-preference-styles.test.ts
+++ b/src/helpers/tests/user-preference-styles.test.ts
@@ -528,6 +528,29 @@ describe('user-preference-styles', () => {
 
 			expect(result).toMatch(/<p style="[^"]*color: #ff0000/);
 		});
+
+		it('should not shrink a heading when the author colors part of it', () => {
+			// TinyMCE wraps the coloured selection in a <span> inside the heading.
+			const content = `<h1>Title <span style="color: blue;">colored</span></h1>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			// the heading keeps its size and the span must NOT be forced to the
+			// preference font-size (it inherits the heading size instead)
+			expect(result).toMatch(/<h1 style="[^"]*font-size: 24px/);
+			expect(result).not.toMatch(/<span[^>]*font-size: 14pt/);
+			expect(result).toContain('color: blue');
+		});
+
+		it('should not force the preference size onto sub/sup', () => {
+			const content = `<p>x<sub>2</sub></p>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			// sub keeps its relative 75% size rather than the absolute preference size
+			expect(result).toMatch(/<sub[^>]*font-size: 75%/);
+			expect(result).not.toMatch(/<sub[^>]*font-size: 14pt/);
+		});
 	});
 
 	describe('edge cases', () => {

--- a/src/helpers/tests/user-preference-styles.test.ts
+++ b/src/helpers/tests/user-preference-styles.test.ts
@@ -6,6 +6,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { TINYMCE_BASE_CONTENT_STYLES } from '../../constants/tinymce-content-styles';
 import {
 	applyUserPreferenceStyles,
 	generateUserPreferenceStyles,
@@ -121,6 +122,19 @@ describe('user-preference-styles', () => {
 			const result = generateUserPreferenceStyles(style);
 
 			expect(result).toContain(':not(a[href])');
+		});
+
+		it('should exclude author color-bearing elements from selector', () => {
+			const style: UserPreferenceStyle = {
+				font: 'Arial',
+				fontSize: '12pt',
+				color: '#000000'
+			};
+
+			const result = generateUserPreferenceStyles(style);
+
+			expect(result).toContain(':not(font)');
+			expect(result).toContain(':not([color])');
 		});
 
 		it('should exclude special formatting elements from selector', () => {
@@ -405,6 +419,114 @@ describe('user-preference-styles', () => {
 			expect(result).toContain('Regular span');
 			expect(result).toContain('Code span');
 			expect(result).toContain('Quote');
+		});
+	});
+
+	// CO-3793: base styles are defaults and must never override what the author
+	// specified via inline style or a presentational attribute.
+	describe('table style preservation (CO-3793)', () => {
+		const style: UserPreferenceStyle = {
+			font: 'Arial, sans-serif',
+			fontSize: '14pt',
+			color: '#ff0000'
+		};
+
+		it('should not override table styling specified via presentational attributes', () => {
+			const content = `<table style="text-align: left; font-size: 8pt;" border="0" cellspacing="0" cellpadding="0">
+					<tbody>
+						<tr>
+							<td style="font-size: 10pt;">Logo</td>
+							<td>Paola Sora</td>
+						</tr>
+					</tbody>
+				</table>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			// cellpadding="0" is respected -> our 8px cell padding default is not applied
+			expect(result).not.toContain('padding: 8px');
+			// cellspacing="0" is respected -> border-collapse is not forced
+			expect(result).not.toContain('border-collapse');
+			// border="0" is respected -> cells keep no border
+			expect(result).toContain('border: none');
+			// the authored attributes survive untouched
+			expect(result).toMatch(/border="0"\s+cellspacing="0"\s+cellpadding="0"/);
+			// the authored inline styles survive untouched
+			expect(result).toContain('text-align: left');
+			expect(result).toContain('font-size: 8pt');
+		});
+
+		it('should not force a width on a table that did not specify one', () => {
+			const content = `<table style="text-align: left;" border="0" cellpadding="0"><tbody><tr><td>cell</td></tr></tbody></table>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).not.toMatch(/width:\s*100%/);
+			expect(result).not.toMatch(/<table[^>]*width="100%"/);
+		});
+
+		it('should still apply default cell padding to a composer table with no overrides', () => {
+			// A composer-created table (no attributes) keeps the defaults.
+			const content = `<table><tbody><tr><td>cell</td></tr></tbody></table>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toContain('padding: 8px');
+		});
+
+		it('should keep an author-specified cell padding instead of our default', () => {
+			const content = `<table cellpadding="4"><tbody><tr><td>cell</td></tr></tbody></table>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toContain('cellpadding="4"');
+			expect(result).not.toContain('padding: 8px');
+		});
+
+		it('should not override an image border specified via the border attribute', () => {
+			const content = `<p>Logo</p><img src="logo.png" border="2" alt="Logo">`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toContain('border="2"');
+			expect(result).not.toContain('border: 0');
+		});
+
+		it('should still apply the default image border when none is specified', () => {
+			const content = `<p>Logo</p><img src="logo.png" alt="Logo">`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toContain('border: 0');
+		});
+
+		it('should not override hr thickness specified via the size attribute', () => {
+			const content = `<hr size="5">`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toContain('size="5"');
+			expect(result).not.toContain('height: 0');
+		});
+
+		it('should not recolor text the author colored via a legacy <font> attribute', () => {
+			const content = `<p>Body</p><font color="green" size="5">Author colored</font>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toContain('color="green"');
+			expect(result).toContain('size="5"');
+			// the user's preference colour/size must not be inlined onto the <font>
+			expect(result).not.toMatch(/<font[^>]*style="[^"]*color: #ff0000/);
+			expect(result).not.toMatch(/<font[^>]*style="[^"]*font-size: 14pt/);
+		});
+
+		it('should still apply user preferences to ordinary body content', () => {
+			const content = `<p>Body</p>`;
+
+			const result = applyUserPreferenceStyles(content, style, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toMatch(/<p style="[^"]*color: #ff0000/);
 		});
 	});
 

--- a/src/helpers/tests/user-preference-styles.test.ts
+++ b/src/helpers/tests/user-preference-styles.test.ts
@@ -24,7 +24,11 @@ describe('user-preference-styles', () => {
 
 			const result = generateUserPreferenceStyles(style);
 
-			expect(result).toBe('p { margin: 0; }');
+			// a default font-family is always applied as a fallback
+			expect(result).toContain('p { margin: 0; }');
+			expect(result).toContain('font-family: arial, helvetica, sans-serif;');
+			expect(result).not.toContain('color:');
+			expect(result).not.toContain('font-size:');
 		});
 
 		it('should generate CSS with color preference only', () => {
@@ -38,7 +42,8 @@ describe('user-preference-styles', () => {
 
 			expect(result).toContain('color: #ff0000;');
 			expect(result).not.toContain('font-size:');
-			expect(result).not.toContain('font-family:');
+			// no font preference -> the default font-family fallback is applied
+			expect(result).toContain('font-family: arial, helvetica, sans-serif;');
 		});
 
 		it('should generate CSS with font-size preference only', () => {
@@ -52,7 +57,8 @@ describe('user-preference-styles', () => {
 
 			expect(result).toContain('font-size: 14pt;');
 			expect(result).not.toContain('color:');
-			expect(result).not.toContain('font-family:');
+			// no font preference -> the default font-family fallback is applied
+			expect(result).toContain('font-family: arial, helvetica, sans-serif;');
 		});
 
 		it('should generate CSS with font-family preference only', () => {
@@ -568,6 +574,59 @@ describe('user-preference-styles', () => {
 
 			// the top-level div carries the preference; the nested <p> inherits it
 			expect(result).toMatch(/<div style="[^"]*color: #ff0000[^"]*font-size: 14pt/);
+		});
+
+		it('should apply a default font-family when neither preference nor author provides one', () => {
+			const noFont: UserPreferenceStyle = {
+				font: undefined,
+				fontSize: undefined,
+				color: undefined
+			};
+			const content = `<p>Body</p>`;
+
+			const result = applyUserPreferenceStyles(content, noFont, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toMatch(/<p style="[^"]*font-family: arial, helvetica, sans-serif/);
+		});
+
+		it('should set the font-family on table cells (clients that do not inherit it)', () => {
+			const noFont: UserPreferenceStyle = {
+				font: undefined,
+				fontSize: undefined,
+				color: undefined
+			};
+			const content = `<table><tbody><tr><td>cell</td></tr></tbody></table>`;
+
+			const result = applyUserPreferenceStyles(content, noFont, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toMatch(/<td[^>]*font-family: arial, helvetica, sans-serif/);
+		});
+
+		it('should not apply the fallback font to a cell the author already styled', () => {
+			const noFont: UserPreferenceStyle = {
+				font: undefined,
+				fontSize: undefined,
+				color: undefined
+			};
+			const content = `<table><tbody><tr><td style="font-family: Georgia;">cell</td></tr></tbody></table>`;
+
+			const result = applyUserPreferenceStyles(content, noFont, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).toContain('font-family: Georgia');
+			expect(result).not.toMatch(/<td[^>]*arial, helvetica, sans-serif/);
+		});
+
+		it('should not apply the fallback font to signature table cells', () => {
+			const noFont: UserPreferenceStyle = {
+				font: undefined,
+				fontSize: undefined,
+				color: undefined
+			};
+			const content = `<div class="signature-div"><table><tbody><tr><td>sig</td></tr></tbody></table></div>`;
+
+			const result = applyUserPreferenceStyles(content, noFont, TINYMCE_BASE_CONTENT_STYLES);
+
+			expect(result).not.toContain('arial, helvetica, sans-serif');
 		});
 	});
 

--- a/src/helpers/user-preference-styles.ts
+++ b/src/helpers/user-preference-styles.ts
@@ -46,6 +46,8 @@ export const generateUserPreferenceStyles = (style: UserPreferenceStyle): string
 	// - mark: highlighted text with specific styling
 	// - blockquote: quoted content with distinct styling
 	// - caption: table captions with bold/larger text
+	// - font, [color]: author color/size set via legacy <font> or a color
+	//   attribute must win over the compose preference (CO-3793)
 	const excludedSelectors = [
 		'.signature-div',
 		'h1',
@@ -60,7 +62,9 @@ export const generateUserPreferenceStyles = (style: UserPreferenceStyle): string
 		'pre',
 		'mark',
 		'blockquote',
-		'caption'
+		'caption',
+		'font',
+		'[color]'
 	];
 	const notSelectors = excludedSelectors.map((sel) => `:not(${sel})`).join('');
 

--- a/src/helpers/user-preference-styles.ts
+++ b/src/helpers/user-preference-styles.ts
@@ -16,8 +16,9 @@ export type UserPreferenceStyle = {
  * Generates CSS styles that apply user preferences to email content while excluding signature elements
  * and special formatting elements.
  *
- * The selectors target only non-signature, non-special-element content to prevent styles from
- * cascading into elements that should maintain their original styling.
+ * The preference is applied to top-level body elements only and inherited by their
+ * descendants, so nested content that should keep its own value (headings, sub/sup,
+ * code blocks) is not overridden.
  *
  * Note: Elements with explicit inline styles (e.g., style="color: red") will have those styles
  * inlined with higher specificity after CSS processing, so they will take precedence over
@@ -36,7 +37,7 @@ export const generateUserPreferenceStyles = (style: UserPreferenceStyle): string
 		return 'p { margin: 0; }';
 	}
 
-	// Build CSS that applies user preferences to all elements except signature, headings, links, and special elements
+	// Build CSS that applies user preferences to top-level body elements except signature, headings, links, and special elements
 	// Excluded elements maintain their original/intended styling:
 	// - .signature-div: signature content and children
 	// - h1-h6: heading hierarchy
@@ -67,33 +68,25 @@ export const generateUserPreferenceStyles = (style: UserPreferenceStyle): string
 		'[color]'
 	];
 	const notSelectors = excludedSelectors.map((sel) => `:not(${sel})`).join('');
-	const topLevelSelector = `body > *${notSelectors}`;
-	const descendantSelector = `body > *:not(.signature-div) *${notSelectors}`;
 
-	const buildRule = (selector: string, includeFontSize: boolean): string => {
-		const declarations: string[] = [];
-		if (style?.color) {
-			declarations.push(`color: ${style.color};`);
-		}
-		// font-size is applied at the top level only. Inheriting it (instead of
-		// forcing it on every descendant) lets nested content keep its own size -
-		// e.g. text inside a heading, or sub/sup - rather than being shrunk to the
-		// preference size (CO-3793).
-		if (includeFontSize && style?.fontSize) {
-			declarations.push(`font-size: ${style.fontSize};`);
-		}
-		if (style?.font) {
-			declarations.push(`font-family: ${style.font};`);
-		}
-		return `${selector} {\n\t\t\t${declarations.join('\n\t\t\t')}\n\t\t}`;
-	};
+	// Apply the preference only to top-level body elements and let it inherit.
+	// Painting it on every descendant would override nested content that should
+	// keep its own value - text inside a heading, sub/sup, or a code block - and
+	// shrink/recolour/re-font it (CO-3793). Inheritance covers nested content;
+	// the author's inline styles still win.
+	const declarations: string[] = [];
+	if (style?.color) {
+		declarations.push(`color: ${style.color};`);
+	}
+	if (style?.fontSize) {
+		declarations.push(`font-size: ${style.fontSize};`);
+	}
+	if (style?.font) {
+		declarations.push(`font-family: ${style.font};`);
+	}
 
 	styles.push('p { margin: 0; }');
-	styles.push(buildRule(topLevelSelector, true));
-	// Skip the descendant rule when font-size is the only preference (it would be empty)
-	if (style?.color || style?.font) {
-		styles.push(buildRule(descendantSelector, false));
-	}
+	styles.push(`body > *${notSelectors} {\n\t\t\t${declarations.join('\n\t\t\t')}\n\t\t}`);
 
 	return styles.join('\n\t\t');
 };

--- a/src/helpers/user-preference-styles.ts
+++ b/src/helpers/user-preference-styles.ts
@@ -13,12 +13,22 @@ export type UserPreferenceStyle = {
 };
 
 /**
+ * Default font-family used as a fallback when neither the user preference nor
+ * the author specified a font, so content renders in a consistent font instead
+ * of the client default.
+ */
+export const DEFAULT_FONT_FAMILY = 'arial, helvetica, sans-serif';
+
+/**
  * Generates CSS styles that apply user preferences to email content while excluding signature elements
  * and special formatting elements.
  *
  * The preference is applied to top-level body elements only and inherited by their
  * descendants, so nested content that should keep its own value (headings, sub/sup,
  * code blocks) is not overridden.
+ *
+ * A font-family is always emitted - the preference, or {@link DEFAULT_FONT_FAMILY}
+ * as a fallback when the author didn't provide one.
  *
  * Note: Elements with explicit inline styles (e.g., style="color: red") will have those styles
  * inlined with higher specificity after CSS processing, so they will take precedence over
@@ -28,14 +38,10 @@ export type UserPreferenceStyle = {
  * @returns CSS string with user preference styles
  */
 export const generateUserPreferenceStyles = (style: UserPreferenceStyle): string => {
-	const styles: string[] = [];
-
-	// Only apply styles if at least one preference is defined
-	const hasStyles = style?.color || style?.fontSize || style?.font;
-
-	if (!hasStyles) {
-		return 'p { margin: 0; }';
-	}
+	// A font-family is always applied: the user's preference, or a default
+	// fallback when the author didn't provide one. This keeps content in a
+	// consistent font instead of the client default.
+	const fontFamily = style?.font || DEFAULT_FONT_FAMILY;
 
 	// Build CSS that applies user preferences to top-level body elements except signature, headings, links, and special elements
 	// Excluded elements maintain their original/intended styling:
@@ -81,12 +87,16 @@ export const generateUserPreferenceStyles = (style: UserPreferenceStyle): string
 	if (style?.fontSize) {
 		declarations.push(`font-size: ${style.fontSize};`);
 	}
-	if (style?.font) {
-		declarations.push(`font-family: ${style.font};`);
-	}
+	declarations.push(`font-family: ${fontFamily};`);
 
-	styles.push('p { margin: 0; }');
-	styles.push(`body > *${notSelectors} {\n\t\t\t${declarations.join('\n\t\t\t')}\n\t\t}`);
+	const styles = [
+		'p { margin: 0; }',
+		`body > *${notSelectors} {\n\t\t\t${declarations.join('\n\t\t\t')}\n\t\t}`,
+		// Some clients (e.g. Outlook) do not inherit font-family into table cells,
+		// so set the fallback explicitly. Scoped away from signatures and skipped
+		// when the author already styled the cell's font.
+		`body > *:not(.signature-div) td:not([style*="font"]),\n\t\tbody > *:not(.signature-div) th:not([style*="font"]) {\n\t\t\tfont-family: ${fontFamily};\n\t\t}`
+	];
 
 	return styles.join('\n\t\t');
 };

--- a/src/helpers/user-preference-styles.ts
+++ b/src/helpers/user-preference-styles.ts
@@ -67,23 +67,33 @@ export const generateUserPreferenceStyles = (style: UserPreferenceStyle): string
 		'[color]'
 	];
 	const notSelectors = excludedSelectors.map((sel) => `:not(${sel})`).join('');
+	const topLevelSelector = `body > *${notSelectors}`;
+	const descendantSelector = `body > *:not(.signature-div) *${notSelectors}`;
 
-	let userPrefRules = `body > *${notSelectors},\n\t\tbody > *:not(.signature-div) *${notSelectors} {\n`;
-
-	if (style?.color) {
-		userPrefRules += `\t\t\tcolor: ${style.color};\n`;
-	}
-	if (style?.fontSize) {
-		userPrefRules += `\t\t\tfont-size: ${style.fontSize};\n`;
-	}
-	if (style?.font) {
-		userPrefRules += `\t\t\tfont-family: ${style.font};\n`;
-	}
-
-	userPrefRules += '\t\t}';
+	const buildRule = (selector: string, includeFontSize: boolean): string => {
+		const declarations: string[] = [];
+		if (style?.color) {
+			declarations.push(`color: ${style.color};`);
+		}
+		// font-size is applied at the top level only. Inheriting it (instead of
+		// forcing it on every descendant) lets nested content keep its own size -
+		// e.g. text inside a heading, or sub/sup - rather than being shrunk to the
+		// preference size (CO-3793).
+		if (includeFontSize && style?.fontSize) {
+			declarations.push(`font-size: ${style.fontSize};`);
+		}
+		if (style?.font) {
+			declarations.push(`font-family: ${style.font};`);
+		}
+		return `${selector} {\n\t\t\t${declarations.join('\n\t\t\t')}\n\t\t}`;
+	};
 
 	styles.push('p { margin: 0; }');
-	styles.push(userPrefRules);
+	styles.push(buildRule(topLevelSelector, true));
+	// Skip the descendant rule when font-size is the only preference (it would be empty)
+	if (style?.color || style?.font) {
+		styles.push(buildRule(descendantSelector, false));
+	}
 
 	return styles.join('\n\t\t');
 };


### PR DESCRIPTION
### Problem
  The composer rewrote author-defined styling on save/send. The reported case: a signature table
  (`<table border="0" cellspacing="0" cellpadding="0">`) came out forced to `width:100%` — layout broken.

  ### Cause
  Our styles are inlined for WYSIWYG, but they were winning over the author because:

  ### Fix
  - Table defaults now apply only when the author hasn't set that property via inline style or attribute;
    the forced table `width:100%` is removed.
  - Preferences applied to top-level elements only and inherited, so nested content keeps its own value.

