### PR TITLE
chore(deps): update dependency zextras/jenkins-lib-common to v4.1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-common@v3.4.0',
+    identifier: 'jenkins-lib-common@v4.1.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
IN-1168 — pin the Nexus-capable shared library.

`v4.1.4` carries the JFrog → Nexus upload migration (IN-1096, lib #111) plus the three
`nexusHelper` fixes on top of it. The Nexus publish is a best-effort mirror inside
`uploadStage`/`mavenStage`/`dt3_pipeline`: it never fails the build, and JFrog uploads are
unchanged. Pin-only change, no pipeline API surface touched.

Ref: https://zextras.atlassian.net/browse/IN-1168