### PR TITLE
feat: add inline image support in signature editor and rich text editor

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -497,7 +497,12 @@ export const TIMEOUTS = {
 	REDIRECT: SNACKBAR_DEFAULT_TIMEOUT,
 	DRAFT_INFO_HIDING_DELAY: 3000,
 	COMPLETED_UPLOAD_NOTIFICATION_VISIBILITY: 3000,
-	INVALID_EMAIL_RECIPIENT_TIMEOUT: 5000
+	INVALID_EMAIL_RECIPIENT_TIMEOUT: 5000,
+	/**
+	 * How long the send waits for the inline `data:` images to be converted into
+	 * inline attachments before giving up and sending the message as it is.
+	 */
+	INLINE_IMAGES_CONVERSION: 10000
 };
 
 export const LIST_LIMIT = {

--- a/src/helpers/inline-images.ts
+++ b/src/helpers/inline-images.ts
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Helpers shared by the two places where an inline image can enter an editor
+ * without going through an upload: the signature editor (which embeds the
+ * picked file as a `data:` URI, since a signature has no draft to attach to)
+ * and the mail composer (which turns those `data:` URIs back into real files to
+ * upload as inline attachments).
+ */
+
+/** Matches `data:<mime>;base64,<payload>` restricted to image mime types. */
+const DATA_IMAGE_URI_REGEXP = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/=\s]+)$/i;
+
+export const isImageFile = (file: File): boolean => file.type.startsWith('image/');
+
+export const isDataImageUri = (src: string): boolean => DATA_IMAGE_URI_REGEXP.test(src);
+
+/**
+ * Reads the given file and resolves with its content as a `data:` URI.
+ */
+export const readFileAsDataUri = (file: File): Promise<string> =>
+	new Promise((resolve, reject) => {
+		const fileReader = new FileReader();
+		fileReader.addEventListener('load', () => {
+			if (typeof fileReader.result === 'string') {
+				resolve(fileReader.result);
+				return;
+			}
+			reject(new Error(`Cannot read the file ${file.name} as a data URI`));
+		});
+		fileReader.addEventListener('error', () => {
+			reject(fileReader.error ?? new Error(`Cannot read the file ${file.name}`));
+		});
+		fileReader.readAsDataURL(file);
+	});
+
+/**
+ * Converts a base64 `data:` image URI back into a {@link File}, so it can be
+ * uploaded as a regular inline attachment.
+ *
+ * The payload is decoded through `atob` rather than by fetching the data URI:
+ * `fetch` on a `data:` URI is not implemented by jsdom, and this path has to
+ * work in the unit tests as well as in the browser.
+ *
+ * @returns the decoded file, or `undefined` if the URI is not a valid base64
+ * image data URI.
+ */
+export const dataUriToFile = (dataUri: string, fileName: string): File | undefined => {
+	const match = DATA_IMAGE_URI_REGEXP.exec(dataUri);
+	if (!match) {
+		return undefined;
+	}
+
+	const [, mimeType, payload] = match;
+	try {
+		const binary = atob(payload.replace(/\s/g, ''));
+		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+		return new File([bytes], fileName, { type: mimeType });
+	} catch {
+		return undefined;
+	}
+};
+
+/**
+ * Returns a plausible file name for an image extracted from a `data:` URI,
+ * which carries no name of its own.
+ */
+export const getDataUriFileName = (dataUri: string, index: number): string => {
+	const mimeType = DATA_IMAGE_URI_REGEXP.exec(dataUri)?.[1] ?? 'image/png';
+	const extension = mimeType.replace('image/', '').replace('+xml', '');
+	return `inline-image-${index}.${extension}`;
+};

