### PR TITLE
chore: update import icon to use CalendarOutline for better clarity

### DIFF
--- a/src/views/app/detail-panel/preview/attachments-block.tsx
+++ b/src/views/app/detail-panel/preview/attachments-block.tsx
@@ -374,7 +374,7 @@ const Attachment = ({
 			items.push({
 				id: 'import-to-calendar',
 				label: t('label.import_to_calendar', 'Import to Calendars'),
-				icon: 'UploadOutline',
+				icon: 'CalendarOutline',
 				onClick: onImportAppointments
 			});
 		}


### PR DESCRIPTION
we decided to change the icon for "Import to Calendars" action for ics attachments.