### PR TITLE
fix(CO-3874): enhance XSS protection by escaping HTML tags and attributes in plain text renderer

### DIFF
--- a/src/commons/mail-message-renderer/text-message-renderer/tests/text-linkify.test.ts
+++ b/src/commons/mail-message-renderer/text-message-renderer/tests/text-linkify.test.ts
@@ -55,10 +55,29 @@ describe('linkifyToHtml', () => {
 		expect(output.match(/<a.*https:\/\/site\.com.*>/g)).toHaveLength(1);
 	});
 
-	it('does not escapes HTML tags in input', () => {
+	it('escapes HTML tags in input so they are not interpreted as markup', () => {
 		const input = '<b>foo@bar.com</b>';
 		const output = linkifyText(input);
-		expect(output).toBe(input);
+		expect(output).toBe('&lt;b&gt;foo@bar.com&lt;/b&gt;');
+	});
+
+	it('does not allow a quote in a mailto query to break out of the href attribute', () => {
+		const input = 'mailto:a@b.com?subject=x"onmouseover="alert(document.domain)';
+		const output = linkifyText(input);
+		// The double quote must be escaped so no event-handler attribute can be injected.
+		expect(output).not.toContain('"onmouseover');
+		expect(output).not.toMatch(/onmouseover\s*=\s*"/i);
+		expect(output).toContain('&quot;onmouseover');
+	});
+
+	it('neutralizes an <img onerror> XSS payload from a plain text body', () => {
+		const input =
+			'Hello this is an important message<img src=x onerror=window.location.replace("https://badsite.io/static/login/");>';
+		const output = linkifyText(input);
+		// No live tag/attribute may survive: angle brackets must be escaped.
+		expect(output).not.toContain('<img');
+		expect(output).not.toMatch(/<[^a/]/); // only the anchors we generate (<a ...) are allowed
+		expect(output).toContain('&lt;img src=x onerror=');
 	});
 
 	it('applies custom anchorRel and openInNewTab options', () => {
@@ -108,7 +127,7 @@ describe('linkifyToHtml', () => {
 		const input = 'Send to <test@example.com>';
 		const html = linkifyText(input, { linkEmails: false });
 
-		expect(html).toContain('<test@example.com>');
+		expect(html).toContain('&lt;test@example.com&gt;');
 		expect(html).not.toMatch(/mailto:/);
 	});
 
@@ -132,11 +151,14 @@ describe('linkifyToHtml', () => {
 		);
 	});
 
-	it('doest not linkify trailing angle bracket in mailto link', () => {
+	it('escapes the angle brackets around a bracketed mailto link', () => {
 		const input = 'Contact <mailto:test@example.com?subject=Hello>';
 		const output = linkifyText(input);
+		// Angle brackets are escaped so the bracketed form cannot inject markup,
+		// and the closing bracket is kept outside the anchor.
+		expect(output).not.toMatch(/<[^a/]/);
 		expect(output).toBe(
-			'Contact <<a href="mailto:test@example.com?subject=Hello" target="_blank" rel="noopener noreferrer">mailto:test@example.com?subject=Hello</a>>'
+			'Contact &lt;<a href="mailto:test@example.com?subject=Hello" target="_blank" rel="noopener noreferrer">mailto:test@example.com?subject=Hello</a>&gt;'
 		);
 	});
 });

--- a/src/commons/mail-message-renderer/text-message-renderer/tests/text-message-renderer.test.tsx
+++ b/src/commons/mail-message-renderer/text-message-renderer/tests/text-message-renderer.test.tsx
@@ -35,6 +35,19 @@ describe('TextMessageRenderer', () => {
 				'Line 1<br>Line 2<br>Line 3'
 			);
 		});
+
+		it('does not create live DOM nodes from an <img onerror> XSS payload', () => {
+			const content =
+				'Hello this is an important message<img src=x onerror=window.location.replace("https://badsite.io/static/login/");>';
+			setupTest(<TextMessageRenderer body={{ content }} />);
+			const container = screen.getByTestId('text-message-renderer-container');
+			// The markup must be inert: no <img> element is created in the DOM...
+			expect(container.querySelector('img')).toBeNull();
+			// ...and the payload is shown as literal text instead.
+			expect(container).toHaveTextContent(
+				'<img src=x onerror=window.location.replace("https://badsite.io/static/login/");>'
+			);
+		});
 	});
 
 	describe('Quoted text handling', () => {

--- a/src/commons/mail-message-renderer/text-message-renderer/text-linkify.ts
+++ b/src/commons/mail-message-renderer/text-message-renderer/text-linkify.ts
@@ -6,6 +6,7 @@
 
 import Autolinker from 'autolinker';
 import { AutolinkerConfig } from 'autolinker/dist/commonjs/autolinker';
+import { escape as escapeHtml } from 'lodash';
 
 export type LinkifyOptions = {
 	autolinker?: Partial<AutolinkerConfig> | false;
@@ -30,14 +31,19 @@ const DEFAULT_OPTIONS: Required<Omit<LinkifyOptions, 'autolinker'>> & {
 	linkEmails: true
 };
 
+// The query part allows '&' (to separate parameters) but stops at an escaped angle
+// bracket (&lt; / &gt;) so a bracketed <mailto:...> does not swallow its closing
+// bracket once the surrounding text has been HTML-escaped.
 const MAILTO_EMAIL_REGEX =
-	/mailto:([\p{L}\p{N}._%+-]+@(?:[\p{L}\p{N}.-]+\.[\p{L}\p{N}]{2,}|\[[^\]\s<>]+\]))(\?[^\s<>]+)?/gu;
+	/mailto:([\p{L}\p{N}._%+-]+@(?:[\p{L}\p{N}.-]+\.[\p{L}\p{N}]{2,}|\[[^\]\s<>]+\]))(\?(?:(?!&lt;|&gt;)[^\s<>])+)?/gu;
 
 const PLAIN_EMAIL_REGEX =
 	/(^|\s)([\p{L}\p{N}._%+-]+@(?:[\p{L}\p{N}.-]+\.[\p{L}\p{N}]{2,}|\[[^\]\s<>]+\]))/gu;
 
+// NOTE: angle brackets are HTML-escaped (via lodash `escape`) before this runs, so we
+// match the escaped entities &lt; ... &gt; rather than literal < ... >.
 const ANGLE_BRACKET_EMAIL_REGEX =
-	/<([a-zA-Z0-9._%+-]+@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]{2,}|\[[^\]\s<>]+])>/g;
+	/&lt;([a-zA-Z0-9._%+-]+@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]{2,}|\[[^\]\s<>]+])&gt;/g;
 
 function asAttrs(opts: Required<LinkifyOptions>): string {
 	const target = opts.openInNewTab ? ' target="_blank"' : '';
@@ -70,7 +76,11 @@ export function linkifyText(rawText: string, options?: LinkifyOptions): string {
 
 	const attrs = asAttrs(opts);
 
-	let processedText = rawText;
+	// Escape untrusted content up-front with lodash `escape` (handles & < > " '): the result
+	// is rendered via dangerouslySetInnerHTML, so it must not be able to inject markup
+	// (escaped < >) nor break out of the href="..." attributes of the anchors we build
+	// (escaped "). All anchors below are added after this point and are therefore unaffected.
+	let processedText = escapeHtml(rawText);
 
 	if (opts.linkEmails) {
 		// Re-create mailto anchors

--- a/src/commons/mail-message-renderer/text-message-renderer/text-linkify.ts
+++ b/src/commons/mail-message-renderer/text-message-renderer/text-linkify.ts
@@ -52,7 +52,7 @@ function asAttrs(opts: Required<LinkifyOptions>): string {
 }
 
 /**
- * Converts raw text to HTML with linkified URLs, email addresses, MailTo, and Tel links.
+ * Converts raw text to escaped HTML(except links) with linkified URLs, email addresses, MailTo, and Tel links.
  *  If `options.autolinker === false`, only the email/mailto handling runs.
  *
  * @param rawText - The input text containing URLs and email addresses, Telephone numbers.


### PR DESCRIPTION
For plain text emails, we were rendering the message body directly into an HTML element without escaping the content. This was originally done to support interactive links within text/plain messages. However, because the content was not HTML-escaped, it introduced a security issue: HTML markup embedded in a plain text email (for example, an <img> tag with an onerror handler) was interpreted and rendered by the browser, even though the MIME part's content type was text/plain.