--- a/src/helpers/inline-images.ts
+++ b/src/helpers/inline-images.ts
@@ -57,8 +57,8 @@ export const dataUriToFile = (dataUri: string, fileName: string): File | undefin
 
 	const [, mimeType, payload] = match;
 	try {
-		const binary = atob(payload.replace(/\s/g, ''));
-		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+		const binary = atob(payload.replaceAll(/\s/g, ''));
+		const bytes = Uint8Array.from(binary, (char) => char.codePointAt(0) ?? 0);
 		return new File([bytes], fileName, { type: mimeType });
 	} catch {
 		return undefined;

--- a/src/helpers/tests/inline-images.test.ts
+++ b/src/helpers/tests/inline-images.test.ts
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import {
+	dataUriToFile,
+	getDataUriFileName,
+	isDataImageUri,
+	isImageFile,
+	readFileAsDataUri
+} from '../inline-images';
+
+/** A 1x1 transparent PNG. */
+const PNG_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==';
+const PNG_DATA_URI = `data:image/png;base64,${PNG_BASE64}`;
+
+describe('inline-images', () => {
+	describe('isImageFile', () => {
+		it('should accept every image mime type', () => {
+			expect(isImageFile(new File([''], 'a.png', { type: 'image/png' }))).toBe(true);
+			expect(isImageFile(new File([''], 'a.svg', { type: 'image/svg+xml' }))).toBe(true);
+		});
+
+		it('should reject a non image file', () => {
+			expect(isImageFile(new File([''], 'a.pdf', { type: 'application/pdf' }))).toBe(false);
+			expect(isImageFile(new File([''], 'a.bin', { type: '' }))).toBe(false);
+		});
+	});
+
+	describe('isDataImageUri', () => {
+		it('should recognize a base64 image data URI', () => {
+			expect(isDataImageUri(PNG_DATA_URI)).toBe(true);
+			expect(isDataImageUri('data:image/svg+xml;base64,PHN2Zy8+')).toBe(true);
+		});
+
+		it('should reject a data URI which is not a base64 image', () => {
+			expect(isDataImageUri('data:text/plain;base64,aGVsbG8=')).toBe(false);
+			// Not base64: an URL-encoded payload cannot be decoded by `atob`
+			expect(isDataImageUri('data:image/svg+xml,%3Csvg%2F%3E')).toBe(false);
+		});
+
+		it('should reject a regular URL', () => {
+			expect(isDataImageUri('https://example.com/picture.png')).toBe(false);
+			expect(isDataImageUri('cid:image@carbonio')).toBe(false);
+		});
+	});
+
+	describe('dataUriToFile', () => {
+		it('should decode the payload into a file carrying the URI mime type', () => {
+			const file = dataUriToFile(PNG_DATA_URI, 'logo.png');
+
+			expect(file).toBeInstanceOf(File);
+			expect(file?.name).toBe('logo.png');
+			expect(file?.type).toBe('image/png');
+			expect(file?.size).toBe(atob(PNG_BASE64).length);
+		});
+
+		it('should tolerate whitespace inside the payload', () => {
+			const chunked = `data:image/png;base64,${PNG_BASE64.slice(0, 20)}\n${PNG_BASE64.slice(20)}`;
+
+			expect(dataUriToFile(chunked, 'logo.png')?.size).toBe(atob(PNG_BASE64).length);
+		});
+
+		it('should return undefined for anything which is not a base64 image data URI', () => {
+			expect(dataUriToFile('https://example.com/picture.png', 'logo.png')).toBeUndefined();
+			expect(dataUriToFile('data:text/plain;base64,aGVsbG8=', 'logo.png')).toBeUndefined();
+			expect(dataUriToFile('data:image/png;base64,', 'logo.png')).toBeUndefined();
+		});
+	});
+
+	describe('getDataUriFileName', () => {
+		it('should build a name with the extension matching the URI mime type', () => {
+			expect(getDataUriFileName(PNG_DATA_URI, 1)).toBe('inline-image-1.png');
+			expect(getDataUriFileName('data:image/svg+xml;base64,PHN2Zy8+', 2)).toBe(
+				'inline-image-2.svg'
+			);
+		});
+
+		it('should fall back to png when the mime type cannot be read', () => {
+			expect(getDataUriFileName('not a data uri', 3)).toBe('inline-image-3.png');
+		});
+	});
+
+	describe('readFileAsDataUri', () => {
+		it('should read an image file back as its data URI', async () => {
+			const bytes = Uint8Array.from(atob(PNG_BASE64), (char) => char.charCodeAt(0));
+			const file = new File([bytes], 'logo.png', { type: 'image/png' });
+
+			await expect(readFileAsDataUri(file)).resolves.toBe(PNG_DATA_URI);
+		});
+
+		it('should round trip through dataUriToFile', async () => {
+			const file = dataUriToFile(PNG_DATA_URI, 'logo.png');
+
+			await expect(readFileAsDataUri(file as File)).resolves.toBe(PNG_DATA_URI);
+		});
+	});
+});

--- a/src/store/editor/hooks/attachments.ts
+++ b/src/store/editor/hooks/attachments.ts
@@ -69,6 +69,12 @@ type EditorAttachmentHook = {
 	addInlineAttachments: (
 		files: Array<File>,
 		options?: UploadCallbacks & {
+			/**
+			 * Saves the draft as soon as the uploads end, instead of waiting for the
+			 * auto-save interval. Needed when the caller has to act on the resulting
+			 * content ids without keeping a `data:` URI in the body meanwhile.
+			 */
+			saveImmediately?: boolean;
 			onSaveComplete?: (
 				inlineAttachments: Array<{
 					contentId: string | undefined;
@@ -85,7 +91,7 @@ type EditorAttachmentHook = {
 };
 
 export const useEditorAttachments = (editorId: MailsEditorV2['id']): EditorAttachmentHook => {
-	const { debouncedSaveDraft } = useSaveDraftFromEditor(editorId);
+	const { debouncedSaveDraft, immediateSaveDraft } = useSaveDraftFromEditor(editorId);
 	const { setDirty } = useEditorSetDirty(editorId);
 	const notifyUploadError = useNotifyUploadError();
 
@@ -171,11 +177,12 @@ export const useEditorAttachments = (editorId: MailsEditorV2['id']): EditorAttac
 		files: Array<File>,
 		areInline: boolean,
 		callbacks?: UploadAttachmentsOptions & {
+			saveImmediately?: boolean;
 			onSaveComplete?: (savedContentIds: Array<string>) => void;
 		}
 	): Array<UnsavedAttachment> => {
 		const customizedCallbacks = {
-			...callbacks,
+			...omit(callbacks, 'saveImmediately'),
 			onUploadsEnd: (completedUploadsId: Array<string>, failedUploadsId: Array<string>): void => {
 				const editor = getEditor({ id: editorId });
 				if (editor) {
@@ -200,7 +207,12 @@ export const useEditorAttachments = (editorId: MailsEditorV2['id']): EditorAttac
 						}
 					};
 					setDirty();
-					debouncedSaveDraft(saveDraftOptions);
+					if (callbacks?.saveImmediately) {
+						debouncedSaveDraft.cancel();
+						immediateSaveDraft(saveDraftOptions);
+					} else {
+						debouncedSaveDraft(saveDraftOptions);
+					}
 				}
 
 				callbacks?.onUploadsEnd && callbacks.onUploadsEnd(completedUploadsId, failedUploadsId);
@@ -262,6 +274,7 @@ export const useEditorAttachments = (editorId: MailsEditorV2['id']): EditorAttac
 	const addInlineAttachments = (
 		files: Array<File>,
 		callbacks?: UploadCallbacks & {
+			saveImmediately?: boolean;
 			onSaveComplete?: (
 				inlineAttachments: Array<{
 					contentId: string | undefined;

--- a/src/views/app/detail-panel/edit/editor/edit-utils-hooks/use-send-handlers.ts
+++ b/src/views/app/detail-panel/edit/editor/edit-utils-hooks/use-send-handlers.ts
@@ -12,6 +12,7 @@ import { ErrorSoapBodyResponse, t } from '@zextras/carbonio-shell-ui';
 import { checkSubjectAndAttachment } from '../check-subject-attachment';
 import { getErrorSnackbarProps } from './use-error-handler';
 import { createEditBoard } from '../../edit-view-board';
+import { ensureInlineImagesConverted } from '../plugins/inline-image-conversion-registry';
 import { EDIT_VIEW_CLOSING_REASONS, EditViewActions, TIMEOUTS } from 'constants/index';
 import {
 	deleteEditor,
@@ -116,6 +117,11 @@ export const useSendHandlers = (
 
 	const onSendClick = useCallback((): void => {
 		const onConfirmCallback = async (): Promise<void> => {
+			// A reply or a forward can be sent without ever being edited, so the
+			// signature's inline images may still be `data:` URIs. Convert them now,
+			// while the editor is still mounted: it unmounts as soon as the send
+			// countdown starts.
+			await ensureInlineImagesConverted(editorId);
 			sendMessage({
 				onCountdownTick: onSendCountdownTick,
 				onSendStart,
@@ -147,6 +153,7 @@ export const useSendHandlers = (
 	const onSendLaterClick = useCallback(
 		(scheduledTime: number): void => {
 			const onConfirmCallback = async (): Promise<void> => {
+				await ensureInlineImagesConverted(editorId);
 				setAutoSendTime(scheduledTime);
 				saveDraft();
 				close(EDIT_VIEW_CLOSING_REASONS.MESSAGE_SEND_SCHEDULED);

--- a/src/views/app/detail-panel/edit/editor/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/editor/parts/rich-text-editor-container.tsx
@@ -27,12 +27,13 @@ import { ControlledContentPlugin } from '../plugins/controlled-content-plugin';
 import { FloatingLinkEditorPlugin } from '../plugins/floating-link-editor-plugin';
 import { STYLE_PRESERVING_HTML_IMPORT } from '../plugins/html-import-style';
 import { ImagePlugin } from '../plugins/image-plugin';
+import { InlineDataImageUploadPlugin } from '../plugins/inline-data-image-upload-plugin';
 import { ListMarkdownShortcutPlugin } from '../plugins/list-markdown-shortcut-plugin';
 import { ImageNode } from '../plugins/nodes/image-node';
 import { QuotedSeparatorNode } from '../plugins/nodes/quoted-separator-node';
 import { SignatureNode } from '../plugins/nodes/signature-node';
 import { PastePlugin } from '../plugins/paste-plugin';
-import { RichToolbarPlugin, type UploadedInlineImage } from '../plugins/rich-toolbar-plugin';
+import { RichToolbarPlugin, type ResolvedInlineImage } from '../plugins/rich-toolbar-plugin';
 import { TableActionMenuPlugin } from '../plugins/table-action-menu-plugin';
 import { TableCellResizerPlugin } from '../plugins/table-cell-resizer-plugin';
 import { TableHoverActionsPlugin } from '../plugins/table-hover-actions-plugin';
@@ -344,9 +345,17 @@ export const RichTextEditorContainer = ({
 	const [showBlocks, setShowBlocks] = useState(false);
 	const { addInlineAttachments } = useEditorAttachments(editorId);
 
-	const onUploadInlineImages = useCallback(
-		(files: File[], onComplete: (attachments: UploadedInlineImage[]) => void): void => {
-			addInlineAttachments(files, { onSaveComplete: onComplete });
+	const onResolveInlineImages = useCallback(
+		(files: File[], onComplete: (images: ResolvedInlineImage[]) => void): void => {
+			addInlineAttachments(files, {
+				onSaveComplete: (inlineAttachments): void =>
+					onComplete(
+						inlineAttachments.map(({ downloadServiceUrl, cidUrl }) => ({
+							src: downloadServiceUrl,
+							cidUrl
+						}))
+					)
+			});
 		},
 		[addInlineAttachments]
 	);
@@ -402,7 +411,7 @@ export const RichTextEditorContainer = ({
 						<RichToolbarPlugin
 							showBlocks={showBlocks}
 							onToggleShowBlocks={(): void => setShowBlocks((previous) => !previous)}
-							onUploadInlineImages={onUploadInlineImages}
+							onResolveInlineImages={onResolveInlineImages}
 							fontFamily={fontFamily}
 							fontSize={fontSize}
 						/>
@@ -433,7 +442,8 @@ export const RichTextEditorContainer = ({
 					<TableCellResizerPlugin />
 					<TableHoverActionsPlugin />
 					<ImagePlugin />
-					<PastePlugin editorId={editorId} />
+					<PastePlugin onResolveInlineImages={onResolveInlineImages} />
+					<InlineDataImageUploadPlugin editorId={editorId} />
 					<ControlledContentPlugin editorId={editorId} />
 				</LexicalWrapper>
 			</LexicalComposer>

--- a/src/views/app/detail-panel/edit/editor/plugins/image-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/image-plugin.tsx
@@ -13,7 +13,8 @@ import {
 	$isNodeSelection,
 	COMMAND_PRIORITY_EDITOR,
 	createCommand,
-	type LexicalCommand
+	type LexicalCommand,
+	type LexicalEditor
 } from 'lexical';
 
 import { $createImageNode, $isImageNode, type ImageAlignment } from './nodes/image-node';
@@ -35,6 +36,42 @@ export const INSERT_INLINE_IMAGE_COMMAND: LexicalCommand<InsertInlineImagePayloa
 
 export const SET_INLINE_IMAGE_ALIGNMENT_COMMAND: LexicalCommand<ImageAlignment | undefined> =
 	createCommand('SET_INLINE_IMAGE_ALIGNMENT_COMMAND');
+
+/**
+ * An image picked from the device, resolved into something the editor can
+ * display. How it is resolved depends on the host editor: the mail composer
+ * uploads the file as an inline attachment (so `src` is a download-service URL
+ * and `cidUrl` the matching cid), while the signature editor embeds it as a
+ * `data:` URI (so there is no cid).
+ */
+export type ResolvedInlineImage = {
+	src?: string;
+	cidUrl?: string;
+};
+
+export type ResolveInlineImages = (
+	files: File[],
+	onComplete: (images: ResolvedInlineImage[]) => void
+) => void;
+
+/**
+ * Inserts the resolved images at the current selection, skipping the ones whose
+ * resolution failed. Shared by the toolbar's image button and the paste handler.
+ */
+export const insertResolvedInlineImages = (
+	editor: LexicalEditor,
+	images: ResolvedInlineImage[]
+): void => {
+	images.forEach((image) => {
+		if (image.src) {
+			editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
+				src: image.src,
+				cidUrl: image.cidUrl,
+				altText: 'Inline attachment'
+			});
+		}
+	});
+};
 
 function $applyImageAlignment(alignment: ImageAlignment | undefined): void {
 	const selection = $getSelection();

--- a/src/views/app/detail-panel/edit/editor/plugins/inline-data-image-upload-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/inline-data-image-upload-plugin.tsx
@@ -9,9 +9,16 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { $dfs } from '@lexical/utils';
 import { $getNodeByKey, type LexicalEditor, type NodeKey } from 'lexical';
 
+import { registerInlineImageConverter } from './inline-image-conversion-registry';
 import { $isImageNode } from './nodes/image-node';
+import { areContentIdsEqual } from 'commons/content-id-utils';
+import { TIMEOUTS } from 'constants/index';
+import { composeAttachmentDownloadUrl } from 'helpers/attachments';
 import { dataUriToFile, getDataUriFileName, isDataImageUri } from 'helpers/inline-images';
+import { composeCidUrlFromContentId } from 'store/editor/editor-transformations';
+import { useEditorIsDirty } from 'store/editor/hooks/statuses';
 import { useEditorAttachments } from 'store/editor/index';
+import { useEditorsStore } from 'store/editor/store';
 import { MailsEditorV2 } from 'types/editor';
 
 type InlineDataImageUploadPluginProps = {
@@ -58,59 +65,163 @@ function repointImageNode(
  * A signature is stored as a self-contained HTML snippet, so an image embedded
  * in it can only travel as a `data:` URI: while it is being edited in the
  * settings there is no draft to attach it to. Left as such in a sent message
- * that URI is stripped by several mail clients (Gmail among them), so as soon as
- * such an image lands in the composer — with the signature, or from an HTML
- * paste — it is uploaded as an inline attachment and the node is rewritten to
- * point at the upload. That restores the cid bookkeeping the rest of the compose
- * pipeline relies on (`exportDOM` writes `data-pnsrc`, then
- * `replaceServiceUrlWithCidUrl` puts the `cid:` src back on save draft / send)
- * so the recipient gets a `multipart/related` part instead of base64 markup.
+ * that URI is stripped by several mail clients (Gmail among them), so an image
+ * arriving in the composer — with the signature, or from an HTML paste — is
+ * uploaded as an inline attachment and its node is repointed at the upload. That
+ * restores the cid bookkeeping the rest of the compose pipeline relies on
+ * (`exportDOM` writes `data-pnsrc`, then `replaceServiceUrlWithCidUrl` puts the
+ * `cid:` src back on save draft / send) so the recipient gets a
+ * `multipart/related` part instead of base64 markup.
  *
- * Every node is attempted at most once, tracked by node key in
- * `attemptedKeysRef`: the upload completes several editor updates after it is
- * started, and a failed conversion must not be retried on each subsequent
- * update. A content replacement (the store -> editor sync in
- * `ControlledContentPlugin`) re-creates the nodes with fresh keys, so an image
- * still carrying a `data:` URI at that point is legitimately attempted again.
+ * The conversion is deliberately **not** run on mount: uploading requires saving
+ * the draft, and doing that just because a compose window was opened would leave
+ * a draft and an orphan attachment behind for a message the user never wrote.
+ * It is therefore triggered by the first real change to the editor
+ * (`isDirty`), plus on demand from the send handlers through
+ * {@link registerInlineImageConverter}, which covers sending a reply or a forward
+ * without editing it at all.
+ *
+ * All the images found in a pass are uploaded as a **single** batch: one batch
+ * means one `onUploadsEnd`, hence one draft save. Uploading them one by one
+ * would coalesce several saves into the debounce, and `lodash.debounce` keeps
+ * only the arguments of the last call, silently dropping the other batches'
+ * completion callbacks.
+ *
+ * Nodes are repointed by watching `savedAttachments` rather than through the
+ * upload's own completion callback, so the conversion completes whichever draft
+ * save persists the attachment (its own immediate one, or one already running
+ * and which would have made it skip).
  */
 export const InlineDataImageUploadPlugin = ({
 	editorId
 }: InlineDataImageUploadPluginProps): null => {
 	const [editor] = useLexicalComposerContext();
 	const { addInlineAttachments } = useEditorAttachments(editorId);
-	const attemptedKeysRef = useRef<Set<NodeKey>>(new Set());
-	const uploadCountRef = useRef(0);
+	const isDirty = useEditorIsDirty(editorId);
+	const savedAttachments = useEditorsStore((state) => state.editors[editorId]?.savedAttachments);
 
-	const uploadImage = useCallback(
-		({ key, src }: PendingDataUriImage): void => {
+	/** Nodes already uploaded, so an update does not upload them a second time. */
+	const attemptedKeysRef = useRef<Set<NodeKey>>(new Set());
+	/** Content id -> node waiting to be repointed once the draft save persists it. */
+	const pendingRef = useRef<Map<string, NodeKey>>(new Map());
+	/** Resolvers of the promises handed to the send handlers. */
+	const waitersRef = useRef<Array<() => void>>([]);
+	const uploadCountRef = useRef(0);
+	/**
+	 * Whether the user did something which justifies creating a draft. Latched:
+	 * `isDirty` goes back to false after every successful save.
+	 */
+	const startedRef = useRef(false);
+
+	const releaseWaiters = useCallback((): void => {
+		waitersRef.current.forEach((resolve) => resolve());
+		waitersRef.current = [];
+	}, []);
+
+	const convert = useCallback((): void => {
+		const pending = editor
+			.getEditorState()
+			.read(() => $collectPendingDataUriImages(attemptedKeysRef.current));
+		if (pending.length === 0) {
+			return;
+		}
+
+		const files: Array<File> = [];
+		const keys: Array<NodeKey> = [];
+		pending.forEach(({ key, src }) => {
 			attemptedKeysRef.current.add(key);
 			uploadCountRef.current += 1;
 			const file = dataUriToFile(src, getDataUriFileName(src, uploadCountRef.current));
-			if (!file) {
-				return;
+			if (file) {
+				files.push(file);
+				keys.push(key);
 			}
+		});
+		if (files.length === 0) {
+			return;
+		}
 
-			addInlineAttachments([file], {
-				onSaveComplete: (inlineAttachments): void => {
-					const { downloadServiceUrl, cidUrl } = inlineAttachments[0] ?? {};
-					if (downloadServiceUrl) {
-						repointImageNode(editor, key, downloadServiceUrl, cidUrl);
-					}
-				}
-			});
-		},
-		[addInlineAttachments, editor]
-	);
+		// The returned unsaved attachments are positional with `files`, and each
+		// already carries the content id the draft save will persist.
+		const unsavedAttachments = addInlineAttachments(files, { saveImmediately: true });
+		unsavedAttachments.forEach((unsavedAttachment, index) => {
+			const key = keys[index];
+			if (unsavedAttachment.contentId && key !== undefined) {
+				pendingRef.current.set(unsavedAttachment.contentId, key);
+			}
+		});
+	}, [addInlineAttachments, editor]);
 
+	// Trigger: the first real change to the message.
+	useEffect(() => {
+		if (!isDirty) {
+			return;
+		}
+		startedRef.current = true;
+		convert();
+	}, [convert, isDirty]);
+
+	// Trigger: any later change, e.g. pasting HTML which carries a data URI image.
 	useEffect(
 		() =>
-			editor.registerUpdateListener(({ editorState }) => {
-				const pending = editorState.read(() =>
-					$collectPendingDataUriImages(attemptedKeysRef.current)
-				);
-				pending.forEach(uploadImage);
+			editor.registerUpdateListener(() => {
+				if (startedRef.current) {
+					convert();
+				}
 			}),
-		[editor, uploadImage]
+		[convert, editor]
+	);
+
+	// Repoint the nodes as soon as the draft save persists their attachments.
+	useEffect(() => {
+		if (pendingRef.current.size === 0) {
+			return;
+		}
+		pendingRef.current.forEach((key, contentId) => {
+			const saved = savedAttachments?.find(
+				(attachment) =>
+					attachment.isInline &&
+					attachment.contentId !== undefined &&
+					areContentIdsEqual(attachment.contentId, contentId)
+			);
+			if (!saved) {
+				return;
+			}
+			const downloadServiceUrl = composeAttachmentDownloadUrl(saved);
+			if (downloadServiceUrl && saved.contentId) {
+				repointImageNode(
+					editor,
+					key,
+					downloadServiceUrl,
+					composeCidUrlFromContentId(saved.contentId) ?? undefined
+				);
+			}
+			pendingRef.current.delete(contentId);
+		});
+		if (pendingRef.current.size === 0) {
+			releaseWaiters();
+		}
+	}, [editor, releaseWaiters, savedAttachments]);
+
+	/**
+	 * Converts whatever is left and resolves once every image carries a cid.
+	 * Resolves anyway after a timeout: a stuck upload must not block the send.
+	 */
+	const ensureConverted = useCallback((): Promise<void> => {
+		startedRef.current = true;
+		convert();
+		if (pendingRef.current.size === 0) {
+			return Promise.resolve();
+		}
+		return new Promise<void>((resolve) => {
+			waitersRef.current.push(resolve);
+			setTimeout(resolve, TIMEOUTS.INLINE_IMAGES_CONVERSION);
+		});
+	}, [convert]);
+
+	useEffect(
+		() => registerInlineImageConverter(editorId, ensureConverted),
+		[editorId, ensureConverted]
 	);
 
 	return null;

--- a/src/views/app/detail-panel/edit/editor/plugins/inline-data-image-upload-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/inline-data-image-upload-plugin.tsx
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $dfs } from '@lexical/utils';
-import { $getNodeByKey, type NodeKey } from 'lexical';
+import { $getNodeByKey, type LexicalEditor, type NodeKey } from 'lexical';
 
-import { $isImageNode, ImageNode } from './nodes/image-node';
+import { $isImageNode } from './nodes/image-node';
 import { dataUriToFile, getDataUriFileName, isDataImageUri } from 'helpers/inline-images';
 import { useEditorAttachments } from 'store/editor/index';
 import { MailsEditorV2 } from 'types/editor';
@@ -17,6 +17,40 @@ import { MailsEditorV2 } from 'types/editor';
 type InlineDataImageUploadPluginProps = {
 	editorId: MailsEditorV2['id'];
 };
+
+type PendingDataUriImage = {
+	key: NodeKey;
+	src: string;
+};
+
+/**
+ * Collects the images still carrying a `data:` URI which have not been attempted
+ * yet. Must run inside an editor state read, since it walks the current tree.
+ */
+function $collectPendingDataUriImages(attemptedKeys: Set<NodeKey>): Array<PendingDataUriImage> {
+	return $dfs().reduce<Array<PendingDataUriImage>>((pending, { node }) => {
+		if ($isImageNode(node) && !attemptedKeys.has(node.getKey()) && isDataImageUri(node.getSrc())) {
+			pending.push({ key: node.getKey(), src: node.getSrc() });
+		}
+		return pending;
+	}, []);
+}
+
+/** Points an image node at its uploaded counterpart, cid included. */
+function repointImageNode(
+	editor: LexicalEditor,
+	key: NodeKey,
+	src: string,
+	cidUrl: string | undefined
+): void {
+	editor.update(() => {
+		const node = $getNodeByKey(key);
+		if ($isImageNode(node)) {
+			node.setSrc(src);
+			node.setCidUrl(cidUrl);
+		}
+	});
+}
 
 /**
  * Turns base64 `data:` images into real inline attachments.
@@ -47,46 +81,37 @@ export const InlineDataImageUploadPlugin = ({
 	const attemptedKeysRef = useRef<Set<NodeKey>>(new Set());
 	const uploadCountRef = useRef(0);
 
-	useEffect(() => {
-		const uploadImage = (key: NodeKey, dataUri: string): void => {
+	const uploadImage = useCallback(
+		({ key, src }: PendingDataUriImage): void => {
 			attemptedKeysRef.current.add(key);
 			uploadCountRef.current += 1;
-			const file = dataUriToFile(dataUri, getDataUriFileName(dataUri, uploadCountRef.current));
+			const file = dataUriToFile(src, getDataUriFileName(src, uploadCountRef.current));
 			if (!file) {
 				return;
 			}
 
 			addInlineAttachments([file], {
-				onSaveComplete: (inlineAttachments) => {
+				onSaveComplete: (inlineAttachments): void => {
 					const { downloadServiceUrl, cidUrl } = inlineAttachments[0] ?? {};
-					if (!downloadServiceUrl) {
-						return;
+					if (downloadServiceUrl) {
+						repointImageNode(editor, key, downloadServiceUrl, cidUrl);
 					}
-					editor.update(() => {
-						const node = $getNodeByKey(key);
-						if ($isImageNode(node)) {
-							node.setSrc(downloadServiceUrl);
-							node.setCidUrl(cidUrl);
-						}
-					});
 				}
 			});
-		};
+		},
+		[addInlineAttachments, editor]
+	);
 
-		return editor.registerUpdateListener(({ editorState }) => {
-			const dataImages = editorState.read(() =>
-				$dfs()
-					.map(({ node }) => node)
-					.filter((node): node is ImageNode => $isImageNode(node))
-					.filter(
-						(node) => !attemptedKeysRef.current.has(node.getKey()) && isDataImageUri(node.getSrc())
-					)
-					.map((node) => ({ key: node.getKey(), src: node.getSrc() }))
-			);
-
-			dataImages.forEach(({ key, src }) => uploadImage(key, src));
-		});
-	}, [addInlineAttachments, editor]);
+	useEffect(
+		() =>
+			editor.registerUpdateListener(({ editorState }) => {
+				const pending = editorState.read(() =>
+					$collectPendingDataUriImages(attemptedKeysRef.current)
+				);
+				pending.forEach(uploadImage);
+			}),
+		[editor, uploadImage]
+	);
 
 	return null;
 };

--- a/src/views/app/detail-panel/edit/editor/plugins/inline-data-image-upload-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/inline-data-image-upload-plugin.tsx
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useEffect, useRef } from 'react';
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $dfs } from '@lexical/utils';
+import { $getNodeByKey, type NodeKey } from 'lexical';
+
+import { $isImageNode, ImageNode } from './nodes/image-node';
+import { dataUriToFile, getDataUriFileName, isDataImageUri } from 'helpers/inline-images';
+import { useEditorAttachments } from 'store/editor/index';
+import { MailsEditorV2 } from 'types/editor';
+
+type InlineDataImageUploadPluginProps = {
+	editorId: MailsEditorV2['id'];
+};
+
+/**
+ * Turns base64 `data:` images into real inline attachments.
+ *
+ * A signature is stored as a self-contained HTML snippet, so an image embedded
+ * in it can only travel as a `data:` URI: while it is being edited in the
+ * settings there is no draft to attach it to. Left as such in a sent message
+ * that URI is stripped by several mail clients (Gmail among them), so as soon as
+ * such an image lands in the composer — with the signature, or from an HTML
+ * paste — it is uploaded as an inline attachment and the node is rewritten to
+ * point at the upload. That restores the cid bookkeeping the rest of the compose
+ * pipeline relies on (`exportDOM` writes `data-pnsrc`, then
+ * `replaceServiceUrlWithCidUrl` puts the `cid:` src back on save draft / send)
+ * so the recipient gets a `multipart/related` part instead of base64 markup.
+ *
+ * Every node is attempted at most once, tracked by node key in
+ * `attemptedKeysRef`: the upload completes several editor updates after it is
+ * started, and a failed conversion must not be retried on each subsequent
+ * update. A content replacement (the store -> editor sync in
+ * `ControlledContentPlugin`) re-creates the nodes with fresh keys, so an image
+ * still carrying a `data:` URI at that point is legitimately attempted again.
+ */
+export const InlineDataImageUploadPlugin = ({
+	editorId
+}: InlineDataImageUploadPluginProps): null => {
+	const [editor] = useLexicalComposerContext();
+	const { addInlineAttachments } = useEditorAttachments(editorId);
+	const attemptedKeysRef = useRef<Set<NodeKey>>(new Set());
+	const uploadCountRef = useRef(0);
+
+	useEffect(() => {
+		const uploadImage = (key: NodeKey, dataUri: string): void => {
+			attemptedKeysRef.current.add(key);
+			uploadCountRef.current += 1;
+			const file = dataUriToFile(dataUri, getDataUriFileName(dataUri, uploadCountRef.current));
+			if (!file) {
+				return;
+			}
+
+			addInlineAttachments([file], {
+				onSaveComplete: (inlineAttachments) => {
+					const { downloadServiceUrl, cidUrl } = inlineAttachments[0] ?? {};
+					if (!downloadServiceUrl) {
+						return;
+					}
+					editor.update(() => {
+						const node = $getNodeByKey(key);
+						if ($isImageNode(node)) {
+							node.setSrc(downloadServiceUrl);
+							node.setCidUrl(cidUrl);
+						}
+					});
+				}
+			});
+		};
+
+		return editor.registerUpdateListener(({ editorState }) => {
+			const dataImages = editorState.read(() =>
+				$dfs()
+					.map(({ node }) => node)
+					.filter((node): node is ImageNode => $isImageNode(node))
+					.filter(
+						(node) => !attemptedKeysRef.current.has(node.getKey()) && isDataImageUri(node.getSrc())
+					)
+					.map((node) => ({ key: node.getKey(), src: node.getSrc() }))
+			);
+
+			dataImages.forEach(({ key, src }) => uploadImage(key, src));
+		});
+	}, [addInlineAttachments, editor]);
+
+	return null;
+};

--- a/src/views/app/detail-panel/edit/editor/plugins/inline-image-conversion-registry.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/inline-image-conversion-registry.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { MailsEditorV2 } from 'types/editor';
+
+/**
+ * Lets the send handlers ask the mounted editor to finish converting any `data:`
+ * image still in the body before the message leaves.
+ *
+ * The conversion itself lives in `InlineDataImageUploadPlugin`, which normally
+ * runs it on the first real edit. A message can however be sent without ever
+ * editing it (reply or forward with the signature only), and the compose board
+ * unmounts as soon as the send countdown starts, so the plugin cannot catch up
+ * afterwards. The send handler therefore triggers the conversion itself, while
+ * the board — and the plugin — are still mounted.
+ */
+type EnsureInlineImagesConverted = () => Promise<void>;
+
+const converters = new Map<MailsEditorV2['id'], EnsureInlineImagesConverted>();
+
+/**
+ * Registers the converter of an editor. Returns the cleanup to be run on
+ * unmount.
+ */
+export const registerInlineImageConverter = (
+	editorId: MailsEditorV2['id'],
+	ensureConverted: EnsureInlineImagesConverted
+): (() => void) => {
+	converters.set(editorId, ensureConverted);
+	return (): void => {
+		if (converters.get(editorId) === ensureConverted) {
+			converters.delete(editorId);
+		}
+	};
+};
+
+/**
+ * Converts the `data:` images still present in the given editor and resolves
+ * once they carry a cid, or immediately when there is nothing to convert and
+ * when no editor is mounted (a plain text editor, or an already closed board).
+ *
+ * It never rejects: a failed conversion must not prevent the message from being
+ * sent, it only means the image travels as it is.
+ */
+export const ensureInlineImagesConverted = (editorId: MailsEditorV2['id']): Promise<void> =>
+	converters.get(editorId)?.() ?? Promise.resolve();

--- a/src/views/app/detail-panel/edit/editor/plugins/nodes/image-node.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/nodes/image-node.tsx
@@ -253,6 +253,11 @@ export class ImageNode extends DecoratorNode<React.JSX.Element> {
 		writable.__src = src;
 	}
 
+	setCidUrl(cidUrl: string | undefined): void {
+		const writable = this.getWritable();
+		writable.__cidUrl = cidUrl;
+	}
+
 	setAltText(altText: string): void {
 		const writable = this.getWritable();
 		writable.__altText = altText;

--- a/src/views/app/detail-panel/edit/editor/plugins/paste-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/paste-plugin.tsx
@@ -8,8 +8,7 @@ import { useEffect } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { COMMAND_PRIORITY_LOW, PASTE_COMMAND } from 'lexical';
 
-import { INSERT_INLINE_IMAGE_COMMAND } from './image-plugin';
-import { type ResolveInlineImages } from './rich-toolbar-plugin-hooks/use-image-actions';
+import { insertResolvedInlineImages, type ResolveInlineImages } from './image-plugin';
 
 type PastePluginProps = {
 	/**
@@ -63,17 +62,7 @@ export const PastePlugin = ({ onResolveInlineImages }: PastePluginProps): null =
 					}
 
 					event.preventDefault();
-					onResolveInlineImages(imageFiles, (images) => {
-						images.forEach((image) => {
-							if (image.src) {
-								editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
-									src: image.src,
-									cidUrl: image.cidUrl,
-									altText: 'Inline attachment'
-								});
-							}
-						});
-					});
+					onResolveInlineImages(imageFiles, (images) => insertResolvedInlineImages(editor, images));
 					return true;
 				},
 				COMMAND_PRIORITY_LOW

--- a/src/views/app/detail-panel/edit/editor/plugins/paste-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/paste-plugin.tsx
@@ -9,21 +9,26 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { COMMAND_PRIORITY_LOW, PASTE_COMMAND } from 'lexical';
 
 import { INSERT_INLINE_IMAGE_COMMAND } from './image-plugin';
-import { useEditorAttachments } from 'store/editor/index';
-import { MailsEditorV2 } from 'types/editor';
+import { type ResolveInlineImages } from './rich-toolbar-plugin-hooks/use-image-actions';
 
 type PastePluginProps = {
-	editorId: MailsEditorV2['id'];
+	/**
+	 * Resolves the pasted image files into sources the editor can display, the
+	 * same way the toolbar's "insert image from device" button does: an upload as
+	 * inline attachment in the mail composer, a `data:` URI in the signature
+	 * editor.
+	 */
+	onResolveInlineImages: ResolveInlineImages;
 };
 
 /**
- * cid-aware paste handling: image files in the clipboard are uploaded as inline
- * attachments and inserted as {@link ImageNode}s (preserving the cid), while
- * plain text and HTML paste fall through to the default RichTextPlugin handler.
+ * Paste handling for images: image files in the clipboard are resolved through
+ * {@link PastePluginProps.onResolveInlineImages} and inserted as
+ * {@link ImageNode}s (preserving the cid, when there is one), while plain text
+ * and HTML paste fall through to the default RichTextPlugin handler.
  */
-export const PastePlugin = ({ editorId }: PastePluginProps): null => {
+export const PastePlugin = ({ onResolveInlineImages }: PastePluginProps): null => {
 	const [editor] = useLexicalComposerContext();
-	const { addInlineAttachments } = useEditorAttachments(editorId);
 
 	useEffect(
 		() =>
@@ -58,24 +63,22 @@ export const PastePlugin = ({ editorId }: PastePluginProps): null => {
 					}
 
 					event.preventDefault();
-					addInlineAttachments(imageFiles, {
-						onSaveComplete: (inlineAttachments) => {
-							inlineAttachments.forEach((attachment) => {
-								if (attachment.downloadServiceUrl) {
-									editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
-										src: attachment.downloadServiceUrl,
-										cidUrl: attachment.cidUrl,
-										altText: 'Inline attachment'
-									});
-								}
-							});
-						}
+					onResolveInlineImages(imageFiles, (images) => {
+						images.forEach((image) => {
+							if (image.src) {
+								editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
+									src: image.src,
+									cidUrl: image.cidUrl,
+									altText: 'Inline attachment'
+								});
+							}
+						});
 					});
 					return true;
 				},
 				COMMAND_PRIORITY_LOW
 			),
-		[editor, addInlineAttachments]
+		[editor, onResolveInlineImages]
 	);
 
 	return null;

--- a/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin-hooks/use-image-actions.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin-hooks/use-image-actions.ts
@@ -16,10 +16,22 @@ import {
 } from '../image-plugin';
 import { type ImageAlignment } from '../nodes/image-node';
 
-export type UploadedInlineImage = {
-	downloadServiceUrl?: string;
+/**
+ * An image picked from the device, resolved into something the editor can
+ * display. How it is resolved depends on the host editor: the mail composer
+ * uploads the file as an inline attachment (so `src` is a download-service URL
+ * and `cidUrl` the matching cid), while the signature editor embeds it as a
+ * `data:` URI (so there is no cid).
+ */
+export type ResolvedInlineImage = {
+	src?: string;
 	cidUrl?: string;
 };
+
+export type ResolveInlineImages = (
+	files: File[],
+	onComplete: (images: ResolvedInlineImage[]) => void
+) => void;
 
 type ImageActions = {
 	alignImage: (alignment: ImageAlignment) => void;
@@ -32,10 +44,7 @@ type ImageActions = {
 
 export function useImageActions(
 	editor: LexicalEditor,
-	onUploadInlineImages?: (
-		files: File[],
-		onComplete: (attachments: UploadedInlineImage[]) => void
-	) => void
+	onResolveInlineImages?: ResolveInlineImages
 ): ImageActions {
 	const [imageModalOpen, setImageModalOpen] = useState(false);
 
@@ -66,15 +75,15 @@ export function useImageActions(
 	const onImageFilesSelected = useCallback(
 		(event: ChangeEvent<HTMLInputElement>): void => {
 			const fileList = event.target.files;
-			if (!fileList?.length || !onUploadInlineImages) {
+			if (!fileList?.length || !onResolveInlineImages) {
 				return;
 			}
-			onUploadInlineImages(Array.from(fileList), (inlineAttachments) => {
-				inlineAttachments.forEach((attachment) => {
-					if (attachment.downloadServiceUrl) {
+			onResolveInlineImages(Array.from(fileList), (images) => {
+				images.forEach((image) => {
+					if (image.src) {
 						editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
-							src: attachment.downloadServiceUrl,
-							cidUrl: attachment.cidUrl,
+							src: image.src,
+							cidUrl: image.cidUrl,
 							altText: 'Inline attachment'
 						});
 					}
@@ -82,7 +91,7 @@ export function useImageActions(
 			});
 			event.target.value = '';
 		},
-		[onUploadInlineImages, editor]
+		[onResolveInlineImages, editor]
 	);
 
 	const imageAlignItems = useMemo<Array<DropdownItem>>(

--- a/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin-hooks/use-image-actions.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin-hooks/use-image-actions.ts
@@ -10,28 +10,12 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { COMMAND_PRIORITY_LOW, type LexicalEditor } from 'lexical';
 
 import {
-	INSERT_INLINE_IMAGE_COMMAND,
+	insertResolvedInlineImages,
 	OPEN_IMAGE_MODAL_COMMAND,
-	SET_INLINE_IMAGE_ALIGNMENT_COMMAND
+	SET_INLINE_IMAGE_ALIGNMENT_COMMAND,
+	type ResolveInlineImages
 } from '../image-plugin';
 import { type ImageAlignment } from '../nodes/image-node';
-
-/**
- * An image picked from the device, resolved into something the editor can
- * display. How it is resolved depends on the host editor: the mail composer
- * uploads the file as an inline attachment (so `src` is a download-service URL
- * and `cidUrl` the matching cid), while the signature editor embeds it as a
- * `data:` URI (so there is no cid).
- */
-export type ResolvedInlineImage = {
-	src?: string;
-	cidUrl?: string;
-};
-
-export type ResolveInlineImages = (
-	files: File[],
-	onComplete: (images: ResolvedInlineImage[]) => void
-) => void;
 
 type ImageActions = {
 	alignImage: (alignment: ImageAlignment) => void;
@@ -78,17 +62,9 @@ export function useImageActions(
 			if (!fileList?.length || !onResolveInlineImages) {
 				return;
 			}
-			onResolveInlineImages(Array.from(fileList), (images) => {
-				images.forEach((image) => {
-					if (image.src) {
-						editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
-							src: image.src,
-							cidUrl: image.cidUrl,
-							altText: 'Inline attachment'
-						});
-					}
-				});
-			});
+			onResolveInlineImages(Array.from(fileList), (images) =>
+				insertResolvedInlineImages(editor, images)
+			);
 			event.target.value = '';
 		},
 		[onResolveInlineImages, editor]

--- a/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin.tsx
@@ -13,15 +13,13 @@ import { INDENT_CONTENT_COMMAND, OUTDENT_CONTENT_COMMAND } from 'lexical';
 
 import { ColorPickerToolbarButton } from './color-picker-toolbar-button';
 import { ImageModal } from './image-modal';
+import { type ResolveInlineImages } from './image-plugin';
 import { LinkModal } from './link-modal';
 import { useAlignmentAndDirection } from './rich-toolbar-plugin-hooks/use-alignment-and-direction';
 import { useBlockType } from './rich-toolbar-plugin-hooks/use-block-type';
 import { useEmojiAndSpecialCharacters } from './rich-toolbar-plugin-hooks/use-emoji-and-special-characters';
 import { useFontAndSizeSelects } from './rich-toolbar-plugin-hooks/use-font-and-size-selects';
-import {
-	useImageActions,
-	type ResolveInlineImages
-} from './rich-toolbar-plugin-hooks/use-image-actions';
+import { useImageActions } from './rich-toolbar-plugin-hooks/use-image-actions';
 import { useStylePatching } from './rich-toolbar-plugin-hooks/use-style-patching';
 import { useTableInsert } from './rich-toolbar-plugin-hooks/use-table-insert';
 import { useTextFormatting } from './rich-toolbar-plugin-hooks/use-text-formatting';
@@ -33,10 +31,7 @@ import { ToolbarIconButton } from './toolbar-icon-button';
 import { ToolbarSelect } from './toolbar-select';
 import { editorIcon } from '../icons/editor-icons';
 
-export type {
-	ResolvedInlineImage,
-	ResolveInlineImages
-} from './rich-toolbar-plugin-hooks/use-image-actions';
+export type { ResolvedInlineImage, ResolveInlineImages } from './image-plugin';
 
 /**
  * The file input behind the "insert image from device" button is hidden (it is

--- a/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin.tsx
@@ -20,7 +20,7 @@ import { useEmojiAndSpecialCharacters } from './rich-toolbar-plugin-hooks/use-em
 import { useFontAndSizeSelects } from './rich-toolbar-plugin-hooks/use-font-and-size-selects';
 import {
 	useImageActions,
-	type UploadedInlineImage
+	type ResolveInlineImages
 } from './rich-toolbar-plugin-hooks/use-image-actions';
 import { useStylePatching } from './rich-toolbar-plugin-hooks/use-style-patching';
 import { useTableInsert } from './rich-toolbar-plugin-hooks/use-table-insert';
@@ -33,7 +33,16 @@ import { ToolbarIconButton } from './toolbar-icon-button';
 import { ToolbarSelect } from './toolbar-select';
 import { editorIcon } from '../icons/editor-icons';
 
-export type { UploadedInlineImage } from './rich-toolbar-plugin-hooks/use-image-actions';
+export type {
+	ResolvedInlineImage,
+	ResolveInlineImages
+} from './rich-toolbar-plugin-hooks/use-image-actions';
+
+/**
+ * The file input behind the "insert image from device" button is hidden (it is
+ * driven by the button), so it can only be reached by test id.
+ */
+export const INLINE_IMAGE_FILE_INPUT_TESTID = 'inline-image-file-input';
 
 type RichToolbarPluginProps = {
 	/** Whether the "Show blocks" view aid (dashed block outlines) is active. */
@@ -41,14 +50,12 @@ type RichToolbarPluginProps = {
 	/** Toggles the "Show blocks" view aid. */
 	onToggleShowBlocks: () => void;
 	/**
-	 * Uploads image files picked from the "insert image from device" button and
-	 * hands back their resolved URLs. When omitted, that button is hidden — the
-	 * store-agnostic "insert image from URL" button is always available.
+	 * Resolves the image files picked from the "insert image from device" button
+	 * into sources the editor can display (an upload in the mail composer, a
+	 * `data:` URI in the signature editor). When omitted, that button is hidden —
+	 * the store-agnostic "insert image from URL" button is always available.
 	 */
-	onUploadInlineImages?: (
-		files: File[],
-		onComplete: (attachments: UploadedInlineImage[]) => void
-	) => void;
+	onResolveInlineImages?: ResolveInlineImages;
 	/** Account's default font family, used as the font selector's default value. */
 	fontFamily?: string;
 	/** Account's default font size, used as the size selector's default value. */
@@ -58,7 +65,7 @@ type RichToolbarPluginProps = {
 export const RichToolbarPlugin = ({
 	showBlocks,
 	onToggleShowBlocks,
-	onUploadInlineImages,
+	onResolveInlineImages,
 	fontFamily,
 	fontSize
 }: RichToolbarPluginProps): React.JSX.Element => {
@@ -90,7 +97,7 @@ export const RichToolbarPlugin = ({
 		onImageFilesSelected,
 		imageModalOpen,
 		setImageModalOpen
-	} = useImageActions(editor, onUploadInlineImages);
+	} = useImageActions(editor, onResolveInlineImages);
 	const { tableItems, tableLabel, tableMenuOpen, setTableMenuOpen } = useTableInsert(editor);
 	const {
 		emojiItems,
@@ -305,7 +312,7 @@ export const RichToolbarPlugin = ({
 					/>
 				</Dropdown>
 			</Tooltip>
-			{onUploadInlineImages && (
+			{onResolveInlineImages && (
 				<ToolbarIconButton
 					icon={editorIcon('image')}
 					label={t('lexical-label.image', 'Image')}
@@ -405,6 +412,7 @@ export const RichToolbarPlugin = ({
 
 			<input
 				ref={fileInputRef}
+				data-testid={INLINE_IMAGE_FILE_INPUT_TESTID}
 				type="file"
 				accept="image/*"
 				multiple

--- a/src/views/app/detail-panel/edit/editor/plugins/tests/inline-data-image-upload-plugin.test.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/tests/inline-data-image-upload-plugin.test.tsx
@@ -5,17 +5,23 @@
  */
 import React from 'react';
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 
 import { setupTest, screen, within } from '@test-setup';
 import { setupEditorStore } from '__test__/generators/editor-store';
+import { TIMEOUTS } from 'constants/index';
 import { generateNewMessageEditor } from 'store/editor/editor-generators';
 import * as editorStoreIndex from 'store/editor/index';
+import { useEditorsStore } from 'store/editor/store';
+import { SavedAttachment, UnsavedAttachment } from 'types/attachments';
 import { RichTextEditorContainer } from 'views/app/detail-panel/edit/editor/parts/rich-text-editor-container';
+import { ensureInlineImagesConverted } from 'views/app/detail-panel/edit/editor/plugins/inline-image-conversion-registry';
 
 const EDITOR_TESTID = 'edit-view-editor';
-const DOWNLOAD_URL = 'https://service/inline.png';
-const CID_URL = 'cid:inline@carbonio';
+const MESSAGE_ID = '42';
+const PART_NAME = '2';
+const CONTENT_ID = 'inline-1@carbonio';
+const DOWNLOAD_URL = `/service/home/~/?auth=co&id=${MESSAGE_ID}&part=${PART_NAME}`;
 
 /** A 1x1 transparent PNG, as it would be embedded in a signature. */
 const PNG_DATA_URI =
@@ -25,9 +31,32 @@ type AddInlineAttachments = ReturnType<
 	typeof editorStoreIndex.useEditorAttachments
 >['addInlineAttachments'];
 
+function unsavedInlineAttachment(contentId: string): UnsavedAttachment {
+	return {
+		filename: 'inline-image-1.png',
+		contentType: 'image/png',
+		size: 70,
+		isInline: true,
+		contentId,
+		uploadId: contentId.replace('@carbonio', '')
+	};
+}
+
+function savedInlineAttachment(contentId: string): SavedAttachment {
+	return {
+		messageId: MESSAGE_ID,
+		partName: PART_NAME,
+		filename: 'inline-image-1.png',
+		contentType: 'image/png',
+		size: 70,
+		isInline: true,
+		contentId
+	};
+}
+
 /**
  * Replaces `useEditorAttachments` so the conversion's upload step resolves
- * synchronously with a ready-to-use inline attachment.
+ * synchronously, returning the unsaved attachments the real one would.
  */
 function mockEditorAttachments(addInlineAttachments: AddInlineAttachments): void {
 	vi.spyOn(editorStoreIndex, 'useEditorAttachments').mockReturnValue({
@@ -38,11 +67,19 @@ function mockEditorAttachments(addInlineAttachments: AddInlineAttachments): void
 	} as unknown as ReturnType<typeof editorStoreIndex.useEditorAttachments>);
 }
 
-function renderEditorWith(richText: string): void {
+function setupEditorWith(richText: string): string {
 	const editor = generateNewMessageEditor();
 	editor.text = { plainText: '', richText };
 	setupEditorStore({ editors: [editor] });
 	setupTest(<RichTextEditorContainer editorId={editor.id} onDragOver={vi.fn()} />);
+	return editor.id;
+}
+
+/** Simulates the draft save persisting the uploaded inline attachment. */
+function persistInlineAttachment(editorId: string, contentId: string): void {
+	act(() => {
+		useEditorsStore.getState().setSavedAttachments(editorId, [savedInlineAttachment(contentId)]);
+	});
 }
 
 describe('InlineDataImageUploadPlugin', () => {
@@ -50,71 +87,206 @@ describe('InlineDataImageUploadPlugin', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('uploads a data URI image as an inline attachment and repoints the node at it', async () => {
-		const addInlineAttachments = vi.fn((_files, { onSaveComplete }) => {
-			onSaveComplete([{ downloadServiceUrl: DOWNLOAD_URL, cidUrl: CID_URL }]);
-		}) as unknown as AddInlineAttachments;
+	it('does not upload anything until the message is actually edited', async () => {
+		const addInlineAttachments = vi.fn() as unknown as AddInlineAttachments;
 		mockEditorAttachments(addInlineAttachments);
 
-		renderEditorWith(`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`);
+		setupEditorWith(`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`);
+
+		// The image is displayed, but opening a compose window must not create a
+		// draft nor upload an attachment for a message the user has not written.
+		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+		expect(image).toHaveAttribute('src', PNG_DATA_URI);
+		await waitFor(() => {
+			expect(addInlineAttachments).not.toHaveBeenCalled();
+		});
+	});
+
+	it('uploads the data URI image once the editor becomes dirty', async () => {
+		const addInlineAttachments = vi.fn(() => [
+			unsavedInlineAttachment(CONTENT_ID)
+		]) as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		const editorId = setupEditorWith(
+			`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`
+		);
+		await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+
+		act(() => {
+			useEditorsStore.getState().setIsDirty(editorId, true);
+		});
 
 		await waitFor(() => {
 			expect(addInlineAttachments).toHaveBeenCalledTimes(1);
 		});
-
-		// The data URI is decoded back into a real file, so it can be uploaded and
-		// sent as a multipart/related part instead of base64 markup in the body.
-		const [uploadedFiles] = vi.mocked(addInlineAttachments).mock.calls[0];
-		expect(uploadedFiles).toHaveLength(1);
-		expect(uploadedFiles[0]).toBeInstanceOf(File);
-		expect(uploadedFiles[0].type).toBe('image/png');
-		expect(uploadedFiles[0].size).toBeGreaterThan(0);
-
-		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
-		await waitFor(() => {
-			expect(image).toHaveAttribute('src', DOWNLOAD_URL);
-		});
+		// The draft has to be saved at once, otherwise the body keeps the data URI
+		// until the auto-save interval elapses.
+		expect(addInlineAttachments).toHaveBeenCalledWith(
+			[expect.any(File)],
+			expect.objectContaining({ saveImmediately: true })
+		);
 	});
 
-	it('converts each data URI image only once', async () => {
-		const addInlineAttachments = vi.fn((_files, { onSaveComplete }) => {
-			onSaveComplete([{ downloadServiceUrl: DOWNLOAD_URL, cidUrl: CID_URL }]);
-		}) as unknown as AddInlineAttachments;
+	it('repoints the node once the draft save persists the attachment', async () => {
+		const addInlineAttachments = vi.fn(() => [
+			unsavedInlineAttachment(CONTENT_ID)
+		]) as unknown as AddInlineAttachments;
 		mockEditorAttachments(addInlineAttachments);
 
-		renderEditorWith(`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`);
-
+		const editorId = setupEditorWith(
+			`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`
+		);
 		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+
+		act(() => {
+			useEditorsStore.getState().setIsDirty(editorId, true);
+		});
+		await waitFor(() => {
+			expect(addInlineAttachments).toHaveBeenCalledTimes(1);
+		});
+
+		persistInlineAttachment(editorId, CONTENT_ID);
+
 		await waitFor(() => {
 			expect(image).toHaveAttribute('src', DOWNLOAD_URL);
 		});
-		expect(addInlineAttachments).toHaveBeenCalledTimes(1);
 	});
 
-	it('leaves an already uploaded inline image untouched', async () => {
+	it('uploads every data URI image of the signature in a single batch', async () => {
+		const addInlineAttachments = vi.fn(() => [
+			unsavedInlineAttachment('inline-1@carbonio'),
+			unsavedInlineAttachment('inline-2@carbonio')
+		]) as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		const editorId = setupEditorWith(
+			`<p><img src="${PNG_DATA_URI}" alt="one" /><img src="${PNG_DATA_URI}" alt="two" /></p>`
+		);
+		await within(screen.getByTestId(EDITOR_TESTID)).findAllByRole('img');
+
+		act(() => {
+			useEditorsStore.getState().setIsDirty(editorId, true);
+		});
+
+		// A single call: one upload batch means one draft save, so no completion
+		// is lost to the save debounce.
+		await waitFor(() => {
+			expect(addInlineAttachments).toHaveBeenCalledTimes(1);
+		});
+		const [uploadedFiles] = vi.mocked(addInlineAttachments).mock.calls[0];
+		expect(uploadedFiles).toHaveLength(2);
+	});
+
+	it('converts on demand for a message sent without being edited', async () => {
+		const addInlineAttachments = vi.fn(() => [
+			unsavedInlineAttachment(CONTENT_ID)
+		]) as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		const editorId = setupEditorWith(
+			`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`
+		);
+		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+		expect(addInlineAttachments).not.toHaveBeenCalled();
+
+		// What the send handlers do before handing the message over.
+		let converted = false;
+		act(() => {
+			ensureInlineImagesConverted(editorId).then(() => {
+				converted = true;
+			});
+		});
+
+		await waitFor(() => {
+			expect(addInlineAttachments).toHaveBeenCalledTimes(1);
+		});
+		expect(converted).toBe(false);
+
+		persistInlineAttachment(editorId, CONTENT_ID);
+
+		await waitFor(() => {
+			expect(converted).toBe(true);
+		});
+		expect(image).toHaveAttribute('src', DOWNLOAD_URL);
+	});
+
+	it('resolves the on demand conversion even if the attachment is never persisted', async () => {
+		const addInlineAttachments = vi.fn(() => [
+			unsavedInlineAttachment(CONTENT_ID)
+		]) as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		const editorId = setupEditorWith(
+			`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`
+		);
+		await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+
+		// The draft save never completes: the send must still go through rather
+		// than hang forever, even if it means the image travels as it is.
+		let converted = false;
+		act(() => {
+			ensureInlineImagesConverted(editorId).then(() => {
+				converted = true;
+			});
+		});
+		await waitFor(() => {
+			expect(addInlineAttachments).toHaveBeenCalledTimes(1);
+		});
+		expect(converted).toBe(false);
+
+		act(() => {
+			vi.advanceTimersByTime(TIMEOUTS.INLINE_IMAGES_CONVERSION);
+		});
+
+		await waitFor(() => {
+			expect(converted).toBe(true);
+		});
+	});
+
+	it('resolves the on demand conversion immediately when there is nothing to convert', async () => {
 		const addInlineAttachments = vi.fn() as unknown as AddInlineAttachments;
 		mockEditorAttachments(addInlineAttachments);
 
-		renderEditorWith(
-			`<p><img src="${DOWNLOAD_URL}" data-pnsrc="${CID_URL}" alt="Inline attachment" /></p>`
-		);
+		const editorId = setupEditorWith('<p>no images here</p>');
+		await within(screen.getByTestId(EDITOR_TESTID)).findByText('no images here');
 
-		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
-		expect(image).toHaveAttribute('src', DOWNLOAD_URL);
-		await waitFor(() => {
-			expect(addInlineAttachments).not.toHaveBeenCalled();
-		});
+		await expect(ensureInlineImagesConverted(editorId)).resolves.toBeUndefined();
+		expect(addInlineAttachments).not.toHaveBeenCalled();
 	});
 
 	it('does not attempt to upload a data URI which is not an image', async () => {
 		const addInlineAttachments = vi.fn() as unknown as AddInlineAttachments;
 		mockEditorAttachments(addInlineAttachments);
 
-		renderEditorWith(
+		const editorId = setupEditorWith(
 			'<p><img src="data:text/plain;base64,aGVsbG8=" alt="Inline attachment" /></p>'
 		);
-
 		await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+
+		act(() => {
+			useEditorsStore.getState().setIsDirty(editorId, true);
+		});
+
+		await waitFor(() => {
+			expect(addInlineAttachments).not.toHaveBeenCalled();
+		});
+	});
+
+	it('leaves an already uploaded inline image untouched', async () => {
+		const addInlineAttachments = vi.fn() as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		const editorId = setupEditorWith(
+			`<p><img src="${DOWNLOAD_URL}" data-pnsrc="cid:${CONTENT_ID}" alt="Inline attachment" /></p>`
+		);
+		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+
+		act(() => {
+			useEditorsStore.getState().setIsDirty(editorId, true);
+		});
+
+		expect(image).toHaveAttribute('src', DOWNLOAD_URL);
 		await waitFor(() => {
 			expect(addInlineAttachments).not.toHaveBeenCalled();
 		});

--- a/src/views/app/detail-panel/edit/editor/plugins/tests/inline-data-image-upload-plugin.test.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/tests/inline-data-image-upload-plugin.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { waitFor } from '@testing-library/react';
+
+import { setupTest, screen, within } from '@test-setup';
+import { setupEditorStore } from '__test__/generators/editor-store';
+import { generateNewMessageEditor } from 'store/editor/editor-generators';
+import * as editorStoreIndex from 'store/editor/index';
+import { RichTextEditorContainer } from 'views/app/detail-panel/edit/editor/parts/rich-text-editor-container';
+
+const EDITOR_TESTID = 'edit-view-editor';
+const DOWNLOAD_URL = 'https://service/inline.png';
+const CID_URL = 'cid:inline@carbonio';
+
+/** A 1x1 transparent PNG, as it would be embedded in a signature. */
+const PNG_DATA_URI =
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==';
+
+type AddInlineAttachments = ReturnType<
+	typeof editorStoreIndex.useEditorAttachments
+>['addInlineAttachments'];
+
+/**
+ * Replaces `useEditorAttachments` so the conversion's upload step resolves
+ * synchronously with a ready-to-use inline attachment.
+ */
+function mockEditorAttachments(addInlineAttachments: AddInlineAttachments): void {
+	vi.spyOn(editorStoreIndex, 'useEditorAttachments').mockReturnValue({
+		addInlineAttachments,
+		keepOnlyInlineAttachments: vi.fn(),
+		addStandardAttachments: vi.fn(),
+		addUploadedAttachment: vi.fn()
+	} as unknown as ReturnType<typeof editorStoreIndex.useEditorAttachments>);
+}
+
+function renderEditorWith(richText: string): void {
+	const editor = generateNewMessageEditor();
+	editor.text = { plainText: '', richText };
+	setupEditorStore({ editors: [editor] });
+	setupTest(<RichTextEditorContainer editorId={editor.id} onDragOver={vi.fn()} />);
+}
+
+describe('InlineDataImageUploadPlugin', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('uploads a data URI image as an inline attachment and repoints the node at it', async () => {
+		const addInlineAttachments = vi.fn((_files, { onSaveComplete }) => {
+			onSaveComplete([{ downloadServiceUrl: DOWNLOAD_URL, cidUrl: CID_URL }]);
+		}) as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		renderEditorWith(`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`);
+
+		await waitFor(() => {
+			expect(addInlineAttachments).toHaveBeenCalledTimes(1);
+		});
+
+		// The data URI is decoded back into a real file, so it can be uploaded and
+		// sent as a multipart/related part instead of base64 markup in the body.
+		const [uploadedFiles] = vi.mocked(addInlineAttachments).mock.calls[0];
+		expect(uploadedFiles).toHaveLength(1);
+		expect(uploadedFiles[0]).toBeInstanceOf(File);
+		expect(uploadedFiles[0].type).toBe('image/png');
+		expect(uploadedFiles[0].size).toBeGreaterThan(0);
+
+		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+		await waitFor(() => {
+			expect(image).toHaveAttribute('src', DOWNLOAD_URL);
+		});
+	});
+
+	it('converts each data URI image only once', async () => {
+		const addInlineAttachments = vi.fn((_files, { onSaveComplete }) => {
+			onSaveComplete([{ downloadServiceUrl: DOWNLOAD_URL, cidUrl: CID_URL }]);
+		}) as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		renderEditorWith(`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`);
+
+		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+		await waitFor(() => {
+			expect(image).toHaveAttribute('src', DOWNLOAD_URL);
+		});
+		expect(addInlineAttachments).toHaveBeenCalledTimes(1);
+	});
+
+	it('leaves an already uploaded inline image untouched', async () => {
+		const addInlineAttachments = vi.fn() as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		renderEditorWith(
+			`<p><img src="${DOWNLOAD_URL}" data-pnsrc="${CID_URL}" alt="Inline attachment" /></p>`
+		);
+
+		const image = await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+		expect(image).toHaveAttribute('src', DOWNLOAD_URL);
+		await waitFor(() => {
+			expect(addInlineAttachments).not.toHaveBeenCalled();
+		});
+	});
+
+	it('does not attempt to upload a data URI which is not an image', async () => {
+		const addInlineAttachments = vi.fn() as unknown as AddInlineAttachments;
+		mockEditorAttachments(addInlineAttachments);
+
+		renderEditorWith(
+			'<p><img src="data:text/plain;base64,aGVsbG8=" alt="Inline attachment" /></p>'
+		);
+
+		await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+		await waitFor(() => {
+			expect(addInlineAttachments).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/views/app/detail-panel/edit/editor/plugins/tests/inline-image-conversion-registry.test.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/tests/inline-image-conversion-registry.test.ts
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import {
+	ensureInlineImagesConverted,
+	registerInlineImageConverter
+} from 'views/app/detail-panel/edit/editor/plugins/inline-image-conversion-registry';
+
+const EDITOR_ID = 'editor-1';
+
+describe('inline image conversion registry', () => {
+	it('resolves when no editor is registered, so the send is never blocked', async () => {
+		await expect(ensureInlineImagesConverted('never-registered')).resolves.toBeUndefined();
+	});
+
+	it('delegates to the registered converter', async () => {
+		const ensureConverted = vi.fn().mockResolvedValue(undefined);
+		const unregister = registerInlineImageConverter(EDITOR_ID, ensureConverted);
+
+		await ensureInlineImagesConverted(EDITOR_ID);
+
+		expect(ensureConverted).toHaveBeenCalledTimes(1);
+		unregister();
+	});
+
+	it('stops delegating once the editor unmounts', async () => {
+		const ensureConverted = vi.fn().mockResolvedValue(undefined);
+		const unregister = registerInlineImageConverter(EDITOR_ID, ensureConverted);
+
+		unregister();
+		await ensureInlineImagesConverted(EDITOR_ID);
+
+		expect(ensureConverted).not.toHaveBeenCalled();
+	});
+
+	it('keeps the converters of the other editors isolated', async () => {
+		const first = vi.fn().mockResolvedValue(undefined);
+		const second = vi.fn().mockResolvedValue(undefined);
+		const unregisterFirst = registerInlineImageConverter('editor-a', first);
+		const unregisterSecond = registerInlineImageConverter('editor-b', second);
+
+		await ensureInlineImagesConverted('editor-b');
+
+		expect(first).not.toHaveBeenCalled();
+		expect(second).toHaveBeenCalledTimes(1);
+		unregisterFirst();
+		unregisterSecond();
+	});
+
+	it('does not let a stale unregister drop the converter of a remounted editor', async () => {
+		const stale = vi.fn().mockResolvedValue(undefined);
+		const current = vi.fn().mockResolvedValue(undefined);
+		const unregisterStale = registerInlineImageConverter(EDITOR_ID, stale);
+		const unregisterCurrent = registerInlineImageConverter(EDITOR_ID, current);
+
+		// React can run the previous effect's cleanup after the new one registered.
+		unregisterStale();
+		await ensureInlineImagesConverted(EDITOR_ID);
+
+		expect(current).toHaveBeenCalledTimes(1);
+		unregisterCurrent();
+	});
+});

--- a/src/views/settings/components/signature-rich-text-editor.tsx
+++ b/src/views/settings/components/signature-rich-text-editor.tsx
@@ -23,6 +23,7 @@ import { TableCellNode, TableNode, TableRowNode } from '@lexical/table';
 import { useUserSettings } from '@zextras/carbonio-shell-ui';
 import { $getRoot, $insertNodes, type EditorState, type LexicalEditor } from 'lexical';
 
+import { isImageFile, readFileAsDataUri } from 'helpers/inline-images';
 import { DEFAULT_FONT_FAMILY } from 'helpers/user-preference-styles';
 import { LexicalWrapper } from 'views/app/detail-panel/edit/editor/parts/rich-text-editor-container';
 import { AutoLinkPlugin } from 'views/app/detail-panel/edit/editor/plugins/auto-link-plugin';
@@ -30,7 +31,11 @@ import { FloatingLinkEditorPlugin } from 'views/app/detail-panel/edit/editor/plu
 import { STYLE_PRESERVING_HTML_IMPORT } from 'views/app/detail-panel/edit/editor/plugins/html-import-style';
 import { ImagePlugin } from 'views/app/detail-panel/edit/editor/plugins/image-plugin';
 import { ImageNode } from 'views/app/detail-panel/edit/editor/plugins/nodes/image-node';
-import { RichToolbarPlugin } from 'views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin';
+import { PastePlugin } from 'views/app/detail-panel/edit/editor/plugins/paste-plugin';
+import {
+	RichToolbarPlugin,
+	type ResolvedInlineImage
+} from 'views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin';
 import { TableActionMenuPlugin } from 'views/app/detail-panel/edit/editor/plugins/table-action-menu-plugin';
 import { TableCellResizerPlugin } from 'views/app/detail-panel/edit/editor/plugins/table-cell-resizer-plugin';
 import { TableHoverActionsPlugin } from 'views/app/detail-panel/edit/editor/plugins/table-hover-actions-plugin';
@@ -116,11 +121,38 @@ const SignatureContentSyncPlugin = ({
 };
 
 /**
+ * Resolves the images picked from the toolbar (or pasted) into `data:` URIs.
+ *
+ * A signature has no draft to attach files to, so an inline image can only be
+ * embedded in the signature's own HTML. It is converted into a real inline
+ * attachment later, by `InlineDataImageUploadPlugin`, once the signature reaches
+ * a mail composer — a `data:` URI left in a sent message would be stripped by
+ * several mail clients.
+ */
+const resolveInlineImagesAsDataUris = (
+	files: File[],
+	onComplete: (images: ResolvedInlineImage[]) => void
+): void => {
+	const images = files.filter(isImageFile);
+	if (images.length === 0) {
+		return;
+	}
+	Promise.all(images.map((file) => readFileAsDataUri(file).catch(() => undefined))).then(
+		(dataUris) => {
+			onComplete(
+				dataUris.filter((src): src is string => src !== undefined).map((src) => ({ src }))
+			);
+		}
+	);
+};
+
+/**
  * Store-agnostic rich text editor for editing a signature's HTML `description`,
  * built from the same Lexical nodes/plugins as the mail composer's
  * `RichTextEditorContainer`, minus the mail-only nodes (`SignatureNode`,
- * `QuotedSeparatorNode`) and the attachment-upload path of `RichToolbarPlugin`
- * (a signature has no draft/attachments to upload against).
+ * `QuotedSeparatorNode`). Inline images are embedded as `data:` URIs instead of
+ * being uploaded as attachments, since a signature has no draft to attach them
+ * to (see {@link resolveInlineImagesAsDataUris}).
  */
 export const SignatureRichTextEditor = ({
 	value,
@@ -184,6 +216,7 @@ export const SignatureRichTextEditor = ({
 					<RichToolbarPlugin
 						showBlocks={showBlocks}
 						onToggleShowBlocks={(): void => setShowBlocks((previous) => !previous)}
+						onResolveInlineImages={resolveInlineImagesAsDataUris}
 					/>
 				</div>
 				<div className={`editor-inner${showBlocks ? ' mails-lexical-show-blocks' : ''}`}>
@@ -208,6 +241,7 @@ export const SignatureRichTextEditor = ({
 				<TableCellResizerPlugin />
 				<TableHoverActionsPlugin />
 				<ImagePlugin />
+				<PastePlugin onResolveInlineImages={resolveInlineImagesAsDataUris} />
 				<SignatureContentSyncPlugin value={value} onChange={onChange} disabled={disabled} />
 			</LexicalWrapper>
 		</LexicalComposer>

--- a/src/views/settings/components/tests/signature-rich-text-editor.test.tsx
+++ b/src/views/settings/components/tests/signature-rich-text-editor.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+/* eslint-disable max-classes-per-file -- two minimal Event stubs cover a jsdom gap (see below) */
+import React from 'react';
+
+import { fireEvent, waitFor } from '@testing-library/react';
+
+import { setupTest, screen, within } from '@test-setup';
+import { INLINE_IMAGE_FILE_INPUT_TESTID } from 'views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin';
+import { SignatureRichTextEditor } from 'views/settings/components/signature-rich-text-editor';
+
+const CONTENT_TESTID = 'signature-editor-content-editable';
+const IMAGE_LABEL = 'lexical-label.image';
+const IMAGE_FROM_URL_LABEL = 'lexical-label.insert_image_url';
+
+/** A 1x1 transparent PNG, small enough to keep the expected data URI readable. */
+const PNG_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==';
+const PNG_DATA_URI = `data:image/png;base64,${PNG_BASE64}`;
+
+// jsdom (20) implements neither DragEvent nor ClipboardEvent, yet Lexical's
+// default paste handler does `instanceof` checks against both. Two distinct
+// no-op Event subclasses stand in so the checks resolve (rather than throwing a
+// ReferenceError) and the synthetic paste event is classified as a clipboard
+// paste, not a drag.
+class StubDragEvent extends Event {}
+class StubClipboardEvent extends Event {}
+
+function pngFile(name = 'logo.png'): File {
+	const bytes = Uint8Array.from(atob(PNG_BASE64), (char) => char.charCodeAt(0));
+	return new File([bytes], name, { type: 'image/png' });
+}
+
+type TestUser = ReturnType<typeof setupTest>['user'];
+
+function renderSignatureEditor(value = '<p>signature</p>'): {
+	onChange: ReturnType<typeof vi.fn>;
+	user: TestUser;
+} {
+	const onChange = vi.fn();
+	const { user } = setupTest(<SignatureRichTextEditor value={value} onChange={onChange} />);
+	return { onChange, user };
+}
+
+/** Picks files through the hidden input behind the toolbar's image button. */
+function selectFiles(user: TestUser, files: Array<File>): Promise<void> {
+	return user.upload(screen.getByTestId(INLINE_IMAGE_FILE_INPUT_TESTID), files);
+}
+
+/**
+ * Dispatches a synthetic paste event with a hand-built clipboard payload, since
+ * jsdom cannot represent files on a real `DataTransfer` / `userEvent.paste`.
+ */
+function pasteFileInto(target: HTMLElement, file: File): void {
+	// eslint-disable-next-line testing-library/prefer-user-event
+	fireEvent.paste(target, {
+		clipboardData: {
+			items: [{ kind: 'file', type: file.type, getAsFile: (): File => file }],
+			files: [],
+			getData: (): string => '',
+			types: []
+		}
+	});
+}
+
+describe('SignatureRichTextEditor', () => {
+	const globalScope = globalThis as Record<string, unknown>;
+	const originalDragEvent = globalScope.DragEvent;
+	const originalClipboardEvent = globalScope.ClipboardEvent;
+
+	beforeAll(() => {
+		globalScope.DragEvent = originalDragEvent ?? StubDragEvent;
+		globalScope.ClipboardEvent = originalClipboardEvent ?? StubClipboardEvent;
+	});
+
+	afterAll(() => {
+		globalScope.DragEvent = originalDragEvent;
+		globalScope.ClipboardEvent = originalClipboardEvent;
+	});
+
+	it('offers both the insert-image-from-device and the insert-image-from-URL buttons', () => {
+		renderSignatureEditor();
+
+		expect(screen.getByRole('button', { name: IMAGE_LABEL })).toBeVisible();
+		expect(screen.getByRole('button', { name: IMAGE_FROM_URL_LABEL })).toBeVisible();
+	});
+
+	it('embeds an image picked from the device as a data URI', async () => {
+		const { user } = renderSignatureEditor();
+
+		await selectFiles(user, [pngFile()]);
+
+		const image = await within(screen.getByTestId(CONTENT_TESTID)).findByRole('img');
+		expect(image).toHaveAttribute('src', PNG_DATA_URI);
+	});
+
+	it('reports the embedded image through onChange, so it can be saved with the signature', async () => {
+		const { user, onChange } = renderSignatureEditor();
+
+		await selectFiles(user, [pngFile()]);
+
+		await waitFor(() => {
+			expect(onChange).toHaveBeenCalledWith(expect.stringContaining(PNG_DATA_URI));
+		});
+	});
+
+	it('embeds a pasted image as a data URI', async () => {
+		renderSignatureEditor();
+		const content = screen.getByTestId(CONTENT_TESTID);
+
+		pasteFileInto(content, pngFile('pasted.png'));
+
+		const image = await within(content).findByRole('img');
+		expect(image).toHaveAttribute('src', PNG_DATA_URI);
+	});
+
+	it('renders a data URI image of a signature loaded from the server', async () => {
+		renderSignatureEditor(`<p><img src="${PNG_DATA_URI}" alt="Inline attachment" /></p>`);
+
+		const image = await within(screen.getByTestId(CONTENT_TESTID)).findByRole('img');
+		expect(image).toHaveAttribute('src', PNG_DATA_URI);
+	});
+
+	it('ignores a picked file which is not an image', async () => {
+		const { user } = renderSignatureEditor();
+
+		await selectFiles(user, [new File(['a document'], 'doc.pdf', { type: 'application/pdf' })]);
+
+		const content = screen.getByTestId(CONTENT_TESTID);
+		await waitFor(() => {
+			expect(within(content).queryByRole('img')).not.toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
- Implemented inline image upload functionality for the signature editor using data URIs.
- Added InlineDataImageUploadPlugin to convert data URIs to inline attachments.
- Updated RichToolbarPlugin and PastePlugin to handle inline image resolution.
- Created helper functions for managing image data URIs.
- Added tests for inline image handling in both the signature editor and rich text editor.

Refs: CO-3099