### PR TITLE
feat: implement inline image upload with immediate preview and synchronization

### DIFF
--- a/src/helpers/attachments.ts
+++ b/src/helpers/attachments.ts
@@ -351,6 +351,15 @@ export const useAttachmentIconColor = (
 export const isDownloadServicedUrl = (url: string): boolean =>
 	new RegExp(DOWNLOADSERVICEURL_REGEX, 'g').test(url);
 
+/**
+ * Whether the url is a local object url (`URL.createObjectURL`), used as the
+ * temporary src of an inline image whose upload/draft save is still pending.
+ *
+ * Note: {@link isCidUrl} cannot be used to tell those apart, since its pattern
+ * matches any non-empty string.
+ */
+export const isBlobUrl = (url: string): boolean => url.startsWith('blob:');
+
 export const composeAttachmentDownloadUrl = (attachment: SavedAttachment): string =>
 	`/service/home/~/?auth=co&id=${attachment.messageId}&part=${attachment.partName}`;
 

--- a/src/store/editor/editor-transformations.ts
+++ b/src/store/editor/editor-transformations.ts
@@ -12,6 +12,7 @@ import { TINYMCE_BASE_CONTENT_STYLES } from 'constants/tinymce-content-styles';
 import {
 	composeAttachmentDownloadUrl,
 	getCidFromCidUrl,
+	isBlobUrl,
 	isCidUrl,
 	isDownloadServicedUrl
 } from 'helpers/attachments';
@@ -100,6 +101,12 @@ export const replaceCidUrlWithServiceUrl = (
 			if (newSrc === src) {
 				return false || result;
 			}
+			// An inline image whose upload/draft save is still pending has no saved
+			// attachment to resolve its cid against: keep the local preview instead
+			// of replacing it with the (not yet loadable) cid url.
+			if (newSrc === referenceCid && src && isBlobUrl(src)) {
+				return false || result;
+			}
 			img.setAttribute('src', newSrc);
 			img.setAttribute('pnsrc', referenceCid);
 			img.setAttribute('data-src', referenceCid);
@@ -123,7 +130,10 @@ export const replaceServiceUrlWithCidUrl = (content: string): string => {
 
 	forEach(images, (p: HTMLImageElement) => {
 		const src = p.getAttribute('src');
-		if (!src || !isDownloadServicedUrl(src)) {
+		// Blob urls are the temporary src of an inline image whose upload/draft save
+		// is still pending: they too must be turned back into their cid reference,
+		// so that the outgoing message never carries a local-only url.
+		if (!src || (!isDownloadServicedUrl(src) && !isBlobUrl(src))) {
 			return;
 		}
 

--- a/src/store/editor/editor-transformations.ts
+++ b/src/store/editor/editor-transformations.ts
@@ -94,24 +94,24 @@ export const replaceCidUrlWithServiceUrl = (
 				referenceCid = src;
 			}
 			if (!referenceCid) {
-				return false || result;
+				return result;
 			}
 
 			const newSrc = convertCidUrlToServiceUrl(referenceCid, savedAttachment);
 			if (newSrc === src) {
-				return false || result;
+				return result;
 			}
 			// An inline image whose upload/draft save is still pending has no saved
 			// attachment to resolve its cid against: keep the local preview instead
 			// of replacing it with the (not yet loadable) cid url.
 			if (newSrc === referenceCid && src && isBlobUrl(src)) {
-				return false || result;
+				return result;
 			}
 			img.setAttribute('src', newSrc);
 			img.setAttribute('pnsrc', referenceCid);
 			img.setAttribute('data-src', referenceCid);
 			img.setAttribute('data-mce-src', referenceCid);
-			return true || result;
+			return true;
 		},
 		false
 	);

--- a/src/store/editor/tests/editor-transformation.test.ts
+++ b/src/store/editor/tests/editor-transformation.test.ts
@@ -7,8 +7,11 @@
 import {
 	composeAttachMpField,
 	composeCidUrlFromContentId,
-	convertCidUrlToServiceUrl
+	convertCidUrlToServiceUrl,
+	replaceCidUrlWithServiceUrl,
+	replaceServiceUrlWithCidUrl
 } from '../editor-transformations';
+import { SavedAttachment } from 'types/attachments';
 
 describe('editor-transformations', () => {
 	describe('composeAttachMpField', () => {
@@ -264,6 +267,76 @@ describe('editor-transformations', () => {
 				const serviceUrl = convertCidUrlToServiceUrl(cidUrl!, attachments);
 				expect(serviceUrl).toContain('id=email-999');
 				expect(serviceUrl).toContain('part=2.3');
+			});
+		});
+	});
+
+	describe('inline images src conversions', () => {
+		const CID_URL = 'cid:image@carbonio';
+		const PREVIEW_SRC = 'blob:http://localhost/abcd';
+
+		/**
+		 * Mimics what the editor serializes for an inline image: the src to display
+		 * plus the cid reference, written on both `data-pnsrc` and `data-mce-src`
+		 * (see `ImageNode.exportDOM`).
+		 */
+		const inlineImageHtml = (src: string): string =>
+			`<img src="${src}" data-pnsrc="${CID_URL}" data-mce-src="${CID_URL}" />`;
+
+		const srcOf = (html: string): string | null =>
+			new DOMParser()
+				.parseFromString(html, 'text/html')
+				.querySelector('img')
+				?.getAttribute('src') ?? null;
+
+		const savedInlineAttachment: SavedAttachment = {
+			contentId: 'image@carbonio',
+			messageId: 'msg-1',
+			partName: '2',
+			contentType: 'image/png',
+			size: 1000,
+			isInline: true,
+			filename: 'test.png'
+		};
+
+		describe('replaceServiceUrlWithCidUrl', () => {
+			it('should replace a download service url with the referred cid url', () => {
+				const content = inlineImageHtml('/service/home/~/?auth=co&id=msg-1&part=2');
+
+				expect(srcOf(replaceServiceUrlWithCidUrl(content))).toBe(CID_URL);
+			});
+
+			it('should replace the local preview url of a pending inline image with its cid url', () => {
+				// An inline image whose upload/draft save is still pending is displayed
+				// through a local object url, which must never reach the server.
+				const content = inlineImageHtml(PREVIEW_SRC);
+
+				expect(srcOf(replaceServiceUrlWithCidUrl(content))).toBe(CID_URL);
+			});
+
+			it('should leave an external image url untouched', () => {
+				const content = '<img src="https://example.com/picture.png" />';
+
+				expect(srcOf(replaceServiceUrlWithCidUrl(content))).toBe('https://example.com/picture.png');
+			});
+		});
+
+		describe('replaceCidUrlWithServiceUrl', () => {
+			it('should replace a cid url with the download url of the saved attachment', () => {
+				const content = inlineImageHtml(CID_URL);
+
+				const result = srcOf(replaceCidUrlWithServiceUrl(content, [savedInlineAttachment]));
+
+				expect(result).toContain('id=msg-1');
+				expect(result).toContain('part=2');
+			});
+
+			it('should keep the local preview url of an inline image which is not saved yet', () => {
+				// The cid of a pending inline image cannot be resolved to any saved
+				// attachment: overwriting the preview would make the image unloadable.
+				const content = inlineImageHtml(PREVIEW_SRC);
+
+				expect(srcOf(replaceCidUrlWithServiceUrl(content, []))).toBe(PREVIEW_SRC);
 			});
 		});
 	});

--- a/src/views/app/detail-panel/edit/editor/parts/rich-text-editor-container.tsx
+++ b/src/views/app/detail-panel/edit/editor/parts/rich-text-editor-container.tsx
@@ -27,17 +27,18 @@ import { ControlledContentPlugin } from '../plugins/controlled-content-plugin';
 import { FloatingLinkEditorPlugin } from '../plugins/floating-link-editor-plugin';
 import { STYLE_PRESERVING_HTML_IMPORT } from '../plugins/html-import-style';
 import { ImagePlugin } from '../plugins/image-plugin';
+import { InlineImageSrcSyncPlugin } from '../plugins/inline-image-src-sync-plugin';
 import { ListMarkdownShortcutPlugin } from '../plugins/list-markdown-shortcut-plugin';
 import { ImageNode } from '../plugins/nodes/image-node';
 import { QuotedSeparatorNode } from '../plugins/nodes/quoted-separator-node';
 import { SignatureNode } from '../plugins/nodes/signature-node';
 import { PastePlugin } from '../plugins/paste-plugin';
-import { RichToolbarPlugin, type UploadedInlineImage } from '../plugins/rich-toolbar-plugin';
+import { RichToolbarPlugin } from '../plugins/rich-toolbar-plugin';
 import { TableActionMenuPlugin } from '../plugins/table-action-menu-plugin';
 import { TableCellResizerPlugin } from '../plugins/table-cell-resizer-plugin';
 import { TableHoverActionsPlugin } from '../plugins/table-hover-actions-plugin';
+import { useInlineImageUpload } from '../plugins/use-inline-image-upload';
 import { DEFAULT_FONT_FAMILY } from 'helpers/user-preference-styles';
-import { useEditorAttachments } from 'store/editor/index';
 
 export const LexicalWrapper = styled.div<{
 	$fontFamily: string;
@@ -342,14 +343,7 @@ export const RichTextEditorContainer = ({
 }: TextEditorContainerProps): React.JSX.Element => {
 	const { prefs } = useUserSettings();
 	const [showBlocks, setShowBlocks] = useState(false);
-	const { addInlineAttachments } = useEditorAttachments(editorId);
-
-	const onUploadInlineImages = useCallback(
-		(files: File[], onComplete: (attachments: UploadedInlineImage[]) => void): void => {
-			addInlineAttachments(files, { onSaveComplete: onComplete });
-		},
-		[addInlineAttachments]
-	);
+	const onUploadInlineImages = useInlineImageUpload(editorId);
 
 	const fontFamily =
 		(prefs?.zimbraPrefHtmlEditorDefaultFontFamily as string) || DEFAULT_FONT_FAMILY;
@@ -433,6 +427,7 @@ export const RichTextEditorContainer = ({
 					<TableCellResizerPlugin />
 					<TableHoverActionsPlugin />
 					<ImagePlugin />
+					<InlineImageSrcSyncPlugin editorId={editorId} />
 					<PastePlugin editorId={editorId} />
 					<ControlledContentPlugin editorId={editorId} />
 				</LexicalWrapper>

--- a/src/views/app/detail-panel/edit/editor/plugins/image-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/image-plugin.tsx
@@ -6,18 +6,22 @@
 import { useEffect } from 'react';
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { mergeRegister } from '@lexical/utils';
+import { $dfs, mergeRegister } from '@lexical/utils';
 import {
 	$getSelection,
 	$insertNodes,
 	$isNodeSelection,
-	$nodesOfType,
 	COMMAND_PRIORITY_EDITOR,
 	createCommand,
 	type LexicalCommand
 } from 'lexical';
 
-import { $createImageNode, $isImageNode, ImageNode, type ImageAlignment } from './nodes/image-node';
+import {
+	$createImageNode,
+	$isImageNode,
+	type ImageNode,
+	type ImageAlignment
+} from './nodes/image-node';
 import { type ImageDimension } from './nodes/image-types';
 
 export { OPEN_IMAGE_MODAL_COMMAND } from './nodes/image-types';
@@ -54,12 +58,29 @@ export const REMOVE_INLINE_IMAGE_COMMAND: LexicalCommand<RemoveInlineImagePayloa
 );
 
 /**
+ * All the inline images of the editor content.
+ */
+export function $getInlineImageNodes(): Array<ImageNode> {
+	return $dfs()
+		.map(({ node }) => node)
+		.filter($isImageNode);
+}
+
+/**
  * All the inline images referring the given cid. There is normally just one, but
  * the same image can be duplicated by a copy/paste inside the editor, in which
  * case every copy has to be kept in sync.
  */
 function $getImageNodesByCidUrl(cidUrl: string): Array<ImageNode> {
-	return $nodesOfType(ImageNode).filter((node) => node.getCidUrl() === cidUrl);
+	return $getInlineImageNodes().filter((node) => node.getCidUrl() === cidUrl);
+}
+
+function $setImageNodesSrcByCidUrl(cidUrl: string, src: string): void {
+	$getImageNodesByCidUrl(cidUrl).forEach((node) => node.setSrc(src));
+}
+
+function $removeImageNodesByCidUrl(cidUrl: string): void {
+	$getImageNodesByCidUrl(cidUrl).forEach((node) => node.remove());
 }
 
 function $applyImageAlignment(alignment: ImageAlignment | undefined): void {
@@ -116,9 +137,7 @@ export const ImagePlugin = (): null => {
 						// Not tagged as `history-merge`, so that the change reaches the
 						// store through the OnChangePlugin and the persisted html holds the
 						// download url instead of the local preview one.
-						editor.update(() => {
-							$getImageNodesByCidUrl(cidUrl).forEach((node) => node.setSrc(src));
-						});
+						editor.update(() => $setImageNodesSrcByCidUrl(cidUrl, src));
 						return true;
 					},
 					COMMAND_PRIORITY_EDITOR
@@ -126,9 +145,7 @@ export const ImagePlugin = (): null => {
 				editor.registerCommand<RemoveInlineImagePayload>(
 					REMOVE_INLINE_IMAGE_COMMAND,
 					({ cidUrl }) => {
-						editor.update(() => {
-							$getImageNodesByCidUrl(cidUrl).forEach((node) => node.remove());
-						});
+						editor.update(() => $removeImageNodesByCidUrl(cidUrl));
 						return true;
 					},
 					COMMAND_PRIORITY_EDITOR

--- a/src/views/app/detail-panel/edit/editor/plugins/image-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/image-plugin.tsx
@@ -11,12 +11,13 @@ import {
 	$getSelection,
 	$insertNodes,
 	$isNodeSelection,
+	$nodesOfType,
 	COMMAND_PRIORITY_EDITOR,
 	createCommand,
 	type LexicalCommand
 } from 'lexical';
 
-import { $createImageNode, $isImageNode, type ImageAlignment } from './nodes/image-node';
+import { $createImageNode, $isImageNode, ImageNode, type ImageAlignment } from './nodes/image-node';
 import { type ImageDimension } from './nodes/image-types';
 
 export { OPEN_IMAGE_MODAL_COMMAND } from './nodes/image-types';
@@ -36,6 +37,31 @@ export const INSERT_INLINE_IMAGE_COMMAND: LexicalCommand<InsertInlineImagePayloa
 export const SET_INLINE_IMAGE_ALIGNMENT_COMMAND: LexicalCommand<ImageAlignment | undefined> =
 	createCommand('SET_INLINE_IMAGE_ALIGNMENT_COMMAND');
 
+export type ReplaceInlineImageSrcPayload = {
+	cidUrl: string;
+	src: string;
+};
+
+export const REPLACE_INLINE_IMAGE_SRC_COMMAND: LexicalCommand<ReplaceInlineImageSrcPayload> =
+	createCommand('REPLACE_INLINE_IMAGE_SRC_COMMAND');
+
+export type RemoveInlineImagePayload = {
+	cidUrl: string;
+};
+
+export const REMOVE_INLINE_IMAGE_COMMAND: LexicalCommand<RemoveInlineImagePayload> = createCommand(
+	'REMOVE_INLINE_IMAGE_COMMAND'
+);
+
+/**
+ * All the inline images referring the given cid. There is normally just one, but
+ * the same image can be duplicated by a copy/paste inside the editor, in which
+ * case every copy has to be kept in sync.
+ */
+function $getImageNodesByCidUrl(cidUrl: string): Array<ImageNode> {
+	return $nodesOfType(ImageNode).filter((node) => node.getCidUrl() === cidUrl);
+}
+
 function $applyImageAlignment(alignment: ImageAlignment | undefined): void {
 	const selection = $getSelection();
 	if (!$isNodeSelection(selection)) {
@@ -52,7 +78,13 @@ function $applyImageAlignment(alignment: ImageAlignment | undefined): void {
  * Registers the command that inserts an inline image ({@link ImageNode}) at the
  * current selection. The upload of the file and the cid bookkeeping are handled
  * by whoever dispatches the command (the toolbar image button / the paste
- * handler), which only provides the resolved download URL and cid.
+ * handler), which only provides the src to display and the cid.
+ *
+ * A freshly inserted image is displayed straight away through a local preview
+ * url, while its upload and draft save are still in flight; the cid is the
+ * handle used to later replace that preview with the real download url
+ * ({@link REPLACE_INLINE_IMAGE_SRC_COMMAND}) or to drop the image altogether if
+ * its upload fails ({@link REMOVE_INLINE_IMAGE_COMMAND}).
  */
 export const ImagePlugin = (): null => {
 	const [editor] = useLexicalComposerContext();
@@ -74,6 +106,29 @@ export const ImagePlugin = (): null => {
 					SET_INLINE_IMAGE_ALIGNMENT_COMMAND,
 					(alignment) => {
 						editor.update(() => $applyImageAlignment(alignment));
+						return true;
+					},
+					COMMAND_PRIORITY_EDITOR
+				),
+				editor.registerCommand<ReplaceInlineImageSrcPayload>(
+					REPLACE_INLINE_IMAGE_SRC_COMMAND,
+					({ cidUrl, src }) => {
+						// Not tagged as `history-merge`, so that the change reaches the
+						// store through the OnChangePlugin and the persisted html holds the
+						// download url instead of the local preview one.
+						editor.update(() => {
+							$getImageNodesByCidUrl(cidUrl).forEach((node) => node.setSrc(src));
+						});
+						return true;
+					},
+					COMMAND_PRIORITY_EDITOR
+				),
+				editor.registerCommand<RemoveInlineImagePayload>(
+					REMOVE_INLINE_IMAGE_COMMAND,
+					({ cidUrl }) => {
+						editor.update(() => {
+							$getImageNodesByCidUrl(cidUrl).forEach((node) => node.remove());
+						});
 						return true;
 					},
 					COMMAND_PRIORITY_EDITOR

--- a/src/views/app/detail-panel/edit/editor/plugins/inline-image-src-sync-plugin.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/inline-image-src-sync-plugin.ts
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useEffect } from 'react';
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $nodesOfType } from 'lexical';
+
+import { REPLACE_INLINE_IMAGE_SRC_COMMAND } from './image-plugin';
+import { ImageNode } from './nodes/image-node';
+import { isBlobUrl } from 'helpers/attachments';
+import { convertCidUrlToServiceUrl } from 'store/editor/editor-transformations';
+import { useEditorsStore } from 'store/editor/store';
+import { MailsEditorV2 } from 'types/editor';
+
+type InlineImageSrcSyncPluginProps = {
+	editorId: MailsEditorV2['id'];
+};
+
+/**
+ * Replaces the local preview of a freshly inserted inline image with the real
+ * download url, as soon as the image shows up among the saved attachments of the
+ * draft.
+ *
+ * The swap is driven by the store rather than by the callback of the draft save
+ * which follows the upload: that save is debounced per hook instance, and the
+ * one carrying the callback is dropped whenever another save is already running
+ * (see `computeDraftSaveAllowedStatus`), so it cannot be relied upon. Watching
+ * the saved attachments instead covers every save that persists the image, no
+ * matter which one got there first.
+ */
+export const InlineImageSrcSyncPlugin = ({ editorId }: InlineImageSrcSyncPluginProps): null => {
+	const [editor] = useLexicalComposerContext();
+	const savedAttachments = useEditorsStore((state) => state.editors[editorId]?.savedAttachments);
+
+	useEffect(() => {
+		if (!savedAttachments?.length) {
+			return;
+		}
+
+		const resolvedSrcByCidUrl = new Map<string, string>();
+		editor.getEditorState().read(() => {
+			$nodesOfType(ImageNode).forEach((node) => {
+				const cidUrl = node.getCidUrl();
+				if (!cidUrl || !isBlobUrl(node.getSrc()) || resolvedSrcByCidUrl.has(cidUrl)) {
+					return;
+				}
+				const serviceUrl = convertCidUrlToServiceUrl(cidUrl, savedAttachments);
+				// Unchanged means the image is not part of the saved draft yet: its
+				// preview stays in place until a later save picks it up.
+				if (serviceUrl !== cidUrl) {
+					resolvedSrcByCidUrl.set(cidUrl, serviceUrl);
+				}
+			});
+		});
+
+		resolvedSrcByCidUrl.forEach((src, cidUrl) => {
+			editor.dispatchCommand(REPLACE_INLINE_IMAGE_SRC_COMMAND, { cidUrl, src });
+		});
+	}, [editor, savedAttachments]);
+
+	return null;
+};

--- a/src/views/app/detail-panel/edit/editor/plugins/inline-image-src-sync-plugin.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/inline-image-src-sync-plugin.ts
@@ -6,10 +6,8 @@
 import { useEffect } from 'react';
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { $nodesOfType } from 'lexical';
 
-import { REPLACE_INLINE_IMAGE_SRC_COMMAND } from './image-plugin';
-import { ImageNode } from './nodes/image-node';
+import { $getInlineImageNodes, REPLACE_INLINE_IMAGE_SRC_COMMAND } from './image-plugin';
 import { isBlobUrl } from 'helpers/attachments';
 import { convertCidUrlToServiceUrl } from 'store/editor/editor-transformations';
 import { useEditorsStore } from 'store/editor/store';
@@ -42,7 +40,7 @@ export const InlineImageSrcSyncPlugin = ({ editorId }: InlineImageSrcSyncPluginP
 
 		const resolvedSrcByCidUrl = new Map<string, string>();
 		editor.getEditorState().read(() => {
-			$nodesOfType(ImageNode).forEach((node) => {
+			$getInlineImageNodes().forEach((node) => {
 				const cidUrl = node.getCidUrl();
 				if (!cidUrl || !isBlobUrl(node.getSrc()) || resolvedSrcByCidUrl.has(cidUrl)) {
 					return;

--- a/src/views/app/detail-panel/edit/editor/plugins/paste-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/paste-plugin.tsx
@@ -8,8 +8,7 @@ import { useEffect } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { COMMAND_PRIORITY_LOW, PASTE_COMMAND } from 'lexical';
 
-import { INSERT_INLINE_IMAGE_COMMAND } from './image-plugin';
-import { useEditorAttachments } from 'store/editor/index';
+import { uploadAndInsertInlineImages, useInlineImageUpload } from './use-inline-image-upload';
 import { MailsEditorV2 } from 'types/editor';
 
 type PastePluginProps = {
@@ -18,12 +17,13 @@ type PastePluginProps = {
 
 /**
  * cid-aware paste handling: image files in the clipboard are uploaded as inline
- * attachments and inserted as {@link ImageNode}s (preserving the cid), while
- * plain text and HTML paste fall through to the default RichTextPlugin handler.
+ * attachments and inserted as {@link ImageNode}s straight away (preserving the
+ * cid), while plain text and HTML paste fall through to the default
+ * RichTextPlugin handler.
  */
 export const PastePlugin = ({ editorId }: PastePluginProps): null => {
 	const [editor] = useLexicalComposerContext();
-	const { addInlineAttachments } = useEditorAttachments(editorId);
+	const uploadInlineImages = useInlineImageUpload(editorId);
 
 	useEffect(
 		() =>
@@ -58,24 +58,12 @@ export const PastePlugin = ({ editorId }: PastePluginProps): null => {
 					}
 
 					event.preventDefault();
-					addInlineAttachments(imageFiles, {
-						onSaveComplete: (inlineAttachments) => {
-							inlineAttachments.forEach((attachment) => {
-								if (attachment.downloadServiceUrl) {
-									editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
-										src: attachment.downloadServiceUrl,
-										cidUrl: attachment.cidUrl,
-										altText: 'Inline attachment'
-									});
-								}
-							});
-						}
-					});
+					uploadAndInsertInlineImages(editor, uploadInlineImages, imageFiles);
 					return true;
 				},
 				COMMAND_PRIORITY_LOW
 			),
-		[editor, addInlineAttachments]
+		[editor, uploadInlineImages]
 	);
 
 	return null;

--- a/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin-hooks/use-image-actions.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin-hooks/use-image-actions.ts
@@ -9,17 +9,12 @@ import { type DropdownItem } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
 import { COMMAND_PRIORITY_LOW, type LexicalEditor } from 'lexical';
 
-import {
-	INSERT_INLINE_IMAGE_COMMAND,
-	OPEN_IMAGE_MODAL_COMMAND,
-	SET_INLINE_IMAGE_ALIGNMENT_COMMAND
-} from '../image-plugin';
+import { OPEN_IMAGE_MODAL_COMMAND, SET_INLINE_IMAGE_ALIGNMENT_COMMAND } from '../image-plugin';
 import { type ImageAlignment } from '../nodes/image-node';
-
-export type UploadedInlineImage = {
-	downloadServiceUrl?: string;
-	cidUrl?: string;
-};
+import {
+	uploadAndInsertInlineImages,
+	type UploadInlineImagesHandler
+} from '../use-inline-image-upload';
 
 type ImageActions = {
 	alignImage: (alignment: ImageAlignment) => void;
@@ -32,10 +27,7 @@ type ImageActions = {
 
 export function useImageActions(
 	editor: LexicalEditor,
-	onUploadInlineImages?: (
-		files: File[],
-		onComplete: (attachments: UploadedInlineImage[]) => void
-	) => void
+	onUploadInlineImages?: UploadInlineImagesHandler
 ): ImageActions {
 	const [imageModalOpen, setImageModalOpen] = useState(false);
 
@@ -69,17 +61,7 @@ export function useImageActions(
 			if (!fileList?.length || !onUploadInlineImages) {
 				return;
 			}
-			onUploadInlineImages(Array.from(fileList), (inlineAttachments) => {
-				inlineAttachments.forEach((attachment) => {
-					if (attachment.downloadServiceUrl) {
-						editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
-							src: attachment.downloadServiceUrl,
-							cidUrl: attachment.cidUrl,
-							altText: 'Inline attachment'
-						});
-					}
-				});
-			});
+			uploadAndInsertInlineImages(editor, onUploadInlineImages, Array.from(fileList));
 			event.target.value = '';
 		},
 		[onUploadInlineImages, editor]

--- a/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/rich-toolbar-plugin.tsx
@@ -18,10 +18,7 @@ import { useAlignmentAndDirection } from './rich-toolbar-plugin-hooks/use-alignm
 import { useBlockType } from './rich-toolbar-plugin-hooks/use-block-type';
 import { useEmojiAndSpecialCharacters } from './rich-toolbar-plugin-hooks/use-emoji-and-special-characters';
 import { useFontAndSizeSelects } from './rich-toolbar-plugin-hooks/use-font-and-size-selects';
-import {
-	useImageActions,
-	type UploadedInlineImage
-} from './rich-toolbar-plugin-hooks/use-image-actions';
+import { useImageActions } from './rich-toolbar-plugin-hooks/use-image-actions';
 import { useStylePatching } from './rich-toolbar-plugin-hooks/use-style-patching';
 import { useTableInsert } from './rich-toolbar-plugin-hooks/use-table-insert';
 import { useTextFormatting } from './rich-toolbar-plugin-hooks/use-text-formatting';
@@ -31,9 +28,10 @@ import { SourceCodeModal } from './source-code-modal';
 import { ToolbarDivider } from './toolbar-divider';
 import { ToolbarIconButton } from './toolbar-icon-button';
 import { ToolbarSelect } from './toolbar-select';
+import { type UploadInlineImagesHandler } from './use-inline-image-upload';
 import { editorIcon } from '../icons/editor-icons';
 
-export type { UploadedInlineImage } from './rich-toolbar-plugin-hooks/use-image-actions';
+export type { UploadInlineImagesHandler } from './use-inline-image-upload';
 
 type RichToolbarPluginProps = {
 	/** Whether the "Show blocks" view aid (dashed block outlines) is active. */
@@ -41,14 +39,11 @@ type RichToolbarPluginProps = {
 	/** Toggles the "Show blocks" view aid. */
 	onToggleShowBlocks: () => void;
 	/**
-	 * Uploads image files picked from the "insert image from device" button and
-	 * hands back their resolved URLs. When omitted, that button is hidden — the
+	 * Uploads image files picked from the "insert image from device" button as
+	 * inline attachments of the draft. When omitted, that button is hidden — the
 	 * store-agnostic "insert image from URL" button is always available.
 	 */
-	onUploadInlineImages?: (
-		files: File[],
-		onComplete: (attachments: UploadedInlineImage[]) => void
-	) => void;
+	onUploadInlineImages?: UploadInlineImagesHandler;
 	/** Account's default font family, used as the font selector's default value. */
 	fontFamily?: string;
 	/** Account's default font size, used as the size selector's default value. */
@@ -412,6 +407,7 @@ export const RichToolbarPlugin = ({
 				onChange={onImageFilesSelected}
 				aria-hidden="true"
 				tabIndex={-1}
+				data-testid="inline-image-file-input"
 			/>
 		</Row>
 	);

--- a/src/views/app/detail-panel/edit/editor/plugins/tests/inline-image-upload-test-utils.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/tests/inline-image-upload-test-utils.ts
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import * as editorStoreIndex from 'store/editor/index';
+import { useEditorsStore } from 'store/editor/store';
+import { SavedAttachment, UnsavedAttachment } from 'types/attachments';
+
+export const PREVIEW_SRC = 'blob:preview-src';
+export const UPLOAD_ID = 'upload-1';
+export const CONTENT_ID = `${UPLOAD_ID}@carbonio`;
+export const CID_URL = `cid:${CONTENT_ID}`;
+export const MESSAGE_ID = '123';
+export const PART_NAME = '2';
+export const DOWNLOAD_SERVICE_URL = `/service/home/~/?auth=co&id=${MESSAGE_ID}&part=${PART_NAME}`;
+
+type AddInlineAttachments = ReturnType<
+	typeof editorStoreIndex.useEditorAttachments
+>['addInlineAttachments'];
+
+type AddInlineAttachmentsOptions = NonNullable<Parameters<AddInlineAttachments>[1]>;
+
+export type InlineImageUploadMock = {
+	addInlineAttachments: AddInlineAttachments;
+	/** Simulates the failure of the upload of the first file. */
+	failUpload: () => void;
+};
+
+/**
+ * jsdom implements neither `createObjectURL` nor `revokeObjectURL`: both are
+ * stubbed so that the preview url of a pending inline image is predictable.
+ * Returns the teardown to run in `afterEach`.
+ */
+export function stubObjectUrls(): () => void {
+	const { createObjectURL, revokeObjectURL } = URL;
+	URL.createObjectURL = vi.fn(() => PREVIEW_SRC);
+	URL.revokeObjectURL = vi.fn();
+	return (): void => {
+		URL.createObjectURL = createObjectURL;
+		URL.revokeObjectURL = revokeObjectURL;
+	};
+}
+
+/**
+ * Replaces `useEditorAttachments` with a fake whose upload never resolves on its
+ * own, so that what the editor shows while the upload is still pending can be
+ * asserted.
+ */
+export function mockInlineImageUpload(): InlineImageUploadMock {
+	let uploadedFiles: Array<File> = [];
+	let options: AddInlineAttachmentsOptions | undefined;
+
+	const addInlineAttachments = vi.fn((files: Array<File>, uploadOptions) => {
+		uploadedFiles = files;
+		options = uploadOptions;
+		return files.map<UnsavedAttachment>((file, index) => ({
+			filename: file.name,
+			contentType: file.type,
+			size: file.size,
+			uploadId: index === 0 ? UPLOAD_ID : `${UPLOAD_ID}-${index}`,
+			contentId: index === 0 ? CONTENT_ID : `${UPLOAD_ID}-${index}@carbonio`,
+			isInline: true,
+			uploadStatus: { status: 'running', progress: 0 }
+		}));
+	}) as unknown as AddInlineAttachments;
+
+	vi.spyOn(editorStoreIndex, 'useEditorAttachments').mockReturnValue({
+		addInlineAttachments,
+		keepOnlyInlineAttachments: vi.fn(),
+		addStandardAttachments: vi.fn(),
+		addUploadedAttachment: vi.fn()
+	} as unknown as ReturnType<typeof editorStoreIndex.useEditorAttachments>);
+
+	return {
+		addInlineAttachments,
+		failUpload: (): void => {
+			options?.onUploadError?.(uploadedFiles[0], UPLOAD_ID, 'upload failed');
+		}
+	};
+}
+
+/**
+ * Simulates the outcome of the draft save which persists the pending inline
+ * image: the saved attachments of the editor are what the editor watches to
+ * replace a preview with the real download url.
+ */
+export function saveInlineAttachment(editorId: string): void {
+	const savedInlineAttachment: SavedAttachment = {
+		contentId: CONTENT_ID,
+		messageId: MESSAGE_ID,
+		partName: PART_NAME,
+		contentType: 'image/png',
+		size: 1000,
+		isInline: true,
+		filename: 'pic.png'
+	};
+	useEditorsStore.getState().setSavedAttachments(editorId, [savedInlineAttachment]);
+}

--- a/src/views/app/detail-panel/edit/editor/plugins/tests/inline-image-upload.test.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/tests/inline-image-upload.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { act, waitFor } from '@testing-library/react';
+
+import {
+	CID_URL,
+	DOWNLOAD_SERVICE_URL,
+	mockInlineImageUpload,
+	PREVIEW_SRC,
+	saveInlineAttachment,
+	stubObjectUrls
+} from './inline-image-upload-test-utils';
+import { setupTest, screen, within } from '@test-setup';
+import { setupEditorStore } from '__test__/generators/editor-store';
+import { generateNewMessageEditor } from 'store/editor/editor-generators';
+import { useEditorsStore } from 'store/editor/store';
+import { RichTextEditorContainer } from 'views/app/detail-panel/edit/editor/parts/rich-text-editor-container';
+
+const EDITOR_TESTID = 'edit-view-editor';
+const FILE_INPUT_TESTID = 'inline-image-file-input';
+
+function richTextOf(editorId: string): string {
+	return useEditorsStore.getState().editors[editorId]?.text.richText ?? '';
+}
+
+function renderEditor(): { editorId: string; user: ReturnType<typeof setupTest>['user'] } {
+	const editor = generateNewMessageEditor();
+	editor.text = { plainText: '', richText: '<p></p>' };
+	setupEditorStore({ editors: [editor] });
+	const { user } = setupTest(<RichTextEditorContainer editorId={editor.id} onDragOver={vi.fn()} />);
+	return { editorId: editor.id, user };
+}
+
+describe('Inline image upload from the toolbar', () => {
+	let restoreObjectUrls: () => void;
+	beforeEach(() => {
+		restoreObjectUrls = stubObjectUrls();
+	});
+
+	afterEach(() => {
+		restoreObjectUrls();
+		vi.restoreAllMocks();
+	});
+
+	it('previews the picked image immediately, without waiting for the draft save', async () => {
+		const file = new File(['x'], 'pic.png', { type: 'image/png' });
+		const { addInlineAttachments } = mockInlineImageUpload();
+		const { user } = renderEditor();
+
+		await user.upload(screen.getByTestId(FILE_INPUT_TESTID), file);
+
+		expect(addInlineAttachments).toHaveBeenCalledWith([file], expect.anything());
+		const editorElement = screen.getByTestId(EDITOR_TESTID);
+		const image = await within(editorElement).findByRole('img');
+		expect(image).toHaveAttribute('src', PREVIEW_SRC);
+	});
+
+	it('keeps the cid reference in the saved html while the image is still pending', async () => {
+		const file = new File(['x'], 'pic.png', { type: 'image/png' });
+		mockInlineImageUpload();
+		const { editorId, user } = renderEditor();
+
+		await user.upload(screen.getByTestId(FILE_INPUT_TESTID), file);
+		await within(screen.getByTestId(EDITOR_TESTID)).findByRole('img');
+
+		// The cid is what keeps the inline attachment alive and what the outgoing
+		// message refers to, even before the image has been saved.
+		await waitFor(() => {
+			expect(richTextOf(editorId)).toContain(`data-pnsrc="${CID_URL}"`);
+		});
+	});
+
+	it('replaces the preview with the download url in the editor and in the store', async () => {
+		const file = new File(['x'], 'pic.png', { type: 'image/png' });
+		mockInlineImageUpload();
+		const { editorId, user } = renderEditor();
+
+		await user.upload(screen.getByTestId(FILE_INPUT_TESTID), file);
+		const editorElement = screen.getByTestId(EDITOR_TESTID);
+		await within(editorElement).findByRole('img');
+
+		act(() => {
+			saveInlineAttachment(editorId);
+		});
+
+		await waitFor(() => {
+			expect(within(editorElement).getByRole('img')).toHaveAttribute('src', DOWNLOAD_SERVICE_URL);
+		});
+		// The store holds the serialized html, where the url query separators are
+		// html-escaped.
+		const escapedDownloadUrl = DOWNLOAD_SERVICE_URL.replace(/&/g, '&amp;');
+		await waitFor(() => {
+			expect(richTextOf(editorId)).toContain(escapedDownloadUrl);
+		});
+		expect(richTextOf(editorId)).not.toContain(PREVIEW_SRC);
+	});
+
+	it('inserts one image per picked file', async () => {
+		const files = [
+			new File(['x'], 'first.png', { type: 'image/png' }),
+			new File(['y'], 'second.png', { type: 'image/png' })
+		];
+		mockInlineImageUpload();
+		const { user } = renderEditor();
+
+		await user.upload(screen.getByTestId(FILE_INPUT_TESTID), files);
+
+		const editorElement = screen.getByTestId(EDITOR_TESTID);
+		await waitFor(() => {
+			expect(within(editorElement).getAllByRole('img')).toHaveLength(2);
+		});
+	});
+
+	it('removes the picked image when its upload fails', async () => {
+		const file = new File(['x'], 'pic.png', { type: 'image/png' });
+		const { failUpload } = mockInlineImageUpload();
+		const { user } = renderEditor();
+
+		await user.upload(screen.getByTestId(FILE_INPUT_TESTID), file);
+		const editorElement = screen.getByTestId(EDITOR_TESTID);
+		await within(editorElement).findByRole('img');
+
+		act(() => {
+			failUpload();
+		});
+
+		await waitFor(() => {
+			expect(within(editorElement).queryByRole('img')).not.toBeInTheDocument();
+		});
+		expect(URL.revokeObjectURL).toHaveBeenCalledWith(PREVIEW_SRC);
+	});
+});

--- a/src/views/app/detail-panel/edit/editor/plugins/tests/paste-plugin.test.tsx
+++ b/src/views/app/detail-panel/edit/editor/plugins/tests/paste-plugin.test.tsx
@@ -6,8 +6,15 @@
 /* eslint-disable max-classes-per-file -- two minimal Event stubs cover a jsdom gap (see below) */
 import React from 'react';
 
-import { fireEvent, waitFor } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 
+import {
+	DOWNLOAD_SERVICE_URL,
+	mockInlineImageUpload,
+	PREVIEW_SRC,
+	saveInlineAttachment,
+	stubObjectUrls
+} from './inline-image-upload-test-utils';
 import { setupTest, screen, within } from '@test-setup';
 import { setupEditorStore } from '__test__/generators/editor-store';
 import { generateNewMessageEditor } from 'store/editor/editor-generators';
@@ -38,8 +45,8 @@ class StubDragEvent extends Event {}
 class StubClipboardEvent extends Event {}
 
 /**
- * Replaces `useEditorAttachments` so the paste handler's upload step resolves
- * synchronously with a ready-to-insert inline attachment.
+ * Replaces `useEditorAttachments` with a fake that never uploads anything, for
+ * the cases where no upload is expected at all.
  */
 function mockEditorAttachments(addInlineAttachments: AddInlineAttachments): void {
 	vi.spyOn(editorStoreIndex, 'useEditorAttachments').mockReturnValue({
@@ -50,11 +57,12 @@ function mockEditorAttachments(addInlineAttachments: AddInlineAttachments): void
 	} as unknown as ReturnType<typeof editorStoreIndex.useEditorAttachments>);
 }
 
-function renderEditor(): void {
+function renderEditor(): { editorId: string } {
 	const editor = generateNewMessageEditor();
 	editor.text = { plainText: '', richText: '<p></p>' };
 	setupEditorStore({ editors: [editor] });
 	setupTest(<RichTextEditorContainer editorId={editor.id} onDragOver={vi.fn()} />);
+	return { editorId: editor.id };
 }
 
 /**
@@ -96,18 +104,19 @@ describe('PastePlugin', () => {
 		globalScope.ClipboardEvent = originalClipboardEvent;
 	});
 
+	let restoreObjectUrls: () => void;
+	beforeEach(() => {
+		restoreObjectUrls = stubObjectUrls();
+	});
+
 	afterEach(() => {
+		restoreObjectUrls();
 		vi.restoreAllMocks();
 	});
 
-	it('uploads pasted image files and inserts them as inline images', async () => {
+	it('uploads pasted image files and previews them before the draft is saved', async () => {
 		const file = new File(['x'], 'pic.png', { type: 'image/png' });
-		const addInlineAttachments = vi.fn((_files, { onSaveComplete }) => {
-			onSaveComplete([
-				{ downloadServiceUrl: 'https://service/pasted.png', cidUrl: 'cid:pasted@carbonio' }
-			]);
-		}) as unknown as AddInlineAttachments;
-		mockEditorAttachments(addInlineAttachments);
+		const { addInlineAttachments } = mockInlineImageUpload();
 
 		renderEditor();
 		const editorElement = screen.getByTestId(EDITOR_TESTID);
@@ -117,8 +126,52 @@ describe('PastePlugin', () => {
 		expect(addInlineAttachments).toHaveBeenCalledTimes(1);
 		expect(addInlineAttachments).toHaveBeenCalledWith([file], expect.anything());
 
+		// The draft save has not completed yet: the image is already rendered
+		// through its local preview.
 		const image = await within(editorElement).findByRole('img');
-		expect(image).toHaveAttribute('src', 'https://service/pasted.png');
+		expect(image).toHaveAttribute('src', PREVIEW_SRC);
+		expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+	});
+
+	it('replaces the preview with the download url once the draft is saved', async () => {
+		const file = new File(['x'], 'pic.png', { type: 'image/png' });
+		mockInlineImageUpload();
+
+		const { editorId } = renderEditor();
+		const editorElement = screen.getByTestId(EDITOR_TESTID);
+
+		pasteInto(editorElement, [{ kind: 'file', type: 'image/png', getAsFile: (): File => file }]);
+		await within(editorElement).findByRole('img');
+
+		act(() => {
+			saveInlineAttachment(editorId);
+		});
+
+		await waitFor(() => {
+			expect(within(editorElement).getByRole('img')).toHaveAttribute('src', DOWNLOAD_SERVICE_URL);
+		});
+		// The image is updated in place, not inserted a second time.
+		expect(within(editorElement).getAllByRole('img')).toHaveLength(1);
+	});
+
+	it('removes the pasted image when its upload fails', async () => {
+		const file = new File(['x'], 'pic.png', { type: 'image/png' });
+		const { failUpload } = mockInlineImageUpload();
+
+		renderEditor();
+		const editorElement = screen.getByTestId(EDITOR_TESTID);
+
+		pasteInto(editorElement, [{ kind: 'file', type: 'image/png', getAsFile: (): File => file }]);
+		await within(editorElement).findByRole('img');
+
+		act(() => {
+			failUpload();
+		});
+
+		await waitFor(() => {
+			expect(within(editorElement).queryByRole('img')).not.toBeInTheDocument();
+		});
+		expect(URL.revokeObjectURL).toHaveBeenCalledWith(PREVIEW_SRC);
 	});
 
 	it('ignores text-only paste and lets the default handler deal with it', async () => {

--- a/src/views/app/detail-panel/edit/editor/plugins/use-inline-image-upload.ts
+++ b/src/views/app/detail-panel/edit/editor/plugins/use-inline-image-upload.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useCallback } from 'react';
+
+import { type LexicalEditor } from 'lexical';
+
+import { INSERT_INLINE_IMAGE_COMMAND, REMOVE_INLINE_IMAGE_COMMAND } from './image-plugin';
+import { composeCidUrlFromContentId } from 'store/editor/editor-transformations';
+import { useEditorAttachments } from 'store/editor/index';
+import { MailsEditorV2 } from 'types/editor';
+
+const INLINE_IMAGE_ALT_TEXT = 'Inline attachment';
+
+/**
+ * An inline image whose upload (and the draft save that follows it) is still in
+ * flight. Its cid is already known, since it is assigned to the unsaved
+ * attachment before the upload even starts, and is the handle used to update the
+ * image once the draft has been saved.
+ */
+export type PendingInlineImage = {
+	file: File;
+	uploadId: string;
+	cidUrl: string;
+};
+
+export type UploadInlineImagesCallbacks = {
+	onFailed: (uploadId: string) => void;
+};
+
+export type UploadInlineImagesHandler = (
+	files: Array<File>,
+	callbacks: UploadInlineImagesCallbacks
+) => Array<PendingInlineImage>;
+
+/**
+ * Starts the upload of the given files as inline attachments of the editor's
+ * draft and returns, synchronously, the cid assigned to each one of them.
+ */
+export const useInlineImageUpload = (editorId: MailsEditorV2['id']): UploadInlineImagesHandler => {
+	const { addInlineAttachments } = useEditorAttachments(editorId);
+
+	return useCallback<UploadInlineImagesHandler>(
+		(files, { onFailed }) => {
+			const unsavedAttachments = addInlineAttachments(files, {
+				onUploadError: (_file, uploadId): void => onFailed(uploadId)
+			});
+
+			// `uploadAttachmentsApi` maps over the given files preserving their order,
+			// so the nth unsaved attachment always describes the nth file.
+			return unsavedAttachments.reduce<Array<PendingInlineImage>>(
+				(pendingImages, attachment, index) => {
+					const cidUrl = attachment.contentId
+						? composeCidUrlFromContentId(attachment.contentId)
+						: null;
+					if (cidUrl && attachment.uploadId) {
+						pendingImages.push({ file: files[index], uploadId: attachment.uploadId, cidUrl });
+					}
+					return pendingImages;
+				},
+				[]
+			);
+		},
+		[addInlineAttachments]
+	);
+};
+
+/**
+ * Uploads the given image files as inline attachments and inserts them in the
+ * editor right away, without waiting for the (debounced) draft save: each image
+ * is displayed through a local preview url until `InlineImageSrcSyncPlugin`
+ * replaces it with the real download url, which happens as soon as the image is
+ * part of the saved draft. An image whose upload fails is removed again, since it
+ * will never be attached to the message.
+ */
+export function uploadAndInsertInlineImages(
+	editor: LexicalEditor,
+	upload: UploadInlineImagesHandler,
+	files: Array<File>
+): void {
+	const previewsByUploadId = new Map<string, { cidUrl: string; previewSrc: string }>();
+
+	const pendingImages = upload(files, {
+		onFailed: (uploadId): void => {
+			const failedPreview = previewsByUploadId.get(uploadId);
+			if (!failedPreview) {
+				return;
+			}
+			previewsByUploadId.delete(uploadId);
+			editor.dispatchCommand(REMOVE_INLINE_IMAGE_COMMAND, { cidUrl: failedPreview.cidUrl });
+			URL.revokeObjectURL(failedPreview.previewSrc);
+		}
+	});
+
+	// Uploads can only fail asynchronously, so the previews map is always
+	// populated by the time `onFailed` is invoked.
+	pendingImages.forEach(({ file, uploadId, cidUrl }) => {
+		const previewSrc = URL.createObjectURL(file);
+		previewsByUploadId.set(uploadId, { cidUrl, previewSrc });
+		editor.dispatchCommand(INSERT_INLINE_IMAGE_COMMAND, {
+			src: previewSrc,
+			cidUrl,
+			altText: INLINE_IMAGE_ALT_TEXT
+		});
+	});
+}


### PR DESCRIPTION
- Added `isBlobUrl` helper to identify local object URLs for inline images.
- Introduced `InlineImageSrcSyncPlugin` to replace local previews with actual download URLs once images are saved.
- Updated `ImagePlugin` to handle commands for replacing and removing inline image sources.
- Created `useInlineImageUpload` hook to manage inline image uploads and their previews.
- Enhanced `PastePlugin` to support inline image pasting with immediate previews.
- Added tests for inline image upload functionality, ensuring previews and error handling work as expected.

Refs: CO-4195