### PR TITLE
fix(ci): cap vitest forks to 2 to prevent k8s CPU saturation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-common@v2.11.3',
+    identifier: 'jenkins-lib-common@v3.4.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"lint-stats": "eslint --ext .js,.jsx,.ts,.tsx --format node_modules/eslint-stats/byErrorAndWarningStacked --resolve-plugins-relative-to node_modules/@zextras/carbonio-ui-configs src",
 		"lint-check": "pnpm run lint-errors; pnpm run type-check",
 		"test": "TZ=Europe/Rome vitest run --project=unit",
+		"test:ci": "TZ=Europe/Rome vitest run --project=unit --pool-options.forks.maxForks=2",
 		"test:watch": "TZ=Europe/Rome vitest",
 		"coverage": "TZ=Europe/Rome vitest run --coverage",
 		"build:dev": "sdk build --dev --pkgRel $(date +%s)",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"lint-stats": "eslint --ext .js,.jsx,.ts,.tsx --format node_modules/eslint-stats/byErrorAndWarningStacked --resolve-plugins-relative-to node_modules/@zextras/carbonio-ui-configs src",
 		"lint-check": "pnpm run lint-errors; pnpm run type-check",
 		"test": "TZ=Europe/Rome vitest run --project=unit",
-		"test:ci": "TZ=Europe/Rome vitest run --project=unit --pool-options.forks.maxForks=2",
+		"test:ci": "TZ=Europe/Rome vitest run --project=unit --maxWorkers=2",
 		"test:watch": "TZ=Europe/Rome vitest",
 		"coverage": "TZ=Europe/Rome vitest run --coverage",
 		"build:dev": "sdk build --dev --pkgRel $(date +%s)",


### PR DESCRIPTION
## Problem

vitest ≥4.0 changed its default worker pool from `threads` to `forks`. In `forks` mode, vitest calls `os.availableParallelism()` which returns the node's physical core count — not the pod's CPU limit. A single CI pod consumed 12–13 cores; three concurrent pods brought the k8s cluster to 95–105% CPU, blocking all scheduling for ~1.5 hours and growing the Jenkins queue to 61+ items.

This repo runs **vitest 4.1.0**.

Jira: https://zextras.atlassian.net/browse/IN-1154

## Fix

Add a `test:ci` script that mirrors `test` but caps fork count:

```json
"test:ci": "TZ=Europe/Rome vitest run --project=unit --pool-options.forks.maxForks=2"
```

## Reference

carbonio-admin-console-ui PR #1279: https://github.com/zextras/carbonio-admin-console-ui/pull/1279