### PR TITLE
fix(CO-3925): invalid recipient error shows raw placeholder and only one address

### DIFF
--- a/src/views/app/detail-panel/edit/editor/edit-utils-hooks/tests/use-error-handler.test.ts
+++ b/src/views/app/detail-panel/edit/editor/edit-utils-hooks/tests/use-error-handler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { t } from '@zextras/carbonio-shell-ui';
+
 import { getErrorSnackbarProps } from '../use-error-handler';
 import { TIMEOUTS } from 'constants/index';
 
@@ -34,6 +36,49 @@ describe('getErrorSnackbarProps', () => {
 		const result = getErrorSnackbarProps(error);
 		expect(result).toEqual({
 			message: 'error.invalid_recipient',
+			timeout: TIMEOUTS.INVALID_EMAIL_RECIPIENT_TIMEOUT
+		});
+	});
+
+	it('passes the invalid address to the translation as an interpolation variable', () => {
+		const error = {
+			Fault: {
+				Detail: {
+					Error: {
+						Code: 'mail.SEND_ABORTED_ADDRESS_FAILURE',
+						a: [{ n: 'invalid', _content: 'abc@demo.zextras.io' }]
+					}
+				}
+			}
+		};
+		getErrorSnackbarProps(error);
+		expect(t).toHaveBeenCalledWith('error.invalid_recipient', {
+			defaultValue: 'The recipient address "{{invalidAddress}}" does not exist or is invalid',
+			invalidAddress: 'abc@demo.zextras.io'
+		});
+	});
+
+	it('reports all invalid addresses when the error contains more than one', () => {
+		const error = {
+			Fault: {
+				Detail: {
+					Error: {
+						Code: 'mail.SEND_ABORTED_ADDRESS_FAILURE',
+						a: [
+							{ n: 'invalid', _content: 'abc@demo.zextras.io' },
+							{ n: 'invalid', _content: 'def@demo.zextras.io' }
+						]
+					}
+				}
+			}
+		};
+		const result = getErrorSnackbarProps(error);
+		expect(t).toHaveBeenCalledWith('error.invalid_recipients', {
+			defaultValue: 'The recipient addresses "{{invalidAddresses}}" do not exist or are invalid',
+			invalidAddresses: 'abc@demo.zextras.io", "def@demo.zextras.io'
+		});
+		expect(result).toEqual({
+			message: 'error.invalid_recipients',
 			timeout: TIMEOUTS.INVALID_EMAIL_RECIPIENT_TIMEOUT
 		});
 	});

--- a/src/views/app/detail-panel/edit/editor/edit-utils-hooks/use-error-handler.ts
+++ b/src/views/app/detail-panel/edit/editor/edit-utils-hooks/use-error-handler.ts
@@ -13,6 +13,13 @@ function isErrorAboutInvalidRecipient(error: SaveDraftResponse | ErrorSoapBodyRe
 	return error?.Fault?.Detail?.Error?.Code === 'mail.SEND_ABORTED_ADDRESS_FAILURE';
 }
 
