### PR TITLE
fix: html-encode plain text messages and escape special characters

### DIFF
--- a/src/store/editor-slice-utils.ts
+++ b/src/store/editor-slice-utils.ts
@@ -204,7 +204,7 @@ export const extractBody = (msg: MailMessage): ExtractedBody => {
 	const textArr = findBodyPart(msg.parts, 'text/plain');
 	const htmlArr = findBodyPart(msg.parts, 'text/html');
 	const text = textArr?.[0]?.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
-	const textAsHtml = text?.replaceAll('\n', '<br/>');
+	const textAsHtml = text !== undefined ? htmlEncode(text).replaceAll('\n', '<br/>') : undefined;
 	let html = htmlArr.length ? htmlArr[0].replaceAll('dfsrc', 'src') : undefined;
 
 	// Inline CSS styles from <head> <style> tags to preserve formatting

--- a/src/store/tests/editor-slice-utils.test.ts
+++ b/src/store/tests/editor-slice-utils.test.ts
@@ -572,6 +572,79 @@ describe('retrieveReplyTo', () => {
 				const html = extractedBody.richText;
 				expect(html).toEqual(plainText);
 			});
+
+			it('should html-encode angle-bracketed text in a plain text message', () => {
+				const plainText = 'Contact me at <email@example.com> today';
+				const message: MailMessage = {
+					...mailMessage,
+					parts: [
+						{
+							contentType: 'text/plain',
+							size: 0,
+							content: plainText,
+							name: 'Plain body'
+						}
+					]
+				};
+				const extractedBody = extractBody(message);
+				const html = extractedBody.richText;
+				expect(html).toEqual('Contact me at &lt;email@example.com&gt; today');
+			});
+
+			it('should escape html tags in a plain text message so they are not interpreted as markup', () => {
+				const plainText = '<b>not bold</b>';
+				const message: MailMessage = {
+					...mailMessage,
+					parts: [
+						{
+							contentType: 'text/plain',
+							size: 0,
+							content: plainText,
+							name: 'Plain body'
+						}
+					]
+				};
+				const extractedBody = extractBody(message);
+				const html = extractedBody.richText;
+				expect(html).toEqual('&lt;b&gt;not bold&lt;/b&gt;');
+			});
+
+			it('should escape ampersands in a plain text message', () => {
+				const plainText = 'A & B';
+				const message: MailMessage = {
+					...mailMessage,
+					parts: [
+						{
+							contentType: 'text/plain',
+							size: 0,
+							content: plainText,
+							name: 'Plain body'
+						}
+					]
+				};
+				const extractedBody = extractBody(message);
+				const html = extractedBody.richText;
+				expect(html).toEqual('A &amp; B');
+			});
+
+			it('should convert newlines to <br/> while escaping special chars in a plain text message', () => {
+				const plainText = 'first <one>\nsecond <two>';
+				const message: MailMessage = {
+					...mailMessage,
+					parts: [
+						{
+							contentType: 'text/plain',
+							size: 0,
+							content: plainText,
+							name: 'Plain body'
+						}
+					]
+				};
+				const extractedBody = extractBody(message);
+				const html = extractedBody.richText;
+				expect(html).toEqual('first &lt;one&gt;<br/>second &lt;two&gt;');
+			});
+
 			it('should replace dfsrc with src in html message', () => {
 				const htmlContent = '<div>dfsrc<p>Hello there </p></div>';
 				const message: MailMessage = {


### PR DESCRIPTION
This pull request improves the handling of plain text email bodies when converting them to HTML, ensuring that special characters are properly escaped to prevent unintended HTML rendering. It also adds comprehensive tests to verify this behavior.

**Enhancements to plain text to HTML conversion:**

* Modified the `extractBody` function in `editor-slice-utils.ts` to HTML-encode plain text content before converting newlines to `<br/>`, preventing special characters like `<`, `>`, and `&` from being interpreted as HTML markup.

**Expanded test coverage for plain text escaping:**

* Added tests in `editor-slice-utils.test.ts` to verify that:
  - Angle-bracketed text is HTML-encoded (e.g., `<email@example.com>` becomes `&lt;email@example.com&gt;`).
  - HTML tags in plain text are escaped and not rendered as markup (e.g., `<b>not bold</b>` becomes `&lt;b&gt;not bold&lt;/b&gt;`).
  - Ampersands are correctly escaped (e.g., `A & B` becomes `A &amp; B`).
  - Newlines are converted to `<br/>` after escaping special characters.