+function getInvalidAddresses(error: SaveDraftResponse | ErrorSoapBodyResponse): Array<string> {
+	const errorArguments: Array<{ _content?: string }> = error?.Fault?.Detail?.Error?.a ?? [];
+	return errorArguments
+		.map((argument) => argument?._content)
+		.filter((content): content is string => !!content);
+}
+
 export function getErrorSnackbarProps(error: SaveDraftResponse | ErrorSoapBodyResponse): {
 	message: string;
 	timeout: number;
@@ -21,12 +28,19 @@ export function getErrorSnackbarProps(error: SaveDraftResponse | ErrorSoapBodyRe
 	let message = t('label.error_try_again', 'Something went wrong, please try again');
 
 	if (isErrorAboutInvalidRecipient(error)) {
-		const invalidAddress = error?.Fault?.Detail?.Error?.a?.[0]?._content;
+		const invalidAddresses = getInvalidAddresses(error);
 
-		message = t('error.invalid_recipient', {
-			defaultValue: `The recipient address "${invalidAddress}" does not exist or is invalid`,
-			invalidAddress
-		});
+		message =
+			invalidAddresses.length > 1
+				? t('error.invalid_recipients', {
+						defaultValue:
+							'The recipient addresses "{{invalidAddresses}}" do not exist or are invalid',
+						invalidAddresses: invalidAddresses.join('", "')
+					})
+				: t('error.invalid_recipient', {
+						defaultValue: 'The recipient address "{{invalidAddress}}" does not exist or is invalid',
+						invalidAddress: invalidAddresses[0] ?? ''
+					});
 		timeout = TIMEOUTS.INVALID_EMAIL_RECIPIENT_TIMEOUT;
 	}
 

--- a/src/views/app/detail-panel/edit/legacyEditor/edit-utils-hooks/tests/use-error-handler.test.ts
+++ b/src/views/app/detail-panel/edit/legacyEditor/edit-utils-hooks/tests/use-error-handler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { t } from '@zextras/carbonio-shell-ui';
+
 import { getErrorSnackbarProps } from '../use-error-handler';
 import { TIMEOUTS } from 'constants/index';
 
@@ -34,6 +36,49 @@ describe('getErrorSnackbarProps', () => {
 		const result = getErrorSnackbarProps(error);
 		expect(result).toEqual({
 			message: 'error.invalid_recipient',
+			timeout: TIMEOUTS.INVALID_EMAIL_RECIPIENT_TIMEOUT
+		});
+	});
+
+	it('passes the invalid address to the translation as an interpolation variable', () => {
+		const error = {
+			Fault: {
+				Detail: {
+					Error: {
+						Code: 'mail.SEND_ABORTED_ADDRESS_FAILURE',
+						a: [{ n: 'invalid', _content: 'abc@demo.zextras.io' }]
+					}
+				}
+			}
+		};
+		getErrorSnackbarProps(error);
+		expect(t).toHaveBeenCalledWith('error.invalid_recipient', {
+			defaultValue: 'The recipient address "{{invalidAddress}}" does not exist or is invalid',
+			invalidAddress: 'abc@demo.zextras.io'
+		});
+	});
+
+	it('reports all invalid addresses when the error contains more than one', () => {
+		const error = {
+			Fault: {
+				Detail: {
+					Error: {
+						Code: 'mail.SEND_ABORTED_ADDRESS_FAILURE',
+						a: [
+							{ n: 'invalid', _content: 'abc@demo.zextras.io' },
+							{ n: 'invalid', _content: 'def@demo.zextras.io' }
+						]
+					}
+				}
+			}
+		};
+		const result = getErrorSnackbarProps(error);
+		expect(t).toHaveBeenCalledWith('error.invalid_recipients', {
+			defaultValue: 'The recipient addresses "{{invalidAddresses}}" do not exist or are invalid',
+			invalidAddresses: 'abc@demo.zextras.io", "def@demo.zextras.io'
+		});
+		expect(result).toEqual({
+			message: 'error.invalid_recipients',
 			timeout: TIMEOUTS.INVALID_EMAIL_RECIPIENT_TIMEOUT
 		});
 	});

--- a/src/views/app/detail-panel/edit/legacyEditor/edit-utils-hooks/use-error-handler.ts
+++ b/src/views/app/detail-panel/edit/legacyEditor/edit-utils-hooks/use-error-handler.ts
@@ -13,6 +13,13 @@ function isErrorAboutInvalidRecipient(error: SaveDraftResponse | ErrorSoapBodyRe
 	return error?.Fault?.Detail?.Error?.Code === 'mail.SEND_ABORTED_ADDRESS_FAILURE';
 }
 
+function getInvalidAddresses(error: SaveDraftResponse | ErrorSoapBodyResponse): Array<string> {
+	const errorArguments: Array<{ _content?: string }> = error?.Fault?.Detail?.Error?.a ?? [];
+	return errorArguments
+		.map((argument) => argument?._content)
+		.filter((content): content is string => !!content);
+}
+
 export function getErrorSnackbarProps(error: SaveDraftResponse | ErrorSoapBodyResponse): {
 	message: string;
 	timeout: number;
@@ -21,12 +28,19 @@ export function getErrorSnackbarProps(error: SaveDraftResponse | ErrorSoapBodyRe
 	let message = t('label.error_try_again', 'Something went wrong, please try again');
 
 	if (isErrorAboutInvalidRecipient(error)) {
-		const invalidAddress = error?.Fault?.Detail?.Error?.a?.[0]?._content;
+		const invalidAddresses = getInvalidAddresses(error);
 
-		message = t('error.invalid_recipient', {
-			defaultValue: `The recipient address "${invalidAddress}" does not exist or is invalid`,
-			invalidAddress
-		});
+		message =
+			invalidAddresses.length > 1
+				? t('error.invalid_recipients', {
+						defaultValue:
+							'The recipient addresses "{{invalidAddresses}}" do not exist or are invalid',
+						invalidAddresses: invalidAddresses.join('", "')
+					})
+				: t('error.invalid_recipient', {
+						defaultValue: 'The recipient address "{{invalidAddress}}" does not exist or is invalid',
+						invalidAddress: invalidAddresses[0] ?? ''
+					});
 		timeout = TIMEOUTS.INVALID_EMAIL_RECIPIENT_TIMEOUT;
 	}
 


### PR DESCRIPTION
### Problem

When an email couldn't be sent because of invalid recipient addresses, the error message had two problems:

* In some languages, it showed a placeholder instead of the actual email address.
* If multiple addresses were invalid, it only displayed the first one.

### Fix

* The error message now correctly shows the invalid email address in all languages.
* If multiple recipient addresses are invalid, they are all listed in the notification.
* Updated both editor implementations and added tests to cover these cases.


<details><summary>Details</summary>
<p>

  When sending a mail fails with `mail.SEND_ABORTED_ADDRESS_FAILURE`, the error snackbar had two issues:

  1. **Localized placeholder leak** — in non-English locales (reported in Russian) the notification displayed the literal text `${invalid Address}` instead of the rejected email
  address.
  2. **Only one address reported** — when several recipients were invalid, only the first one was shown, leaving users guessing which other addresses failed.

  ## Root cause

  `getErrorSnackbarProps` built the message with a JS template literal as the i18next `defaultValue`:

  ```ts
  message = t('error.invalid_recipient', {
        defaultValue: `The recipient address "${invalidAddress}" does not exist or is invalid`,
        invalidAddress
  });
  ```
  
  JS interpolated the address into the English default before i18next ever saw a placeholder, so English looked fine — but the translation catalogs inherited the `${...}` token,
  which i18next never substitutes (its syntax is `{{...}}`). Every translated locale therefore printed the placeholder verbatim. Additionally, the code read only `Error.a[0]`,
  discarding the other rejected addresses in the SOAP fault.

  ## Changes
  
  - Use i18next interpolation (`{{invalidAddress}}`) in the `defaultValue` so translated strings receive the actual address at runtime.
  - Collect **all** invalid addresses from the fault's `Error.a` array via a new `getInvalidAddresses` helper.
  - When more than one address is invalid, use a new plural key `error.invalid_recipients` listing every address, each individually quoted:
    `The recipient addresses "abc@x.io", "def@x.io" do not exist or are invalid`
  - Applied identically to both `editor` and `legacyEditor` variants of `use-error-handler.ts`.
  - Extended unit tests to cover the interpolation options and the multi-address case.

</p>
</details>  


